### PR TITLE
Also use Gradle's plugins DSL for Kotlin tests.

### DIFF
--- a/api-scanner/src/test/resources/kotlin-annotations/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-annotations/build.gradle
@@ -1,18 +1,7 @@
-buildscript {
-    repositories {
-        mavenLocal()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version'
-    }
-}
-
 plugins {
     id 'net.corda.plugins.api-scanner'
+    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
 }
-apply plugin: 'kotlin'
 
 description 'Test appearance of Kotlin-specific annotations'
 

--- a/api-scanner/src/test/resources/kotlin-lambdas/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-lambdas/build.gradle
@@ -1,18 +1,7 @@
-buildscript {
-    repositories {
-        mavenLocal()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version'
-    }
-}
-
 plugins {
     id 'net.corda.plugins.api-scanner'
+    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
 }
-apply plugin: 'kotlin'
 
 description 'Test appearance of Kotlin-specific annotations'
 


### PR DESCRIPTION
Update the API Scanner's Kotlin tests so that the Kotlin plugin also uses Gradle's new plugins DSL.