### PR TITLE
[CORDA-1162] Sort class/interface/method annotations into ascending order.

### DIFF
--- a/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
+++ b/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
@@ -389,7 +389,7 @@ public class ScanApi extends DefaultTask {
                 method.getTypeDescriptor(),
                 method.getAnnotationNames().stream()
                     .filter(this::isVisibleAnnotation)
-                    // TODO: Sort these annotations ourselves!
+                    .sorted()
                     .collect(toList())
             );
         }

--- a/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
+++ b/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
@@ -349,7 +349,7 @@ public class ScanApi extends DefaultTask {
             Map<Boolean, List<String>> partitioned = classes.stream()
                 .map(ClassInfo::toString)
                 .filter(ScanApi::isApplicationClass)
-                .collect(partitioningBy(this::isVisibleAnnotation, toCollection(LinkedList::new)));
+                .collect(partitioningBy(this::isVisibleAnnotation, toCollection(ArrayList::new)));
 
             Function<List<String>, List<String>> ordering = list -> { sort(list); return list; };
             return new Names(ordering.apply(partitioned.get(true)), ordering.apply(partitioned.get(false)));

--- a/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
+++ b/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
@@ -18,7 +18,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.*;
-import java.util.function.Function;
 import java.util.stream.StreamSupport;
 
 import static java.util.Collections.*;
@@ -350,9 +349,7 @@ public class ScanApi extends DefaultTask {
                 .map(ClassInfo::toString)
                 .filter(ScanApi::isApplicationClass)
                 .collect(partitioningBy(this::isVisibleAnnotation, toCollection(ArrayList::new)));
-
-            Function<List<String>, List<String>> ordering = list -> { sort(list); return list; };
-            return new Names(ordering.apply(partitioned.get(true)), ordering.apply(partitioned.get(false)));
+            return new Names(ordering(partitioned.get(true)), ordering(partitioned.get(false)));
         }
 
         private Set<ClassInfo> readClassAnnotationsFor(ClassInfo classInfo) {
@@ -398,6 +395,11 @@ public class ScanApi extends DefaultTask {
         private boolean hasInternalAnnotation(Collection<String> annotationNames) {
             return annotationNames.stream().anyMatch(internalAnnotations::contains);
         }
+    }
+
+    private static <T extends Comparable<? super T>> List<T> ordering(List<T> list) {
+        sort(list);
+        return list;
     }
 
     private static boolean isKotlinInternalScope(MethodInfo method) {

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedClassTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedClassTest.java
@@ -44,10 +44,12 @@ public class AnnotatedClassTest {
         Path api = pathOf(testProjectDir, "build", "api", "annotated-class.txt");
         assertThat(api.toFile()).isFile();
         assertEquals(
-            "@net.corda.example.NotInherited @net.corda.example.IsInherited public class net.corda.example.HasInheritedAnnotation extends java.lang.Object\n" +
+            "public @interface net.corda.example.AlsoInherited\n" +
+            "##\n" +
+            "@net.corda.example.AlsoInherited @net.corda.example.IsInherited @net.corda.example.NotInherited public class net.corda.example.HasInheritedAnnotation extends java.lang.Object\n" +
             "  public <init>()\n" +
             "##\n" +
-            "@net.corda.example.IsInherited public class net.corda.example.InheritingAnnotations extends net.corda.example.HasInheritedAnnotation\n" +
+            "@net.corda.example.AlsoInherited @net.corda.example.IsInherited public class net.corda.example.InheritingAnnotations extends net.corda.example.HasInheritedAnnotation\n" +
             "  public <init>()\n" +
             "##\n" +
             "public @interface net.corda.example.IsInherited\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedInterfaceTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedInterfaceTest.java
@@ -44,9 +44,11 @@ public class AnnotatedInterfaceTest {
         Path api = pathOf(testProjectDir, "build", "api", "annotated-interface.txt");
         assertThat(api.toFile()).isFile();
         assertEquals(
-            "@net.corda.example.NotInherited @net.corda.example.IsInherited public interface net.corda.example.HasInheritedAnnotation\n" +
+            "public @interface net.corda.example.AlsoInherited\n" +
             "##\n" +
-            "@net.corda.example.IsInherited public interface net.corda.example.InheritingAnnotations extends net.corda.example.HasInheritedAnnotation\n" +
+            "@net.corda.example.AlsoInherited @net.corda.example.IsInherited @net.corda.example.NotInherited public interface net.corda.example.HasInheritedAnnotation\n" +
+            "##\n" +
+            "@net.corda.example.AlsoInherited @net.corda.example.IsInherited public interface net.corda.example.InheritingAnnotations extends net.corda.example.HasInheritedAnnotation\n" +
             "##\n" +
             "public @interface net.corda.example.IsInherited\n" +
             "##\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedMethodTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedMethodTest.java
@@ -44,11 +44,15 @@ public class AnnotatedMethodTest {
         Path api = pathOf(testProjectDir, "build", "api", "annotated-method.txt");
         assertThat(api.toFile()).isFile();
         assertEquals(
+            "public @interface net.corda.example.A\n" +
+            "##\n" +
+            "public @interface net.corda.example.B\n" +
+            "##\n" +
+            "public @interface net.corda.example.C\n" +
+            "##\n" +
             "public class net.corda.example.HasAnnotatedMethod extends java.lang.Object\n" +
             "  public <init>()\n" +
-            "  @net.corda.example.Visible public void hasAnnotation()\n" +
-            "##\n" +
-            "public @interface net.corda.example.Visible\n" +
+            "  @net.corda.example.A @net.corda.example.B @net.corda.example.C public void hasAnnotation()\n" +
             "##\n", CopyUtils.toString(api));
     }
 }

--- a/api-scanner/src/test/resources/annotated-class/java/net/corda/example/AlsoInherited.java
+++ b/api-scanner/src/test/resources/annotated-class/java/net/corda/example/AlsoInherited.java
@@ -1,0 +1,14 @@
+package net.corda.example;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD})
+@Retention(CLASS)
+@Inherited
+public @interface AlsoInherited {
+}

--- a/api-scanner/src/test/resources/annotated-class/java/net/corda/example/HasInheritedAnnotation.java
+++ b/api-scanner/src/test/resources/annotated-class/java/net/corda/example/HasInheritedAnnotation.java
@@ -1,6 +1,7 @@
 package net.corda.example;
 
-@IsInherited
 @NotInherited
+@IsInherited
+@AlsoInherited
 public class HasInheritedAnnotation {
 }

--- a/api-scanner/src/test/resources/annotated-interface/java/net/corda/example/AlsoInherited.java
+++ b/api-scanner/src/test/resources/annotated-interface/java/net/corda/example/AlsoInherited.java
@@ -1,0 +1,14 @@
+package net.corda.example;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD})
+@Retention(CLASS)
+@Inherited
+public @interface AlsoInherited {
+}

--- a/api-scanner/src/test/resources/annotated-interface/java/net/corda/example/HasInheritedAnnotation.java
+++ b/api-scanner/src/test/resources/annotated-interface/java/net/corda/example/HasInheritedAnnotation.java
@@ -1,6 +1,7 @@
 package net.corda.example;
 
-@IsInherited
 @NotInherited
+@IsInherited
+@AlsoInherited
 public interface HasInheritedAnnotation {
 }

--- a/api-scanner/src/test/resources/annotated-method/java/net/corda/example/A.java
+++ b/api-scanner/src/test/resources/annotated-method/java/net/corda/example/A.java
@@ -1,0 +1,12 @@
+package net.corda.example;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD})
+@Retention(CLASS)
+public @interface A {
+}

