### PR TITLE
[CORDA-1148] Fix API Scanner not to exclude vararg methods.

### DIFF
--- a/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
+++ b/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
@@ -27,7 +27,13 @@ import static java.util.stream.Collectors.*;
 public class ScanApi extends DefaultTask {
     private static final int CLASS_MASK = Modifier.classModifiers();
     private static final int INTERFACE_MASK = Modifier.interfaceModifiers() & ~Modifier.ABSTRACT;
-    private static final int METHOD_MASK = Modifier.methodModifiers();
+    /**
+     * The VARARG modifier for methods has the same value as the TRANSIENT modifier for fields.
+     * Unfortunately, {@link Modifier#methodModifiers() methodModifiers} doesn't include this
+     * flag, and so we need to add it back ourselves.
+     * @link https://docs.oracle.com/javase/specs/jls/se8/html/index.html
+     */
+    private static final int METHOD_MASK = Modifier.methodModifiers() | Modifier.TRANSIENT;
     private static final int FIELD_MASK = Modifier.fieldModifiers();
     private static final int VISIBILITY_MASK = Modifier.PUBLIC | Modifier.PROTECTED;
 

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinVarargMethodTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinVarargMethodTest.java
@@ -1,0 +1,48 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+import static org.junit.Assert.*;
+
+public class KotlinVarargMethodTest {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        File buildFile = testProjectDir.newFile("build.gradle");
+        copyResourceTo("kotlin-vararg-method/build.gradle", buildFile);
+    }
+
+    @Test
+    public void testKotlinVarargMethod() throws IOException {
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(getGradleArguments("scanApi"))
+            .withPluginClasspath()
+            .build();
+        String output = result.getOutput();
+        System.out.println(output);
+
+        BuildTask scanApi = result.task(":scanApi");
+        assertNotNull(scanApi);
+        assertEquals(SUCCESS, scanApi.getOutcome());
+
+        Path api = pathOf(testProjectDir, "build", "api", "kotlin-vararg-method.txt");
+        assertThat(api.toFile()).isFile();
+        assertEquals("public interface net.corda.example.KotlinVarargMethod\n" +
+            "  public abstract void action(Object...)\n" +
+            "##\n", CopyUtils.toString(api));
+    }
+}

--- a/api-scanner/src/test/java/net/corda/plugins/VarargMethodTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/VarargMethodTest.java
@@ -1,0 +1,48 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+import static org.junit.Assert.*;
+
+public class VarargMethodTest {
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    @Before
+    public void setup() throws IOException {
+        File buildFile = testProjectDir.newFile("build.gradle");
+        copyResourceTo("vararg-method/build.gradle", buildFile);
+    }
+
+    @Test
+    public void testVarargMethod() throws IOException {
+        BuildResult result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(getGradleArguments("scanApi"))
+            .withPluginClasspath()
+            .build();
+        String output = result.getOutput();
+        System.out.println(output);
+
+        BuildTask scanApi = result.task(":scanApi");
+        assertNotNull(scanApi);
+        assertEquals(SUCCESS, scanApi.getOutcome());
+
+        Path api = pathOf(testProjectDir, "build", "api", "vararg-method.txt");
+        assertThat(api.toFile()).isFile();
+        assertEquals("public interface net.corda.example.VarargMethod\n" +
+            "  public abstract void action(Object...)\n" +
+            "##\n", CopyUtils.toString(api));
+    }
+}

--- a/api-scanner/src/test/resources/kotlin-internal-annotation/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-internal-annotation/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
 }
 
-description 'Test appearance of Kotlin-specific annotations'
+description 'Test appearance of internal Corda annotations in Kotlin'
 
 repositories {
     mavenLocal()

--- a/api-scanner/src/test/resources/kotlin-vararg-method/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-vararg-method/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
 }
 
-description 'Test appearance of Kotlin lambdas'
+description 'Test appearance of Kotlin vararg functions'
 
 repositories {
     mavenLocal()
@@ -13,7 +13,7 @@ repositories {
 sourceSets {
     main {
         kotlin {
-            srcDir file("../resources/test/kotlin-lambdas/kotlin")
+            srcDir file("../resources/test/kotlin-vararg-method/kotlin")
         }
     }
 }
@@ -24,7 +24,7 @@ dependencies {
 }
 
 jar {
-    baseName = "kotlin-lambdas"
+    baseName = "kotlin-vararg-method"
 }
 
 scanApi {

--- a/api-scanner/src/test/resources/kotlin-vararg-method/kotlin/net/corda/example/KotlinVarargMethod.kt
+++ b/api-scanner/src/test/resources/kotlin-vararg-method/kotlin/net/corda/example/KotlinVarargMethod.kt
@@ -1,0 +1,5 @@
+package net.corda.example
+
+interface KotlinVarargMethod {
+    fun action(vararg arg: Any?)
+}

--- a/api-scanner/src/test/resources/vararg-method/build.gradle
+++ b/api-scanner/src/test/resources/vararg-method/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'net.corda.plugins.api-scanner'
+    id 'java'
+}
+
+description 'Test appearance of Java vararg functions'
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir file("../resources/test/vararg-method/java")
+        }
+    }
+}
+
+jar {
+    baseName = "vararg-method"
+}
+
+scanApi {
+    verbose = true
+}

--- a/api-scanner/src/test/resources/vararg-method/java/net/corda/example/VarargMethod.java
+++ b/api-scanner/src/test/resources/vararg-method/java/net/corda/example/VarargMethod.java
@@ -1,0 +1,5 @@
+package net.corda.example;
+
+public interface VarargMethod {
+    void action(Object... arg);
+}

--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=4.0.3
+gradlePluginsVersion=4.0.4
 kotlinVersion=1.2.20
 platformVersion=3
 guavaVersion=21.0


### PR DESCRIPTION
Methods with `vararg` parameters have an extra flag in the `.class` file. This flag has value 0x0080, which happens to be the same as `TRANSIENT` for fields.

_However_, the `java.lang.reflect.Modifier` class doesn't include this flag in the list of modifiers allowed for a method! We need to add this flag into the flag mask for methods.