### PR TITLE
API Scanner supports any @CordaInternal annotation, regardless of its package.

### DIFF
--- a/api-scanner/build.gradle
+++ b/api-scanner/build.gradle
@@ -11,6 +11,15 @@ repositories {
     jcenter()
 }
 
+gradlePlugin {
+    plugins {
+        apiScannerPlugin {
+            id = 'net.corda.plugins.api-scanner'
+            implementationClass = 'net.corda.plugins.ApiScanner'
+        }
+    }
+}
+
 dependencies {
     compile "io.github.lukehutch:fast-classpath-scanner:2.7.0"
     testCompile "junit:junit:$junit_version"

--- a/api-scanner/build.gradle
+++ b/api-scanner/build.gradle
@@ -22,6 +22,7 @@ gradlePlugin {
 
 dependencies {
     compile "io.github.lukehutch:fast-classpath-scanner:2.7.0"
+    testCompile "org.assertj:assertj-core:$assertj_version"
     testCompile "junit:junit:$junit_version"
 
     // This dependency is only to prevent IntelliJ from choking

--- a/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
+++ b/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
@@ -204,14 +204,14 @@ public class ScanApi extends DefaultTask {
 
         private void loadAnnotationCaches(ScanResult result) {
             Set<String> internal = result.getNamesOfAllAnnotationClasses().stream()
-                .filter((s) -> s.endsWith(INTERNAL_ANNOTATION_NAME))
-                .collect(toSet());
+                .filter(s -> s.endsWith(INTERNAL_ANNOTATION_NAME))
+                .collect(toCollection(LinkedHashSet::new));
             internal.add(DEFAULT_INTERNAL_ANNOTATION);
             internalAnnotations = unmodifiableSet(internal);
 
             Set<String> invisible = internalAnnotations.stream()
-                .flatMap((a) -> result.getNamesOfAnnotationsWithMetaAnnotation(a).stream())
-                .collect(toSet());
+                .flatMap(a -> result.getNamesOfAnnotationsWithMetaAnnotation(a).stream())
+                .collect(toCollection(LinkedHashSet::new));
             invisible.addAll(ANNOTATION_BLACKLIST);
             invisible.addAll(internal);
             invisibleAnnotations = unmodifiableSet(invisible);

--- a/api-scanner/src/main/resources/META-INF/gradle-plugins/net.corda.plugins.api-scanner.properties
+++ b/api-scanner/src/main/resources/META-INF/gradle-plugins/net.corda.plugins.api-scanner.properties
@@ -1,1 +1,0 @@
-implementation-class=net.corda.plugins.ApiScanner

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedClassTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedClassTest.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
@@ -23,14 +24,14 @@ public class AnnotatedClassTest {
     @Before
     public void setup() throws IOException {
         File buildFile = testProjectDir.newFile("build.gradle");
-        CopyUtils.copyResourceTo("annotated-class/build.gradle", buildFile);
+        copyResourceTo("annotated-class/build.gradle", buildFile);
     }
 
     @Test
     public void testAnnotatedClass() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments("scanApi", "--info")
+            .withArguments(getGradleArguments("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();
@@ -40,7 +41,7 @@ public class AnnotatedClassTest {
         assertNotNull(scanApi);
         assertEquals(SUCCESS, scanApi.getOutcome());
 
-        Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "annotated-class.txt");
+        Path api = pathOf(testProjectDir, "build", "api", "annotated-class.txt");
         assertThat(api.toFile()).isFile();
         assertEquals(
             "@net.corda.example.NotInherited @net.corda.example.IsInherited public class net.corda.example.HasInheritedAnnotation extends java.lang.Object\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedClassTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedClassTest.java
@@ -3,7 +3,7 @@ package net.corda.plugins;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
-import org.gradle.testkit.runner.TaskOutcome;
+import static org.gradle.testkit.runner.TaskOutcome.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class AnnotatedClassTest {
@@ -37,10 +38,10 @@ public class AnnotatedClassTest {
 
         BuildTask scanApi = result.task(":scanApi");
         assertNotNull(scanApi);
-        assertEquals(TaskOutcome.SUCCESS, scanApi.getOutcome());
+        assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "annotated-class.txt");
-        assertTrue(api.toFile().isFile());
+        assertThat(api.toFile()).isFile();
         assertEquals(
             "@net.corda.example.NotInherited @net.corda.example.IsInherited public class net.corda.example.HasInheritedAnnotation extends java.lang.Object\n" +
             "  public <init>()\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedInterfaceTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedInterfaceTest.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
@@ -23,14 +24,14 @@ public class AnnotatedInterfaceTest {
     @Before
     public void setup() throws IOException {
         File buildFile = testProjectDir.newFile("build.gradle");
-        CopyUtils.copyResourceTo("annotated-interface/build.gradle", buildFile);
+        copyResourceTo("annotated-interface/build.gradle", buildFile);
     }
 
     @Test
     public void testAnnotatedInterface() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments("scanApi", "--info")
+            .withArguments(getGradleArguments("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();
@@ -40,7 +41,7 @@ public class AnnotatedInterfaceTest {
         assertNotNull(scanApi);
         assertEquals(SUCCESS, scanApi.getOutcome());
 
-        Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "annotated-interface.txt");
+        Path api = pathOf(testProjectDir, "build", "api", "annotated-interface.txt");
         assertThat(api.toFile()).isFile();
         assertEquals(
             "@net.corda.example.NotInherited @net.corda.example.IsInherited public interface net.corda.example.HasInheritedAnnotation\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedInterfaceTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedInterfaceTest.java
@@ -3,7 +3,7 @@ package net.corda.plugins;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
-import org.gradle.testkit.runner.TaskOutcome;
+import static org.gradle.testkit.runner.TaskOutcome.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class AnnotatedInterfaceTest {
@@ -37,10 +38,10 @@ public class AnnotatedInterfaceTest {
 
         BuildTask scanApi = result.task(":scanApi");
         assertNotNull(scanApi);
-        assertEquals(TaskOutcome.SUCCESS, scanApi.getOutcome());
+        assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "annotated-interface.txt");
-        assertTrue(api.toFile().isFile());
+        assertThat(api.toFile()).isFile();
         assertEquals(
             "@net.corda.example.NotInherited @net.corda.example.IsInherited public interface net.corda.example.HasInheritedAnnotation\n" +
             "##\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedMethodTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedMethodTest.java
@@ -3,7 +3,7 @@ package net.corda.plugins;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
-import org.gradle.testkit.runner.TaskOutcome;
+import static org.gradle.testkit.runner.TaskOutcome.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class AnnotatedMethodTest {
@@ -37,10 +38,10 @@ public class AnnotatedMethodTest {
 
         BuildTask scanApi = result.task(":scanApi");
         assertNotNull(scanApi);
-        assertEquals(TaskOutcome.SUCCESS, scanApi.getOutcome());
+        assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "annotated-method.txt");
-        assertTrue(api.toFile().isFile());
+        assertThat(api.toFile()).isFile();
         assertEquals(
             "public class net.corda.example.HasAnnotatedMethod extends java.lang.Object\n" +
             "  public <init>()\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedMethodTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedMethodTest.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
@@ -23,14 +24,14 @@ public class AnnotatedMethodTest {
     @Before
     public void setup() throws IOException {
         File buildFile = testProjectDir.newFile("build.gradle");
-        CopyUtils.copyResourceTo("annotated-method/build.gradle", buildFile);
+        copyResourceTo("annotated-method/build.gradle", buildFile);
     }
 
     @Test
     public void testAnnotatedMethod() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments("scanApi", "--info")
+            .withArguments(getGradleArguments("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();
@@ -40,7 +41,7 @@ public class AnnotatedMethodTest {
         assertNotNull(scanApi);
         assertEquals(SUCCESS, scanApi.getOutcome());
 
-        Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "annotated-method.txt");
+        Path api = pathOf(testProjectDir, "build", "api", "annotated-method.txt");
         assertThat(api.toFile()).isFile();
         assertEquals(
             "public class net.corda.example.HasAnnotatedMethod extends java.lang.Object\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/BasicAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/BasicAnnotationTest.java
@@ -3,7 +3,7 @@ package net.corda.plugins;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
-import org.gradle.testkit.runner.TaskOutcome;
+import static org.gradle.testkit.runner.TaskOutcome.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class BasicAnnotationTest {
@@ -37,10 +38,10 @@ public class BasicAnnotationTest {
 
         BuildTask scanApi = result.task(":scanApi");
         assertNotNull(scanApi);
-        assertEquals(TaskOutcome.SUCCESS, scanApi.getOutcome());
+        assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "basic-annotation.txt");
-        assertTrue(api.toFile().isFile());
+        assertThat(api.toFile()).isFile();
         assertEquals(
             "public @interface net.corda.example.BasicAnnotation\n" +
             "##\n", CopyUtils.toString(api));

--- a/api-scanner/src/test/java/net/corda/plugins/BasicAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/BasicAnnotationTest.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
@@ -23,14 +24,14 @@ public class BasicAnnotationTest {
     @Before
     public void setup() throws IOException {
         File buildFile = testProjectDir.newFile("build.gradle");
-        CopyUtils.copyResourceTo("basic-annotation/build.gradle", buildFile);
+        copyResourceTo("basic-annotation/build.gradle", buildFile);
     }
 
     @Test
     public void testBasicAnnotation() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments("scanApi", "--info")
+            .withArguments(getGradleArguments("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();
@@ -40,7 +41,7 @@ public class BasicAnnotationTest {
         assertNotNull(scanApi);
         assertEquals(SUCCESS, scanApi.getOutcome());
 
-        Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "basic-annotation.txt");
+        Path api = pathOf(testProjectDir, "build", "api", "basic-annotation.txt");
         assertThat(api.toFile()).isFile();
         assertEquals(
             "public @interface net.corda.example.BasicAnnotation\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/BasicClassTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/BasicClassTest.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
@@ -23,14 +24,14 @@ public class BasicClassTest {
     @Before
     public void setup() throws IOException {
         File buildFile = testProjectDir.newFile("build.gradle");
-        CopyUtils.copyResourceTo("basic-class/build.gradle", buildFile);
+        copyResourceTo("basic-class/build.gradle", buildFile);
     }
 
     @Test
     public void testBasicClass() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments("scanApi", "--info")
+            .withArguments(getGradleArguments("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();
@@ -40,7 +41,7 @@ public class BasicClassTest {
         assertNotNull(scanApi);
         assertEquals(SUCCESS, scanApi.getOutcome());
 
-        Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "basic-class.txt");
+        Path api = pathOf(testProjectDir, "build", "api", "basic-class.txt");
         assertThat(api.toFile()).isFile();
         assertEquals(
             "public class net.corda.example.BasicClass extends java.lang.Object\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/BasicClassTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/BasicClassTest.java
@@ -3,7 +3,7 @@ package net.corda.plugins;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
-import org.gradle.testkit.runner.TaskOutcome;
+import static org.gradle.testkit.runner.TaskOutcome.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class BasicClassTest {
@@ -37,10 +38,10 @@ public class BasicClassTest {
 
         BuildTask scanApi = result.task(":scanApi");
         assertNotNull(scanApi);
-        assertEquals(TaskOutcome.SUCCESS, scanApi.getOutcome());
+        assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "basic-class.txt");
-        assertTrue(api.toFile().isFile());
+        assertThat(api.toFile()).isFile();
         assertEquals(
             "public class net.corda.example.BasicClass extends java.lang.Object\n" +
             "  public <init>(String)\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/BasicInterfaceTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/BasicInterfaceTest.java
@@ -3,7 +3,7 @@ package net.corda.plugins;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
-import org.gradle.testkit.runner.TaskOutcome;
+import static org.gradle.testkit.runner.TaskOutcome.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class BasicInterfaceTest {
@@ -37,10 +38,10 @@ public class BasicInterfaceTest {
 
         BuildTask scanApi = result.task(":scanApi");
         assertNotNull(scanApi);
-        assertEquals(TaskOutcome.SUCCESS, scanApi.getOutcome());
+        assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "basic-interface.txt");
-        assertTrue(api.toFile().isFile());
+        assertThat(api.toFile()).isFile();
         assertEquals(
             "public interface net.corda.example.BasicInterface\n" +
             "  public abstract java.math.BigInteger getBigNumber()\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/BasicInterfaceTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/BasicInterfaceTest.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
@@ -23,14 +24,14 @@ public class BasicInterfaceTest {
     @Before
     public void setup() throws IOException {
         File buildFile = testProjectDir.newFile("build.gradle");
-        CopyUtils.copyResourceTo("basic-interface/build.gradle", buildFile);
+        copyResourceTo("basic-interface/build.gradle", buildFile);
     }
 
     @Test
     public void testBasicInterface() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments("scanApi", "--info")
+            .withArguments(getGradleArguments("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();
@@ -40,7 +41,7 @@ public class BasicInterfaceTest {
         assertNotNull(scanApi);
         assertEquals(SUCCESS, scanApi.getOutcome());
 
-        Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "basic-interface.txt");
+        Path api = pathOf(testProjectDir, "build", "api", "basic-interface.txt");
         assertThat(api.toFile()).isFile();
         assertEquals(
             "public interface net.corda.example.BasicInterface\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/ClassWithInternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/ClassWithInternalAnnotationTest.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
@@ -23,14 +24,14 @@ public class ClassWithInternalAnnotationTest {
     @Before
     public void setup() throws IOException {
         File buildFile = testProjectDir.newFile("build.gradle");
-        CopyUtils.copyResourceTo("class-internal-annotation/build.gradle", buildFile);
+        copyResourceTo("class-internal-annotation/build.gradle", buildFile);
     }
 
     @Test
     public void testClassWithInternalAnnotation() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments("scanApi", "--info")
+            .withArguments(getGradleArguments("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();
@@ -42,7 +43,7 @@ public class ClassWithInternalAnnotationTest {
 
         assertThat(output).contains("net.corda.example.InvisibleAnnotation");
 
-        Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "class-internal-annotation.txt");
+        Path api = pathOf(testProjectDir, "build", "api", "class-internal-annotation.txt");
         assertThat(api.toFile()).isFile();
         assertEquals("public class net.corda.example.AnnotatedClass extends java.lang.Object\n" +
             "  public <init>()\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/ClassWithInternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/ClassWithInternalAnnotationTest.java
@@ -3,7 +3,7 @@ package net.corda.plugins;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
-import org.gradle.testkit.runner.TaskOutcome;
+import static org.gradle.testkit.runner.TaskOutcome.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class ClassWithInternalAnnotationTest {
@@ -37,12 +38,12 @@ public class ClassWithInternalAnnotationTest {
 
         BuildTask scanApi = result.task(":scanApi");
         assertNotNull(scanApi);
-        assertEquals(TaskOutcome.SUCCESS, scanApi.getOutcome());
+        assertEquals(SUCCESS, scanApi.getOutcome());
 
-        assertTrue(output.contains("net.corda.example.InvisibleAnnotation"));
+        assertThat(output).contains("net.corda.example.InvisibleAnnotation");
 
         Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "class-internal-annotation.txt");
-        assertTrue(api.toFile().isFile());
+        assertThat(api.toFile()).isFile();
         assertEquals("public class net.corda.example.AnnotatedClass extends java.lang.Object\n" +
             "  public <init>()\n" +
             "##\n", CopyUtils.toString(api));

--- a/api-scanner/src/test/java/net/corda/plugins/CopyUtils.java
+++ b/api-scanner/src/test/java/net/corda/plugins/CopyUtils.java
@@ -6,12 +6,18 @@ import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardCopyOption.*;
 
 public final class CopyUtils {
-    private CopyUtils() {}
+    private static final String testGradleUserHome = System.getProperty("test.gradle.user.home", "");
+
+    private CopyUtils() {
+    }
 
     public static long copyResourceTo(String resourceName, Path target) throws IOException {
         try (InputStream input = CopyUtils.class.getClassLoader().getResourceAsStream(resourceName)) {
@@ -29,5 +35,15 @@ public final class CopyUtils {
 
     public static Path pathOf(TemporaryFolder folder, String... elements) {
         return Paths.get(folder.getRoot().getAbsolutePath(), elements);
+    }
+
+    public static List<String> getGradleArguments(String... taskNames) {
+        List<String> args = new ArrayList<>(taskNames.length + 3);
+        Collections.addAll(args, taskNames);
+        args.add("--info");
+        if (!testGradleUserHome.isEmpty()) {
+            Collections.addAll(args,"-g", testGradleUserHome);
+        }
+        return args;
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/ExtendedClassTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/ExtendedClassTest.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
@@ -23,14 +24,14 @@ public class ExtendedClassTest {
     @Before
     public void setup() throws IOException {
         File buildFile = testProjectDir.newFile("build.gradle");
-        CopyUtils.copyResourceTo("extended-class/build.gradle", buildFile);
+        copyResourceTo("extended-class/build.gradle", buildFile);
     }
 
     @Test
     public void testExtendedClass() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments("scanApi", "--info")
+            .withArguments(getGradleArguments("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();
@@ -40,7 +41,7 @@ public class ExtendedClassTest {
         assertNotNull(scanApi);
         assertEquals(SUCCESS, scanApi.getOutcome());
 
-        Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "extended-class.txt");
+        Path api = pathOf(testProjectDir, "build", "api", "extended-class.txt");
         assertThat(api.toFile()).isFile();
         assertEquals(
             "public class net.corda.example.ExtendedClass extends java.io.FilterInputStream\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/ExtendedClassTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/ExtendedClassTest.java
@@ -3,7 +3,7 @@ package net.corda.plugins;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
-import org.gradle.testkit.runner.TaskOutcome;
+import static org.gradle.testkit.runner.TaskOutcome.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class ExtendedClassTest {
@@ -37,10 +38,10 @@ public class ExtendedClassTest {
 
         BuildTask scanApi = result.task(":scanApi");
         assertNotNull(scanApi);
-        assertEquals(TaskOutcome.SUCCESS, scanApi.getOutcome());
+        assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "extended-class.txt");
-        assertTrue(api.toFile().isFile());
+        assertThat(api.toFile()).isFile();
         assertEquals(
             "public class net.corda.example.ExtendedClass extends java.io.FilterInputStream\n" +
             "  public <init>(java.io.InputStream)\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/ExtendedInterfaceTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/ExtendedInterfaceTest.java
@@ -3,7 +3,7 @@ package net.corda.plugins;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
-import org.gradle.testkit.runner.TaskOutcome;
+import static org.gradle.testkit.runner.TaskOutcome.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class ExtendedInterfaceTest {
@@ -37,10 +38,10 @@ public class ExtendedInterfaceTest {
 
         BuildTask scanApi = result.task(":scanApi");
         assertNotNull(scanApi);
-        assertEquals(TaskOutcome.SUCCESS, scanApi.getOutcome());
+        assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "extended-interface.txt");
-        assertTrue(api.toFile().isFile());
+        assertThat(api.toFile()).isFile();
         assertEquals(
             "public interface net.corda.example.ExtendedInterface extends java.util.concurrent.Future\n" +
             "  public abstract String getName()\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/ExtendedInterfaceTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/ExtendedInterfaceTest.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
@@ -23,14 +24,14 @@ public class ExtendedInterfaceTest {
     @Before
     public void setup() throws IOException {
         File buildFile = testProjectDir.newFile("build.gradle");
-        CopyUtils.copyResourceTo("extended-interface/build.gradle", buildFile);
+        copyResourceTo("extended-interface/build.gradle", buildFile);
     }
 
     @Test
     public void testExtendedInterface() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments("scanApi", "--info")
+            .withArguments(getGradleArguments("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();
@@ -40,7 +41,7 @@ public class ExtendedInterfaceTest {
         assertNotNull(scanApi);
         assertEquals(SUCCESS, scanApi.getOutcome());
 
-        Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "extended-interface.txt");
+        Path api = pathOf(testProjectDir, "build", "api", "extended-interface.txt");
         assertThat(api.toFile()).isFile();
         assertEquals(
             "public interface net.corda.example.ExtendedInterface extends java.util.concurrent.Future\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/InternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/InternalAnnotationTest.java
@@ -12,8 +12,8 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.regex.Pattern;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class InternalAnnotationTest {
@@ -36,15 +36,16 @@ public class InternalAnnotationTest {
         String output = result.getOutput();
         System.out.println(output);
 
-        assertTrue(output.contains("net.corda.core.CordaInternal"));
-        assertTrue(output.contains("net.corda.example.CordaInternal"));
+        assertThat(output)
+            .contains("net.corda.core.CordaInternal")
+            .contains("net.corda.example.CordaInternal");
 
         BuildTask scanApi = result.task(":scanApi");
         assertNotNull(scanApi);
         assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "internal-annotation.txt");
-        assertTrue(api.toFile().isFile());
+        assertThat(api.toFile()).isFile();
         assertEquals("", CopyUtils.toString(api));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/InternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/InternalAnnotationTest.java
@@ -12,21 +12,22 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.regex.Pattern;
 
 import static org.junit.Assert.*;
 
-public class MethodWithInternalAnnotationTest {
+public class InternalAnnotationTest {
     @Rule
     public final TemporaryFolder testProjectDir = new TemporaryFolder();
 
     @Before
     public void setup() throws IOException {
         File buildFile = testProjectDir.newFile("build.gradle");
-        CopyUtils.copyResourceTo("method-internal-annotation/build.gradle", buildFile);
+        CopyUtils.copyResourceTo("internal-annotation/build.gradle", buildFile);
     }
 
     @Test
-    public void testMethodWithInternalAnnotations() throws IOException {
+    public void testInternalAnnotations() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
             .withArguments("scanApi", "--info")
@@ -35,18 +36,15 @@ public class MethodWithInternalAnnotationTest {
         String output = result.getOutput();
         System.out.println(output);
 
+        assertTrue(output.contains("net.corda.core.CordaInternal"));
+        assertTrue(output.contains("net.corda.example.CordaInternal"));
+
         BuildTask scanApi = result.task(":scanApi");
         assertNotNull(scanApi);
         assertEquals(SUCCESS, scanApi.getOutcome());
 
-        assertTrue(output.contains("net.corda.example.InvisibleAnnotation"));
-        assertTrue(output.contains("net.corda.example.LocalInvisibleAnnotation"));
-
-        Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "method-internal-annotation.txt");
+        Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "internal-annotation.txt");
         assertTrue(api.toFile().isFile());
-        assertEquals("public class net.corda.example.HasVisibleMethod extends java.lang.Object\n" +
-            "  public <init>()\n" +
-            "  public void hasInvisibleAnnotations()\n" +
-            "##\n", CopyUtils.toString(api));
+        assertEquals("", CopyUtils.toString(api));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/InternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/InternalAnnotationTest.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
@@ -23,14 +24,14 @@ public class InternalAnnotationTest {
     @Before
     public void setup() throws IOException {
         File buildFile = testProjectDir.newFile("build.gradle");
-        CopyUtils.copyResourceTo("internal-annotation/build.gradle", buildFile);
+        copyResourceTo("internal-annotation/build.gradle", buildFile);
     }
 
     @Test
     public void testInternalAnnotations() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments("scanApi", "--info")
+            .withArguments(getGradleArguments("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();
@@ -44,7 +45,7 @@ public class InternalAnnotationTest {
         assertNotNull(scanApi);
         assertEquals(SUCCESS, scanApi.getOutcome());
 
-        Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "internal-annotation.txt");
+        Path api = pathOf(testProjectDir, "build", "api", "internal-annotation.txt");
         assertThat(api.toFile()).isFile();
         assertEquals("", CopyUtils.toString(api));
     }

--- a/api-scanner/src/test/java/net/corda/plugins/InternalMethodTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/InternalMethodTest.java
@@ -12,6 +12,7 @@ import org.junit.rules.TemporaryFolder;
 import java.io.*;
 import java.nio.file.Path;
 
+import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
@@ -22,14 +23,14 @@ public class InternalMethodTest {
     @Before
     public void setup() throws IOException {
         File buildFile = testProjectDir.newFile("build.gradle");
-        CopyUtils.copyResourceTo("internal-method/build.gradle", buildFile);
+        copyResourceTo("internal-method/build.gradle", buildFile);
     }
 
     @Test
     public void testInternalMethod() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments("scanApi", "--info")
+            .withArguments(getGradleArguments("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();
@@ -39,7 +40,7 @@ public class InternalMethodTest {
         assertNotNull(scanApi);
         assertEquals(SUCCESS, scanApi.getOutcome());
 
-        Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "internal-method.txt");
+        Path api = pathOf(testProjectDir, "build", "api", "internal-method.txt");
         assertThat(api.toFile()).isFile();
         assertEquals(
             "public class net.corda.example.WithInternalMethod extends java.lang.Object\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/InternalMethodTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/InternalMethodTest.java
@@ -3,7 +3,7 @@ package net.corda.plugins;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
-import org.gradle.testkit.runner.TaskOutcome;
+import static org.gradle.testkit.runner.TaskOutcome.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,6 +12,7 @@ import org.junit.rules.TemporaryFolder;
 import java.io.*;
 import java.nio.file.Path;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class InternalMethodTest {
@@ -36,10 +37,10 @@ public class InternalMethodTest {
 
         BuildTask scanApi = result.task(":scanApi");
         assertNotNull(scanApi);
-        assertEquals(TaskOutcome.SUCCESS, scanApi.getOutcome());
+        assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "internal-method.txt");
-        assertTrue(api.toFile().isFile());
+        assertThat(api.toFile()).isFile();
         assertEquals(
             "public class net.corda.example.WithInternalMethod extends java.lang.Object\n" +
             "  public <init>()\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/InternalPackageTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/InternalPackageTest.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
@@ -23,14 +24,14 @@ public class InternalPackageTest {
     @Before
     public void setup() throws IOException {
         File buildFile = testProjectDir.newFile("build.gradle");
-        CopyUtils.copyResourceTo("internal-package/build.gradle", buildFile);
+        copyResourceTo("internal-package/build.gradle", buildFile);
     }
 
     @Test
     public void testInternalPackageIsIgnored() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments("scanApi", "--info")
+            .withArguments(getGradleArguments("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();
@@ -42,7 +43,7 @@ public class InternalPackageTest {
 
         assertThat(output).contains("net.corda.internal.InvisibleClass");
 
-        Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "internal-package.txt");
+        Path api = pathOf(testProjectDir, "build", "api", "internal-package.txt");
         assertThat(api.toFile()).isFile();
         assertEquals(
     "public class net.corda.VisibleClass extends java.lang.Object\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/InternalPackageTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/InternalPackageTest.java
@@ -3,7 +3,7 @@ package net.corda.plugins;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
-import org.gradle.testkit.runner.TaskOutcome;
+import static org.gradle.testkit.runner.TaskOutcome.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class InternalPackageTest {
@@ -37,15 +38,15 @@ public class InternalPackageTest {
 
         BuildTask scanApi = result.task(":scanApi");
         assertNotNull(scanApi);
-        assertEquals(TaskOutcome.SUCCESS, scanApi.getOutcome());
+        assertEquals(SUCCESS, scanApi.getOutcome());
 
-        assertTrue(output.contains("net.corda.internal.InvisibleClass"));
+        assertThat(output).contains("net.corda.internal.InvisibleClass");
 
         Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "internal-package.txt");
-        assertTrue(api.toFile().isFile());
+        assertThat(api.toFile()).isFile();
         assertEquals(
-                "public class net.corda.VisibleClass extends java.lang.Object\n" +
-                        "  public <init>()\n" +
-                        "##\n", CopyUtils.toString(api));
+    "public class net.corda.VisibleClass extends java.lang.Object\n" +
+            "  public <init>()\n" +
+            "##\n", CopyUtils.toString(api));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinAnnotationsTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinAnnotationsTest.java
@@ -3,7 +3,7 @@ package net.corda.plugins;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
-import org.gradle.testkit.runner.TaskOutcome;
+import static org.gradle.testkit.runner.TaskOutcome.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,7 +37,7 @@ public class KotlinAnnotationsTest {
 
         BuildTask scanApi = result.task(":scanApi");
         assertNotNull(scanApi);
-        assertEquals(TaskOutcome.SUCCESS, scanApi.getOutcome());
+        assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "kotlin-annotations.txt");
         assertTrue(api.toFile().isFile());

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinAnnotationsTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinAnnotationsTest.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class KotlinAnnotationsTest {
@@ -40,24 +41,24 @@ public class KotlinAnnotationsTest {
         assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "kotlin-annotations.txt");
-        assertTrue(api.toFile().isFile());
+        assertThat(api.toFile()).isFile();
         assertEquals(
-                "public final class net.corda.example.HasJvmStaticFunction extends java.lang.Object\n" +
-                "  public <init>()\n" +
-                "  @kotlin.jvm.JvmStatic public static final void doThing(String)\n" +
-                "  public static final net.corda.example.HasJvmStaticFunction$Companion Companion\n" +
-                "##\n" +
-                "public static final class net.corda.example.HasJvmStaticFunction$Companion extends java.lang.Object\n" +
-                "  @kotlin.jvm.JvmStatic public final void doThing(String)\n" +
-                "##\n" +
-                "public final class net.corda.example.HasOverloadedConstructor extends java.lang.Object\n" +
-                "  public <init>()\n" +
-                "  public <init>(String)\n" +
-                "  public <init>(String, String)\n" +
-                "  public <init>(String, String, int)\n" +
-                "  @org.jetbrains.annotations.NotNull public final String getNotNullable()\n" +
-                "  @org.jetbrains.annotations.Nullable public final String getNullable()\n" +
-                "  public final int getNumber()\n" +
-                "##\n", CopyUtils.toString(api));
+            "public final class net.corda.example.HasJvmStaticFunction extends java.lang.Object\n" +
+            "  public <init>()\n" +
+            "  @kotlin.jvm.JvmStatic public static final void doThing(String)\n" +
+            "  public static final net.corda.example.HasJvmStaticFunction$Companion Companion\n" +
+            "##\n" +
+            "public static final class net.corda.example.HasJvmStaticFunction$Companion extends java.lang.Object\n" +
+            "  @kotlin.jvm.JvmStatic public final void doThing(String)\n" +
+            "##\n" +
+            "public final class net.corda.example.HasOverloadedConstructor extends java.lang.Object\n" +
+            "  public <init>()\n" +
+            "  public <init>(String)\n" +
+            "  public <init>(String, String)\n" +
+            "  public <init>(String, String, int)\n" +
+            "  @org.jetbrains.annotations.NotNull public final String getNotNullable()\n" +
+            "  @org.jetbrains.annotations.Nullable public final String getNullable()\n" +
+            "  public final int getNumber()\n" +
+            "##\n", CopyUtils.toString(api));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinAnnotationsTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinAnnotationsTest.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
@@ -23,14 +24,14 @@ public class KotlinAnnotationsTest {
     @Before
     public void setup() throws IOException {
         File buildFile = testProjectDir.newFile("build.gradle");
-        CopyUtils.copyResourceTo("kotlin-annotations/build.gradle", buildFile);
+        copyResourceTo("kotlin-annotations/build.gradle", buildFile);
     }
 
     @Test
     public void testKotlinAnnotations() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments("scanApi", "--info")
+            .withArguments(getGradleArguments("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();
@@ -40,7 +41,7 @@ public class KotlinAnnotationsTest {
         assertNotNull(scanApi);
         assertEquals(SUCCESS, scanApi.getOutcome());
 
-        Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "kotlin-annotations.txt");
+        Path api = pathOf(testProjectDir, "build", "api", "kotlin-annotations.txt");
         assertThat(api.toFile()).isFile();
         assertEquals(
             "public final class net.corda.example.HasJvmStaticFunction extends java.lang.Object\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinInternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinInternalAnnotationTest.java
@@ -3,7 +3,6 @@ package net.corda.plugins;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
-import static org.gradle.testkit.runner.TaskOutcome.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -13,20 +12,21 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
 import static org.junit.Assert.*;
 
-public class KotlinLambdasTest {
+public class KotlinInternalAnnotationTest {
     @Rule
     public final TemporaryFolder testProjectDir = new TemporaryFolder();
 
     @Before
     public void setup() throws IOException {
         File buildFile = testProjectDir.newFile("build.gradle");
-        CopyUtils.copyResourceTo("kotlin-lambdas/build.gradle", buildFile);
+        CopyUtils.copyResourceTo("kotlin-internal-annotation/build.gradle", buildFile);
     }
 
     @Test
-    public void testKotlinLambdas() throws IOException {
+    public void testKotlinInternalAnnotation() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
             .withArguments("scanApi", "--info")
@@ -35,17 +35,17 @@ public class KotlinLambdasTest {
         String output = result.getOutput();
         System.out.println(output);
 
+        assertTrue(output.contains("net.corda.kotlin.CordaInternal"));
+
         BuildTask scanApi = result.task(":scanApi");
         assertNotNull(scanApi);
         assertEquals(SUCCESS, scanApi.getOutcome());
 
-        assertTrue(output.contains("net.corda.example.LambdaExpressions$testing$$inlined$schedule$1"));
-
-        Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "kotlin-lambdas.txt");
+        Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "kotlin-internal-annotation.txt");
         assertTrue(api.toFile().isFile());
-        assertEquals("public final class net.corda.example.LambdaExpressions extends java.lang.Object\n" +
+        assertEquals(
+            "public final class net.corda.kotlin.AnnotatedClass extends java.lang.Object\n" +
             "  public <init>()\n" +
-            "  public final void testing(kotlin.Unit)\n" +
             "##\n", CopyUtils.toString(api));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinInternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinInternalAnnotationTest.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
 import static org.junit.Assert.*;
@@ -23,14 +24,14 @@ public class KotlinInternalAnnotationTest {
     @Before
     public void setup() throws IOException {
         File buildFile = testProjectDir.newFile("build.gradle");
-        CopyUtils.copyResourceTo("kotlin-internal-annotation/build.gradle", buildFile);
+        copyResourceTo("kotlin-internal-annotation/build.gradle", buildFile);
     }
 
     @Test
     public void testKotlinInternalAnnotation() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments("scanApi", "--info")
+            .withArguments(getGradleArguments("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();
@@ -42,7 +43,7 @@ public class KotlinInternalAnnotationTest {
         assertNotNull(scanApi);
         assertEquals(SUCCESS, scanApi.getOutcome());
 
-        Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "kotlin-internal-annotation.txt");
+        Path api = pathOf(testProjectDir, "build", "api", "kotlin-internal-annotation.txt");
         assertThat(api.toFile()).isFile();
         assertEquals(
             "public final class net.corda.example.kotlin.AnnotatedClass extends java.lang.Object\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinInternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinInternalAnnotationTest.java
@@ -35,7 +35,7 @@ public class KotlinInternalAnnotationTest {
         String output = result.getOutput();
         System.out.println(output);
 
-        assertTrue(output.contains("net.corda.kotlin.CordaInternal"));
+        assertTrue(output.contains("net.corda.example.kotlin.CordaInternal"));
 
         BuildTask scanApi = result.task(":scanApi");
         assertNotNull(scanApi);
@@ -44,7 +44,7 @@ public class KotlinInternalAnnotationTest {
         Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "kotlin-internal-annotation.txt");
         assertTrue(api.toFile().isFile());
         assertEquals(
-            "public final class net.corda.kotlin.AnnotatedClass extends java.lang.Object\n" +
+            "public final class net.corda.example.kotlin.AnnotatedClass extends java.lang.Object\n" +
             "  public <init>()\n" +
             "##\n", CopyUtils.toString(api));
     }

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinInternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinInternalAnnotationTest.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
 import static org.junit.Assert.*;
 
@@ -35,14 +36,14 @@ public class KotlinInternalAnnotationTest {
         String output = result.getOutput();
         System.out.println(output);
 
-        assertTrue(output.contains("net.corda.example.kotlin.CordaInternal"));
+        assertThat(output).contains("net.corda.example.kotlin.CordaInternal");
 
         BuildTask scanApi = result.task(":scanApi");
         assertNotNull(scanApi);
         assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "kotlin-internal-annotation.txt");
-        assertTrue(api.toFile().isFile());
+        assertThat(api.toFile()).isFile();
         assertEquals(
             "public final class net.corda.example.kotlin.AnnotatedClass extends java.lang.Object\n" +
             "  public <init>()\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinLambdasTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinLambdasTest.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class KotlinLambdasTest {
@@ -39,10 +40,10 @@ public class KotlinLambdasTest {
         assertNotNull(scanApi);
         assertEquals(SUCCESS, scanApi.getOutcome());
 
-        assertTrue(output.contains("net.corda.example.LambdaExpressions$testing$$inlined$schedule$1"));
+        assertThat(output).contains("net.corda.example.LambdaExpressions$testing$$inlined$schedule$1");
 
         Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "kotlin-lambdas.txt");
-        assertTrue(api.toFile().isFile());
+        assertThat(api.toFile()).isFile();
         assertEquals("public final class net.corda.example.LambdaExpressions extends java.lang.Object\n" +
             "  public <init>()\n" +
             "  public final void testing(kotlin.Unit)\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinLambdasTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinLambdasTest.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
@@ -23,14 +24,14 @@ public class KotlinLambdasTest {
     @Before
     public void setup() throws IOException {
         File buildFile = testProjectDir.newFile("build.gradle");
-        CopyUtils.copyResourceTo("kotlin-lambdas/build.gradle", buildFile);
+        copyResourceTo("kotlin-lambdas/build.gradle", buildFile);
     }
 
     @Test
     public void testKotlinLambdas() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments("scanApi", "--info")
+            .withArguments(getGradleArguments("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();
@@ -42,7 +43,7 @@ public class KotlinLambdasTest {
 
         assertThat(output).contains("net.corda.example.LambdaExpressions$testing$$inlined$schedule$1");
 
-        Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "kotlin-lambdas.txt");
+        Path api = pathOf(testProjectDir, "build", "api", "kotlin-lambdas.txt");
         assertThat(api.toFile()).isFile();
         assertEquals("public final class net.corda.example.LambdaExpressions extends java.lang.Object\n" +
             "  public <init>()\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/MethodWithInternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/MethodWithInternalAnnotationTest.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class MethodWithInternalAnnotationTest {
@@ -39,11 +40,12 @@ public class MethodWithInternalAnnotationTest {
         assertNotNull(scanApi);
         assertEquals(SUCCESS, scanApi.getOutcome());
 
-        assertTrue(output.contains("net.corda.example.InvisibleAnnotation"));
-        assertTrue(output.contains("net.corda.example.LocalInvisibleAnnotation"));
+        assertThat(output)
+            .contains("net.corda.example.InvisibleAnnotation")
+            .contains("net.corda.example.LocalInvisibleAnnotation");
 
         Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "method-internal-annotation.txt");
-        assertTrue(api.toFile().isFile());
+        assertThat(api.toFile()).isFile();
         assertEquals("public class net.corda.example.HasVisibleMethod extends java.lang.Object\n" +
             "  public <init>()\n" +
             "  public void hasInvisibleAnnotations()\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/MethodWithInternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/MethodWithInternalAnnotationTest.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
@@ -23,14 +24,14 @@ public class MethodWithInternalAnnotationTest {
     @Before
     public void setup() throws IOException {
         File buildFile = testProjectDir.newFile("build.gradle");
-        CopyUtils.copyResourceTo("method-internal-annotation/build.gradle", buildFile);
+        copyResourceTo("method-internal-annotation/build.gradle", buildFile);
     }
 
     @Test
     public void testMethodWithInternalAnnotations() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments("scanApi", "--info")
+            .withArguments(getGradleArguments("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();
@@ -44,7 +45,7 @@ public class MethodWithInternalAnnotationTest {
             .contains("net.corda.example.InvisibleAnnotation")
             .contains("net.corda.example.LocalInvisibleAnnotation");
 
-        Path api = CopyUtils.pathOf(testProjectDir, "build", "api", "method-internal-annotation.txt");
+        Path api = pathOf(testProjectDir, "build", "api", "method-internal-annotation.txt");
         assertThat(api.toFile()).isFile();
         assertEquals("public class net.corda.example.HasVisibleMethod extends java.lang.Object\n" +
             "  public <init>()\n" +

--- a/api-scanner/src/test/resources/internal-annotation/build.gradle
+++ b/api-scanner/src/test/resources/internal-annotation/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'java'
+    id 'net.corda.plugins.api-scanner'
+}
+
+description 'Test behaviour of @CordaInternal annotations'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir files(
+                "../resources/test/internal-annotation/java",
+                "../resources/test/common/java"
+            )
+        }
+    }
+}
+
+jar {
+    baseName = "internal-annotation"
+}
+
+scanApi {
+    verbose = true
+}

--- a/api-scanner/src/test/resources/internal-annotation/java/net/corda/example/CordaInternal.java
+++ b/api-scanner/src/test/resources/internal-annotation/java/net/corda/example/CordaInternal.java
@@ -1,0 +1,12 @@
+package net.corda.example;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD})
+@Retention(CLASS)
+public @interface CordaInternal {
+}

--- a/api-scanner/src/test/resources/kotlin-annotations/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-annotations/build.gradle
@@ -20,6 +20,7 @@ sourceSets {
 
 dependencies {
     compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version'
+    compile 'org.jetbrains.kotlin:kotlin-reflect:$kotlin_version'
 }
 
 jar {

--- a/api-scanner/src/test/resources/kotlin-internal-annotation/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-internal-annotation/build.gradle
@@ -13,7 +13,7 @@ repositories {
 sourceSets {
     main {
         kotlin {
-            srcDir file("../resources/test/kotlin-lambdas/kotlin")
+            srcDir file("../resources/test/kotlin-internal-annotation/kotlin")
         }
     }
 }
@@ -24,7 +24,7 @@ dependencies {
 }
 
 jar {
-    baseName = "kotlin-lambdas"
+    baseName = "kotlin-internal-annotation"
 }
 
 scanApi {

--- a/api-scanner/src/test/resources/kotlin-internal-annotation/kotlin/net/corda/example/kotlin/AnnotatedClass.kt
+++ b/api-scanner/src/test/resources/kotlin-internal-annotation/kotlin/net/corda/example/kotlin/AnnotatedClass.kt
@@ -1,4 +1,4 @@
-package net.corda.kotlin
+package net.corda.example.kotlin
 
 @InvisibleAnnotation
 class AnnotatedClass

--- a/api-scanner/src/test/resources/kotlin-internal-annotation/kotlin/net/corda/example/kotlin/CordaInternal.kt
+++ b/api-scanner/src/test/resources/kotlin-internal-annotation/kotlin/net/corda/example/kotlin/CordaInternal.kt
@@ -1,9 +1,8 @@
-package net.corda.kotlin
+package net.corda.example.kotlin
 
 import kotlin.annotation.AnnotationRetention.*
 import kotlin.annotation.AnnotationTarget.*
 
-@Target(FILE, CLASS, FUNCTION)
+@Target(FILE, CLASS, FUNCTION, ANNOTATION_CLASS)
 @Retention(BINARY)
-@CordaInternal
-annotation class InvisibleAnnotation
+annotation class CordaInternal

--- a/api-scanner/src/test/resources/kotlin-internal-annotation/kotlin/net/corda/example/kotlin/InvisibleAnnotation.kt
+++ b/api-scanner/src/test/resources/kotlin-internal-annotation/kotlin/net/corda/example/kotlin/InvisibleAnnotation.kt
@@ -1,0 +1,9 @@
+package net.corda.example.kotlin
+
+import kotlin.annotation.AnnotationRetention.*
+import kotlin.annotation.AnnotationTarget.*
+
+@Target(FILE, CLASS, FUNCTION)
+@Retention(BINARY)
+@CordaInternal
+annotation class InvisibleAnnotation

--- a/api-scanner/src/test/resources/kotlin-internal-annotation/kotlin/net/corda/kotlin/AnnotatedClass.kt
+++ b/api-scanner/src/test/resources/kotlin-internal-annotation/kotlin/net/corda/kotlin/AnnotatedClass.kt
@@ -1,0 +1,4 @@
+package net.corda.kotlin
+
+@InvisibleAnnotation
+class AnnotatedClass

--- a/api-scanner/src/test/resources/kotlin-internal-annotation/kotlin/net/corda/kotlin/CordaInternal.kt
+++ b/api-scanner/src/test/resources/kotlin-internal-annotation/kotlin/net/corda/kotlin/CordaInternal.kt
@@ -1,0 +1,8 @@
+package net.corda.kotlin
+
+import kotlin.annotation.AnnotationRetention.*
+import kotlin.annotation.AnnotationTarget.*
+
+@Target(FILE, CLASS, FUNCTION, ANNOTATION_CLASS)
+@Retention(BINARY)
+annotation class CordaInternal

--- a/api-scanner/src/test/resources/kotlin-internal-annotation/kotlin/net/corda/kotlin/CordaInternal.kt
+++ b/api-scanner/src/test/resources/kotlin-internal-annotation/kotlin/net/corda/kotlin/CordaInternal.kt
@@ -1,8 +1,0 @@
-package net.corda.kotlin
-
-import kotlin.annotation.AnnotationRetention.*
-import kotlin.annotation.AnnotationTarget.*
-
-@Target(FILE, CLASS, FUNCTION, ANNOTATION_CLASS)
-@Retention(BINARY)
-annotation class CordaInternal

--- a/api-scanner/src/test/resources/kotlin-internal-annotation/kotlin/net/corda/kotlin/InvisibleAnnotation.kt
+++ b/api-scanner/src/test/resources/kotlin-internal-annotation/kotlin/net/corda/kotlin/InvisibleAnnotation.kt
@@ -1,0 +1,9 @@
+package net.corda.kotlin
+
+import kotlin.annotation.AnnotationRetention.*
+import kotlin.annotation.AnnotationTarget.*
+
+@Target(FILE, CLASS, FUNCTION)
+@Retention(BINARY)
+@CordaInternal
+annotation class InvisibleAnnotation

--- a/api-scanner/src/test/resources/method-internal-annotation/java/net/corda/example/CordaInternal.java
+++ b/api-scanner/src/test/resources/method-internal-annotation/java/net/corda/example/CordaInternal.java
@@ -1,0 +1,12 @@
+package net.corda.example;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD})
+@Retention(CLASS)
+public @interface CordaInternal {
+}

--- a/api-scanner/src/test/resources/method-internal-annotation/java/net/corda/example/HasVisibleMethod.java
+++ b/api-scanner/src/test/resources/method-internal-annotation/java/net/corda/example/HasVisibleMethod.java
@@ -2,7 +2,8 @@ package net.corda.example;
 
 public class HasVisibleMethod {
     @InvisibleAnnotation
-    public void hasInvisibleAnnotation() {
-        System.out.println("VISIBLE METHOD, INVISIBLE ANNOTATION");
+    @LocalInvisibleAnnotation
+    public void hasInvisibleAnnotations() {
+        System.out.println("VISIBLE METHOD, INVISIBLE ANNOTATIONS");
     }
 }

--- a/api-scanner/src/test/resources/method-internal-annotation/java/net/corda/example/LocalInvisibleAnnotation.java
+++ b/api-scanner/src/test/resources/method-internal-annotation/java/net/corda/example/LocalInvisibleAnnotation.java
@@ -1,0 +1,13 @@
+package net.corda.example;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD})
+@Retention(CLASS)
+@CordaInternal
+public @interface LocalInvisibleAnnotation {
+}

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,11 @@ allprojects {
     tasks.withType(Test) {
         // Prevent the project from creating temporary files outside of the build directory.
         systemProperty 'java.io.tmpdir', buildDir.absolutePath
+
+        // Tell the tests where Gradle's current module cache is.
+        // We need the tests to share this module cache to prevent the
+        // Gradle Test-Kit from downloading its own copy of Kotlin etc.
+        systemProperty 'test.gradle.user.home', project.gradle.gradleUserHomeDir
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
         artifactory_plugin_version = constants.getProperty('artifactoryPluginVersion')
         snake_yaml_version = constants.getProperty('snakeYamlVersion')
         commons_io_version = '2.6'
+        assertj_version = '3.8.0'
         junit_version = '4.12'
     }
 


### PR DESCRIPTION
Some modules may wish to define internal annotations, and yet not depend on `core`. Support this case by allowing _any_ package to define a `@CordaInternal` annotation. The API Scanner will handle these in the same way as `@net.corda.core.CoreInternal`.