### PR TITLE
Force '.' to be an ordinary character in regex.

### DIFF
--- a/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
+++ b/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
@@ -115,7 +115,7 @@ public class ScanApi extends DefaultTask {
     }
 
     private File toTarget(File source) {
-        return new File(outputDir, source.getName().replaceAll(".jar$", ".txt"));
+        return new File(outputDir, source.getName().replaceAll("\\.jar$", ".txt"));
     }
 
     @TaskAction


### PR DESCRIPTION
The '.' matches _any_ character in a regular expression, but we require a literal dot for a file extension.