### PR TITLE
Configure the Gradle wrapper via the Wrapper task.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,3 +82,8 @@ artifactory {
         }
     }
 }
+
+task wrapper(type: Wrapper) {
+    gradleVersion = "4.4.1"
+    distributionType = Wrapper.DistributionType.ALL
+}


### PR DESCRIPTION
Using the `Wrapper` task enables IntelliJ to work out which version of the Gradle APIs it is supposed to be building against.