--- a/api-scanner/src/test/resources/annotated-method/java/net/corda/example/B.java
+++ b/api-scanner/src/test/resources/annotated-method/java/net/corda/example/B.java
@@ -8,5 +8,5 @@ import static java.lang.annotation.RetentionPolicy.*;
 
 @Target({TYPE, METHOD})
 @Retention(CLASS)
-public @interface Visible {
+public @interface B {
 }

--- a/api-scanner/src/test/resources/annotated-method/java/net/corda/example/C.java
+++ b/api-scanner/src/test/resources/annotated-method/java/net/corda/example/C.java
@@ -1,0 +1,12 @@
+package net.corda.example;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD})
+@Retention(CLASS)
+public @interface C {
+}

--- a/api-scanner/src/test/resources/annotated-method/java/net/corda/example/HasAnnotatedMethod.java
+++ b/api-scanner/src/test/resources/annotated-method/java/net/corda/example/HasAnnotatedMethod.java
@@ -1,8 +1,8 @@
 package net.corda.example;
 
 public class HasAnnotatedMethod {
-    @Visible
+    @B @C @A
     public void hasAnnotation() {
-        System.out.println("VISIBLE ANNOTATION");
+        System.out.println("VISIBLE ANNOTATIONS");
     }
 }


### PR DESCRIPTION
The API Scanner currently writes `class`/`interface`/`method` annotations in the order they are returned from `fast-classpath-scanner:2.7`. While this ordering is stable, it is also an implementation detail of `fast-classpath-scanner` and so is likely to change in future versions. So we need to sort these annotations ourselves into ascending order.

**NOTE**: This change will require us to update `api-current.txt` in the Corda repository.