### PR TITLE
Fix relative directory issue causing local install issue

### DIFF
--- a/publish-utils/build.gradle
+++ b/publish-utils/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.jfrog.artifactory'
 // Used for bootstrapping project
 buildscript {
     Properties constants = new Properties()
-    file("../../constants.properties").withInputStream { constants.load(it) }
+    file("../constants.properties").withInputStream { constants.load(it) }
 
     ext {
         gradle_plugins_version = constants.getProperty("gradlePluginsVersion")


### PR DESCRIPTION
The constants.properties is only one directory beneath publish-utils now - the gradle.build file still assumes it is two directories beneath like it was in the corda repo