### PR TITLE
Increase the "Gradle-Fu" of the API Scanner plugin

### DIFF
--- a/api-scanner/build.gradle
+++ b/api-scanner/build.gradle
@@ -8,11 +8,10 @@ description "Generates a summary of the artifact's public API"
 repositories {
     mavenLocal()
     mavenCentral()
+    jcenter()
 }
 
 dependencies {
-    compile gradleApi()
-
     compile "io.github.lukehutch:fast-classpath-scanner:2.7.0"
     testCompile "junit:junit:$junit_version"
 
@@ -30,4 +29,3 @@ processTestResources {
 publish {
     name project.name
 }
-

--- a/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
+++ b/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
@@ -8,11 +8,8 @@ import io.github.lukehutch.fastclasspathscanner.scanner.ScanResult;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.tasks.CompileClasspath;
-import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFiles;
-import org.gradle.api.tasks.OutputFiles;
-import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.*;
+import org.gradle.api.tasks.Console;
 
 import java.io.*;
 import java.lang.annotation.Annotation;
@@ -67,6 +64,7 @@ public class ScanApi extends DefaultTask {
         outputDir = new File(getProject().getBuildDir(), "api");
     }
 
+    @SkipWhenEmpty
     @InputFiles
     public FileCollection getSources() {
         return sources;
@@ -105,7 +103,7 @@ public class ScanApi extends DefaultTask {
         );
     }
 
-    @Input
+    @Console
     public boolean isVerbose() {
         return verbose;
     }


### PR DESCRIPTION
The new `java-gradle-plugin` means that the scanner no longer needs an explicit `compile` dependency on `gradleApi()`.
Also choose better Gradle annotations on the `ScanApi` task's properties so that Gradle understands how they are expected to be used.