### PR TITLE
Sort field annotations into ascending order. Also stop showing @JvmField.

### DIFF
--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedClassTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedClassTest.java
@@ -11,6 +11,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static net.corda.plugins.CopyUtils.*;
@@ -31,7 +32,7 @@ public class AnnotatedClassTest {
     public void testAnnotatedClass() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArguments("scanApi"))
+            .withArguments(getGradleArgsForTasks("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();
@@ -43,18 +44,9 @@ public class AnnotatedClassTest {
 
         Path api = pathOf(testProjectDir, "build", "api", "annotated-class.txt");
         assertThat(api.toFile()).isFile();
-        assertEquals(
-            "public @interface net.corda.example.AlsoInherited\n" +
-            "##\n" +
-            "@net.corda.example.AlsoInherited @net.corda.example.IsInherited @net.corda.example.NotInherited public class net.corda.example.HasInheritedAnnotation extends java.lang.Object\n" +
-            "  public <init>()\n" +
-            "##\n" +
-            "@net.corda.example.AlsoInherited @net.corda.example.IsInherited public class net.corda.example.InheritingAnnotations extends net.corda.example.HasInheritedAnnotation\n" +
-            "  public <init>()\n" +
-            "##\n" +
-            "public @interface net.corda.example.IsInherited\n" +
-            "##\n" +
-            "public @interface net.corda.example.NotInherited\n" +
-            "##\n", CopyUtils.toString(api));
+        assertThat(Files.readAllLines(api)).containsOnlyOnce(
+            "@net.corda.example.AlsoInherited @net.corda.example.IsInherited @net.corda.example.NotInherited public class net.corda.example.HasInheritedAnnotation extends java.lang.Object",
+            "@net.corda.example.AlsoInherited @net.corda.example.IsInherited public class net.corda.example.InheritingAnnotations extends net.corda.example.HasInheritedAnnotation"
+        );
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedFieldTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedFieldTest.java
@@ -3,7 +3,6 @@ package net.corda.plugins;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
-import static org.gradle.testkit.runner.TaskOutcome.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -11,24 +10,26 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.gradle.testkit.runner.TaskOutcome.*;
 import static org.junit.Assert.*;
 
-public class MethodWithInternalAnnotationTest {
+public class AnnotatedFieldTest {
     @Rule
     public final TemporaryFolder testProjectDir = new TemporaryFolder();
 
     @Before
     public void setup() throws IOException {
         File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("method-internal-annotation/build.gradle", buildFile);
+        copyResourceTo("annotated-field/build.gradle", buildFile);
     }
 
     @Test
-    public void testMethodWithInternalAnnotations() throws IOException {
+    public void testAnnotatedField() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
             .withArguments(getGradleArgsForTasks("scanApi"))
@@ -41,15 +42,11 @@ public class MethodWithInternalAnnotationTest {
         assertNotNull(scanApi);
         assertEquals(SUCCESS, scanApi.getOutcome());
 
-        assertThat(output)
-            .contains("net.corda.example.method.InvisibleAnnotation")
-            .contains("net.corda.example.method.LocalInvisibleAnnotation");
-
-        Path api = pathOf(testProjectDir, "build", "api", "method-internal-annotation.txt");
+        Path api = pathOf(testProjectDir, "build", "api", "annotated-field.txt");
         assertThat(api.toFile()).isFile();
-        assertEquals("public class net.corda.example.method.HasVisibleMethod extends java.lang.Object\n" +
-            "  public <init>()\n" +
-            "  public void hasInvisibleAnnotations()\n" +
-            "##\n", CopyUtils.toString(api));
+        assertThat(Files.readAllLines(api)).containsOnlyOnce(
+            "public class net.corda.example.HasAnnotatedField extends java.lang.Object",
+            "  @net.corda.example.A @net.corda.example.B @net.corda.example.C public static final String ANNOTATED_FIELD = \"<string-value>\""
+        );
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedInterfaceTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedInterfaceTest.java
@@ -11,6 +11,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static net.corda.plugins.CopyUtils.*;
@@ -31,7 +32,7 @@ public class AnnotatedInterfaceTest {
     public void testAnnotatedInterface() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArguments("scanApi"))
+            .withArguments(getGradleArgsForTasks("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();
@@ -43,16 +44,9 @@ public class AnnotatedInterfaceTest {
 
         Path api = pathOf(testProjectDir, "build", "api", "annotated-interface.txt");
         assertThat(api.toFile()).isFile();
-        assertEquals(
-            "public @interface net.corda.example.AlsoInherited\n" +
-            "##\n" +
-            "@net.corda.example.AlsoInherited @net.corda.example.IsInherited @net.corda.example.NotInherited public interface net.corda.example.HasInheritedAnnotation\n" +
-            "##\n" +
-            "@net.corda.example.AlsoInherited @net.corda.example.IsInherited public interface net.corda.example.InheritingAnnotations extends net.corda.example.HasInheritedAnnotation\n" +
-            "##\n" +
-            "public @interface net.corda.example.IsInherited\n" +
-            "##\n" +
-            "public @interface net.corda.example.NotInherited\n" +
-            "##\n", CopyUtils.toString(api));
+        assertThat(Files.readAllLines(api)).containsOnlyOnce(
+            "@net.corda.example.AlsoInherited @net.corda.example.IsInherited @net.corda.example.NotInherited public interface net.corda.example.HasInheritedAnnotation",
+            "@net.corda.example.AlsoInherited @net.corda.example.IsInherited public interface net.corda.example.InheritingAnnotations extends net.corda.example.HasInheritedAnnotation"
+        );
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedMethodTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedMethodTest.java
@@ -11,6 +11,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static net.corda.plugins.CopyUtils.*;
@@ -31,7 +32,7 @@ public class AnnotatedMethodTest {
     public void testAnnotatedMethod() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArguments("scanApi"))
+            .withArguments(getGradleArgsForTasks("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();
@@ -43,16 +44,9 @@ public class AnnotatedMethodTest {
 
         Path api = pathOf(testProjectDir, "build", "api", "annotated-method.txt");
         assertThat(api.toFile()).isFile();
-        assertEquals(
-            "public @interface net.corda.example.A\n" +
-            "##\n" +
-            "public @interface net.corda.example.B\n" +
-            "##\n" +
-            "public @interface net.corda.example.C\n" +
-            "##\n" +
-            "public class net.corda.example.HasAnnotatedMethod extends java.lang.Object\n" +
-            "  public <init>()\n" +
-            "  @net.corda.example.A @net.corda.example.B @net.corda.example.C public void hasAnnotation()\n" +
-            "##\n", CopyUtils.toString(api));
+        assertThat(Files.readAllLines(api)).containsOnlyOnce(
+            "public class net.corda.example.HasAnnotatedMethod extends java.lang.Object",
+            "  @net.corda.example.A @net.corda.example.B @net.corda.example.C public void hasAnnotation()"
+        );
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/BasicAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/BasicAnnotationTest.java
@@ -31,7 +31,7 @@ public class BasicAnnotationTest {
     public void testBasicAnnotation() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArguments("scanApi"))
+            .withArguments(getGradleArgsForTasks("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();

--- a/api-scanner/src/test/java/net/corda/plugins/BasicClassTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/BasicClassTest.java
@@ -31,7 +31,7 @@ public class BasicClassTest {
     public void testBasicClass() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArguments("scanApi"))
+            .withArguments(getGradleArgsForTasks("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();

--- a/api-scanner/src/test/java/net/corda/plugins/BasicInterfaceTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/BasicInterfaceTest.java
@@ -31,7 +31,7 @@ public class BasicInterfaceTest {
     public void testBasicInterface() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArguments("scanApi"))
+            .withArguments(getGradleArgsForTasks("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();

--- a/api-scanner/src/test/java/net/corda/plugins/ClassWithInternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/ClassWithInternalAnnotationTest.java
@@ -31,7 +31,7 @@ public class ClassWithInternalAnnotationTest {
     public void testClassWithInternalAnnotation() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArguments("scanApi"))
+            .withArguments(getGradleArgsForTasks("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();

--- a/api-scanner/src/test/java/net/corda/plugins/CopyUtils.java
+++ b/api-scanner/src/test/java/net/corda/plugins/CopyUtils.java
@@ -37,7 +37,7 @@ public final class CopyUtils {
         return Paths.get(folder.getRoot().getAbsolutePath(), elements);
     }
 
-    public static List<String> getGradleArguments(String... taskNames) {
+    public static List<String> getGradleArgsForTasks(String... taskNames) {
         List<String> args = new ArrayList<>(taskNames.length + 3);
         Collections.addAll(args, taskNames);
         args.add("--info");

--- a/api-scanner/src/test/java/net/corda/plugins/ExtendedClassTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/ExtendedClassTest.java
@@ -31,7 +31,7 @@ public class ExtendedClassTest {
     public void testExtendedClass() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArguments("scanApi"))
+            .withArguments(getGradleArgsForTasks("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();

--- a/api-scanner/src/test/java/net/corda/plugins/ExtendedInterfaceTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/ExtendedInterfaceTest.java
@@ -31,7 +31,7 @@ public class ExtendedInterfaceTest {
     public void testExtendedInterface() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArguments("scanApi"))
+            .withArguments(getGradleArgsForTasks("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();

--- a/api-scanner/src/test/java/net/corda/plugins/FieldWithInternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/FieldWithInternalAnnotationTest.java
@@ -3,7 +3,6 @@ package net.corda.plugins;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
-import static org.gradle.testkit.runner.TaskOutcome.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -15,20 +14,21 @@ import java.nio.file.Path;
 
 import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.gradle.testkit.runner.TaskOutcome.*;
 import static org.junit.Assert.*;
 
-public class MethodWithInternalAnnotationTest {
+public class FieldWithInternalAnnotationTest {
     @Rule
     public final TemporaryFolder testProjectDir = new TemporaryFolder();
 
     @Before
     public void setup() throws IOException {
         File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("method-internal-annotation/build.gradle", buildFile);
+        copyResourceTo("field-internal-annotation/build.gradle", buildFile);
     }
 
     @Test
-    public void testMethodWithInternalAnnotations() throws IOException {
+    public void testFieldWithInternalAnnotations() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
             .withArguments(getGradleArgsForTasks("scanApi"))
@@ -42,14 +42,14 @@ public class MethodWithInternalAnnotationTest {
         assertEquals(SUCCESS, scanApi.getOutcome());
 
         assertThat(output)
-            .contains("net.corda.example.method.InvisibleAnnotation")
-            .contains("net.corda.example.method.LocalInvisibleAnnotation");
+            .contains("net.corda.example.field.InvisibleAnnotation")
+            .contains("net.corda.example.field.LocalInvisibleAnnotation");
 
-        Path api = pathOf(testProjectDir, "build", "api", "method-internal-annotation.txt");
+        Path api = pathOf(testProjectDir, "build", "api", "field-internal-annotation.txt");
         assertThat(api.toFile()).isFile();
-        assertEquals("public class net.corda.example.method.HasVisibleMethod extends java.lang.Object\n" +
+        assertEquals("public class net.corda.example.field.HasVisibleField extends java.lang.Object\n" +
             "  public <init>()\n" +
-            "  public void hasInvisibleAnnotations()\n" +
+            "  public String hasInvisibleAnnotations\n" +
             "##\n", CopyUtils.toString(api));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/InternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/InternalAnnotationTest.java
@@ -31,7 +31,7 @@ public class InternalAnnotationTest {
     public void testInternalAnnotations() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArguments("scanApi"))
+            .withArguments(getGradleArgsForTasks("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();

--- a/api-scanner/src/test/java/net/corda/plugins/InternalFieldTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/InternalFieldTest.java
@@ -3,7 +3,6 @@ package net.corda.plugins;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
-import static org.gradle.testkit.runner.TaskOutcome.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -15,20 +14,21 @@ import java.nio.file.Path;
 
 import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.gradle.testkit.runner.TaskOutcome.*;
 import static org.junit.Assert.*;
 
-public class MethodWithInternalAnnotationTest {
+public class InternalFieldTest {
     @Rule
     public final TemporaryFolder testProjectDir = new TemporaryFolder();
 
     @Before
     public void setup() throws IOException {
         File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("method-internal-annotation/build.gradle", buildFile);
+        copyResourceTo("internal-field/build.gradle", buildFile);
     }
 
     @Test
-    public void testMethodWithInternalAnnotations() throws IOException {
+    public void testInternalField() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
             .withArguments(getGradleArgsForTasks("scanApi"))
@@ -41,15 +41,11 @@ public class MethodWithInternalAnnotationTest {
         assertNotNull(scanApi);
         assertEquals(SUCCESS, scanApi.getOutcome());
 
-        assertThat(output)
-            .contains("net.corda.example.method.InvisibleAnnotation")
-            .contains("net.corda.example.method.LocalInvisibleAnnotation");
-
-        Path api = pathOf(testProjectDir, "build", "api", "method-internal-annotation.txt");
+        Path api = pathOf(testProjectDir, "build", "api", "internal-field.txt");
         assertThat(api.toFile()).isFile();
-        assertEquals("public class net.corda.example.method.HasVisibleMethod extends java.lang.Object\n" +
+        assertEquals(
+            "public class net.corda.example.WithInternalField extends java.lang.Object\n" +
             "  public <init>()\n" +
-            "  public void hasInvisibleAnnotations()\n" +
             "##\n", CopyUtils.toString(api));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/InternalMethodTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/InternalMethodTest.java
@@ -30,7 +30,7 @@ public class InternalMethodTest {
     public void testInternalMethod() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArguments("scanApi"))
+            .withArguments(getGradleArgsForTasks("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();

--- a/api-scanner/src/test/java/net/corda/plugins/InternalPackageTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/InternalPackageTest.java
@@ -31,7 +31,7 @@ public class InternalPackageTest {
     public void testInternalPackageIsIgnored() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArguments("scanApi"))
+            .withArguments(getGradleArgsForTasks("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinAnnotationsTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinAnnotationsTest.java
@@ -31,7 +31,7 @@ public class KotlinAnnotationsTest {
     public void testKotlinAnnotations() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArguments("scanApi"))
+            .withArguments(getGradleArgsForTasks("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();
@@ -44,6 +44,10 @@ public class KotlinAnnotationsTest {
         Path api = pathOf(testProjectDir, "build", "api", "kotlin-annotations.txt");
         assertThat(api.toFile()).isFile();
         assertEquals(
+            "public final class net.corda.example.HasJvmField extends java.lang.Object\n" +
+            "  public <init>()\n" +
+            "  @org.jetbrains.annotations.NotNull public final String stringValue = \"Hello World\"\n" +
+            "##\n" +
             "public final class net.corda.example.HasJvmStaticFunction extends java.lang.Object\n" +
             "  public <init>()\n" +
             "  @kotlin.jvm.JvmStatic public static final void doThing(String)\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinInternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinInternalAnnotationTest.java
@@ -31,7 +31,7 @@ public class KotlinInternalAnnotationTest {
     public void testKotlinInternalAnnotation() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArguments("scanApi"))
+            .withArguments(getGradleArgsForTasks("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinLambdasTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinLambdasTest.java
@@ -31,7 +31,7 @@ public class KotlinLambdasTest {
     public void testKotlinLambdas() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArguments("scanApi"))
+            .withArguments(getGradleArgsForTasks("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinVarargMethodTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinVarargMethodTest.java
@@ -29,7 +29,7 @@ public class KotlinVarargMethodTest {
     public void testKotlinVarargMethod() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArguments("scanApi"))
+            .withArguments(getGradleArgsForTasks("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();

--- a/api-scanner/src/test/java/net/corda/plugins/VarargMethodTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/VarargMethodTest.java
@@ -29,7 +29,7 @@ public class VarargMethodTest {
     public void testVarargMethod() throws IOException {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArguments("scanApi"))
+            .withArguments(getGradleArgsForTasks("scanApi"))
             .withPluginClasspath()
             .build();
         String output = result.getOutput();

--- a/api-scanner/src/test/resources/annotated-field/build.gradle
+++ b/api-scanner/src/test/resources/annotated-field/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'net.corda.plugins.api-scanner'
 }
 
-description 'Test behaviour of internal annotations on classes'
+description 'Test annotation behaviour for a field'
 
 repositories {
     mavenLocal()
@@ -14,15 +14,15 @@ sourceSets {
     main {
         java {
             srcDir files(
-                "../resources/test/class-internal-annotation/java",
-                "../resources/test/common-internal/java"
+                "../resources/test/annotated-field/java",
+                "../resources/test/common-annotations/java"
             )
         }
     }
 }
 
 jar {
-    baseName = "class-internal-annotation"
+    baseName = "annotated-field"
 }
 
 scanApi {

--- a/api-scanner/src/test/resources/annotated-field/java/net/corda/example/HasAnnotatedField.java
+++ b/api-scanner/src/test/resources/annotated-field/java/net/corda/example/HasAnnotatedField.java
@@ -1,0 +1,6 @@
+package net.corda.example;
+
+public class HasAnnotatedField {
+    @B @C @A
+    public static final String ANNOTATED_FIELD = "<string-value>";
+}

--- a/api-scanner/src/test/resources/annotated-method/build.gradle
+++ b/api-scanner/src/test/resources/annotated-method/build.gradle
@@ -13,7 +13,10 @@ repositories {
 sourceSets {
     main {
         java {
-            srcDir file("../resources/test/annotated-method/java")
+            srcDir files(
+                "../resources/test/annotated-method/java",
+                "../resources/test/common-annotations/java"
+            )
         }
     }
 }

--- a/api-scanner/src/test/resources/common-annotations/java/net/corda/example/A.java
+++ b/api-scanner/src/test/resources/common-annotations/java/net/corda/example/A.java
@@ -6,7 +6,7 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.*;
 
-@Target({TYPE, METHOD})
+@Target({TYPE, METHOD, FIELD})
 @Retention(CLASS)
 public @interface A {
 }

--- a/api-scanner/src/test/resources/common-annotations/java/net/corda/example/B.java
+++ b/api-scanner/src/test/resources/common-annotations/java/net/corda/example/B.java
@@ -1,0 +1,12 @@
+package net.corda.example;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD, FIELD})
+@Retention(CLASS)
+public @interface B {
+}

--- a/api-scanner/src/test/resources/common-annotations/java/net/corda/example/C.java
+++ b/api-scanner/src/test/resources/common-annotations/java/net/corda/example/C.java
@@ -1,0 +1,12 @@
+package net.corda.example;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD, FIELD})
+@Retention(CLASS)
+public @interface C {
+}

--- a/api-scanner/src/test/resources/common-internal/java/net/corda/core/CordaInternal.java
+++ b/api-scanner/src/test/resources/common-internal/java/net/corda/core/CordaInternal.java
@@ -1,0 +1,12 @@
+package net.corda.core;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, METHOD, FIELD})
+@Retention(CLASS)
+public @interface CordaInternal {
+}

--- a/api-scanner/src/test/resources/field-internal-annotation/build.gradle
+++ b/api-scanner/src/test/resources/field-internal-annotation/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'net.corda.plugins.api-scanner'
 }
 
-description 'Test behaviour of internal annotations on classes'
+description 'Test behaviour of internal annotations on fields'
 
 repositories {
     mavenLocal()
@@ -14,7 +14,7 @@ sourceSets {
     main {
         java {
             srcDir files(
-                "../resources/test/class-internal-annotation/java",
+                "../resources/test/field-internal-annotation/java",
                 "../resources/test/common-internal/java"
             )
         }
@@ -22,7 +22,7 @@ sourceSets {
 }
 
 jar {
-    baseName = "class-internal-annotation"
+    baseName = "field-internal-annotation"
 }
 
 scanApi {

--- a/api-scanner/src/test/resources/field-internal-annotation/java/net/corda/example/field/CordaInternal.java
+++ b/api-scanner/src/test/resources/field-internal-annotation/java/net/corda/example/field/CordaInternal.java
@@ -1,4 +1,4 @@
-package net.corda.example;
+package net.corda.example.field;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -6,7 +6,7 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.*;
 
-@Target({TYPE, METHOD})
+@Target({TYPE, FIELD})
 @Retention(CLASS)
-public @interface B {
+public @interface CordaInternal {
 }

--- a/api-scanner/src/test/resources/field-internal-annotation/java/net/corda/example/field/HasVisibleField.java
+++ b/api-scanner/src/test/resources/field-internal-annotation/java/net/corda/example/field/HasVisibleField.java
@@ -1,0 +1,7 @@
+package net.corda.example.field;
+
+public class HasVisibleField {
+    @InvisibleAnnotation
+    @LocalInvisibleAnnotation
+    public String hasInvisibleAnnotations;
+}

--- a/api-scanner/src/test/resources/field-internal-annotation/java/net/corda/example/field/InvisibleAnnotation.java
+++ b/api-scanner/src/test/resources/field-internal-annotation/java/net/corda/example/field/InvisibleAnnotation.java
@@ -1,12 +1,14 @@
-package net.corda.core;
+package net.corda.example.field;
 
+import net.corda.core.CordaInternal;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.*;
 
-@Target({TYPE, METHOD})
+@Target({TYPE, FIELD})
 @Retention(CLASS)
-public @interface CordaInternal {
+@CordaInternal
+public @interface InvisibleAnnotation {
 }

--- a/api-scanner/src/test/resources/field-internal-annotation/java/net/corda/example/field/LocalInvisibleAnnotation.java
+++ b/api-scanner/src/test/resources/field-internal-annotation/java/net/corda/example/field/LocalInvisibleAnnotation.java
@@ -1,4 +1,4 @@
-package net.corda.example;
+package net.corda.example.field;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -6,7 +6,7 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.*;
 
-@Target({TYPE, METHOD})
+@Target({TYPE, FIELD})
 @Retention(CLASS)
 @CordaInternal
 public @interface LocalInvisibleAnnotation {

--- a/api-scanner/src/test/resources/internal-annotation/build.gradle
+++ b/api-scanner/src/test/resources/internal-annotation/build.gradle
@@ -15,7 +15,7 @@ sourceSets {
         java {
             srcDir files(
                 "../resources/test/internal-annotation/java",
-                "../resources/test/common/java"
+                "../resources/test/common-internal/java"
             )
         }
     }

--- a/api-scanner/src/test/resources/internal-field/build.gradle
+++ b/api-scanner/src/test/resources/internal-field/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'net.corda.plugins.api-scanner'
 }
 
-description 'Test behaviour of internal annotations on classes'
+description 'Test behaviour of @CordaInternal annotation on fields'
 
 repositories {
     mavenLocal()
@@ -14,7 +14,7 @@ sourceSets {
     main {
         java {
             srcDir files(
-                "../resources/test/class-internal-annotation/java",
+                "../resources/test/internal-field/java",
                 "../resources/test/common-internal/java"
             )
         }
@@ -22,7 +22,7 @@ sourceSets {
 }
 
 jar {
-    baseName = "class-internal-annotation"
+    baseName = "internal-field"
 }
 
 scanApi {

--- a/api-scanner/src/test/resources/internal-field/java/net/corda/example/WithInternalField.java
+++ b/api-scanner/src/test/resources/internal-field/java/net/corda/example/WithInternalField.java
@@ -1,0 +1,8 @@
+package net.corda.example;
+
+import net.corda.core.CordaInternal;
+
+public class WithInternalField {
+    @CordaInternal
+    public static final String INTERNAL_FIELD = "<secret value>";
+}

--- a/api-scanner/src/test/resources/internal-method/build.gradle
+++ b/api-scanner/src/test/resources/internal-method/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'net.corda.plugins.api-scanner'
 }
 
-description 'Test behaviour of @CordaInternal annotation'
+description 'Test behaviour of @CordaInternal annotation on methods'
 
 repositories {
     mavenLocal()
@@ -15,7 +15,7 @@ sourceSets {
         java {
             srcDir files(
                 "../resources/test/internal-method/java",
-                "../resources/test/common/java"
+                "../resources/test/common-internal/java"
             )
         }
     }

--- a/api-scanner/src/test/resources/kotlin-annotations/kotlin/net/corda/example/HasJvmField.kt
+++ b/api-scanner/src/test/resources/kotlin-annotations/kotlin/net/corda/example/HasJvmField.kt
@@ -1,0 +1,6 @@
+package net.corda.example
+
+class HasJvmField {
+    @JvmField
+    val stringValue = "Hello World"
+}

--- a/api-scanner/src/test/resources/method-internal-annotation/build.gradle
+++ b/api-scanner/src/test/resources/method-internal-annotation/build.gradle
@@ -15,7 +15,7 @@ sourceSets {
         java {
             srcDir files(
                 "../resources/test/method-internal-annotation/java",
-                "../resources/test/common/java"
+                "../resources/test/common-internal/java"
             )
         }
     }

--- a/api-scanner/src/test/resources/method-internal-annotation/java/net/corda/example/method/CordaInternal.java
+++ b/api-scanner/src/test/resources/method-internal-annotation/java/net/corda/example/method/CordaInternal.java
@@ -1,4 +1,4 @@
-package net.corda.example;
+package net.corda.example.method;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;

--- a/api-scanner/src/test/resources/method-internal-annotation/java/net/corda/example/method/HasVisibleMethod.java
+++ b/api-scanner/src/test/resources/method-internal-annotation/java/net/corda/example/method/HasVisibleMethod.java
@@ -1,4 +1,4 @@
-package net.corda.example;
+package net.corda.example.method;
 
 public class HasVisibleMethod {
     @InvisibleAnnotation

--- a/api-scanner/src/test/resources/method-internal-annotation/java/net/corda/example/method/InvisibleAnnotation.java
+++ b/api-scanner/src/test/resources/method-internal-annotation/java/net/corda/example/method/InvisibleAnnotation.java
@@ -1,4 +1,4 @@
-package net.corda.example;
+package net.corda.example.method;
 
 import net.corda.core.CordaInternal;
 import java.lang.annotation.Retention;

--- a/api-scanner/src/test/resources/method-internal-annotation/java/net/corda/example/method/LocalInvisibleAnnotation.java
+++ b/api-scanner/src/test/resources/method-internal-annotation/java/net/corda/example/method/LocalInvisibleAnnotation.java
@@ -1,4 +1,4 @@
-package net.corda.example;
+package net.corda.example.method;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -8,5 +8,6 @@ import static java.lang.annotation.RetentionPolicy.*;
 
 @Target({TYPE, METHOD})
 @Retention(CLASS)
-public @interface C {
+@CordaInternal
+public @interface LocalInvisibleAnnotation {
 }


### PR DESCRIPTION
Apply the same sorting/filtering logic for fields as we do for methods.
Also stop including `@JvmField` in the output because it's superfluous.