### PR TITLE
Tidy the API scanner tests up slightly

### DIFF
--- a/api-scanner/build.gradle
+++ b/api-scanner/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     // This dependency is only to prevent IntelliJ from choking
     // on the Kotlin classes in the test/resources directory.
     testCompile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    testCompile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 }
 
 processTestResources {

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedClassTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedClassTest.java
@@ -43,7 +43,7 @@ public class AnnotatedClassTest {
         assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = pathOf(testProjectDir, "build", "api", "annotated-class.txt");
-        assertThat(api.toFile()).isFile();
+        assertThat(api).isRegularFile();
         assertThat(Files.readAllLines(api)).containsOnlyOnce(
             "@net.corda.example.AlsoInherited @net.corda.example.IsInherited @net.corda.example.NotInherited public class net.corda.example.HasInheritedAnnotation extends java.lang.Object",
             "@net.corda.example.AlsoInherited @net.corda.example.IsInherited public class net.corda.example.InheritingAnnotations extends net.corda.example.HasInheritedAnnotation"

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedFieldTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedFieldTest.java
@@ -43,7 +43,7 @@ public class AnnotatedFieldTest {
         assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = pathOf(testProjectDir, "build", "api", "annotated-field.txt");
-        assertThat(api.toFile()).isFile();
+        assertThat(api).isRegularFile();
         assertThat(Files.readAllLines(api)).containsOnlyOnce(
             "public class net.corda.example.HasAnnotatedField extends java.lang.Object",
             "  @net.corda.example.A @net.corda.example.B @net.corda.example.C public static final String ANNOTATED_FIELD = \"<string-value>\""

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedInterfaceTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedInterfaceTest.java
@@ -43,7 +43,7 @@ public class AnnotatedInterfaceTest {
         assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = pathOf(testProjectDir, "build", "api", "annotated-interface.txt");
-        assertThat(api.toFile()).isFile();
+        assertThat(api).isRegularFile();
         assertThat(Files.readAllLines(api)).containsOnlyOnce(
             "@net.corda.example.AlsoInherited @net.corda.example.IsInherited @net.corda.example.NotInherited public interface net.corda.example.HasInheritedAnnotation",
             "@net.corda.example.AlsoInherited @net.corda.example.IsInherited public interface net.corda.example.InheritingAnnotations extends net.corda.example.HasInheritedAnnotation"

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedMethodTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedMethodTest.java
@@ -43,7 +43,7 @@ public class AnnotatedMethodTest {
         assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = pathOf(testProjectDir, "build", "api", "annotated-method.txt");
-        assertThat(api.toFile()).isFile();
+        assertThat(api).isRegularFile();
         assertThat(Files.readAllLines(api)).containsOnlyOnce(
             "public class net.corda.example.HasAnnotatedMethod extends java.lang.Object",
             "  @net.corda.example.A @net.corda.example.B @net.corda.example.C public void hasAnnotation()"

--- a/api-scanner/src/test/java/net/corda/plugins/BasicAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/BasicAnnotationTest.java
@@ -42,7 +42,7 @@ public class BasicAnnotationTest {
         assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = pathOf(testProjectDir, "build", "api", "basic-annotation.txt");
-        assertThat(api.toFile()).isFile();
+        assertThat(api).isRegularFile();
         assertEquals(
             "public @interface net.corda.example.BasicAnnotation\n" +
             "##\n", CopyUtils.toString(api));

--- a/api-scanner/src/test/java/net/corda/plugins/BasicClassTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/BasicClassTest.java
@@ -42,7 +42,7 @@ public class BasicClassTest {
         assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = pathOf(testProjectDir, "build", "api", "basic-class.txt");
-        assertThat(api.toFile()).isFile();
+        assertThat(api).isRegularFile();
         assertEquals(
             "public class net.corda.example.BasicClass extends java.lang.Object\n" +
             "  public <init>(String)\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/BasicInterfaceTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/BasicInterfaceTest.java
@@ -42,7 +42,7 @@ public class BasicInterfaceTest {
         assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = pathOf(testProjectDir, "build", "api", "basic-interface.txt");
-        assertThat(api.toFile()).isFile();
+        assertThat(api).isRegularFile();
         assertEquals(
             "public interface net.corda.example.BasicInterface\n" +
             "  public abstract java.math.BigInteger getBigNumber()\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/ClassWithInternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/ClassWithInternalAnnotationTest.java
@@ -44,7 +44,7 @@ public class ClassWithInternalAnnotationTest {
         assertThat(output).contains("net.corda.example.InvisibleAnnotation");
 
         Path api = pathOf(testProjectDir, "build", "api", "class-internal-annotation.txt");
-        assertThat(api.toFile()).isFile();
+        assertThat(api).isRegularFile();
         assertEquals("public class net.corda.example.AnnotatedClass extends java.lang.Object\n" +
             "  public <init>()\n" +
             "##\n", CopyUtils.toString(api));

--- a/api-scanner/src/test/java/net/corda/plugins/ExtendedClassTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/ExtendedClassTest.java
@@ -42,7 +42,7 @@ public class ExtendedClassTest {
         assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = pathOf(testProjectDir, "build", "api", "extended-class.txt");
-        assertThat(api.toFile()).isFile();
+        assertThat(api).isRegularFile();
         assertEquals(
             "public class net.corda.example.ExtendedClass extends java.io.FilterInputStream\n" +
             "  public <init>(java.io.InputStream)\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/ExtendedInterfaceTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/ExtendedInterfaceTest.java
@@ -42,7 +42,7 @@ public class ExtendedInterfaceTest {
         assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = pathOf(testProjectDir, "build", "api", "extended-interface.txt");
-        assertThat(api.toFile()).isFile();
+        assertThat(api).isRegularFile();
         assertEquals(
             "public interface net.corda.example.ExtendedInterface extends java.util.concurrent.Future\n" +
             "  public abstract String getName()\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/FieldWithInternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/FieldWithInternalAnnotationTest.java
@@ -46,7 +46,7 @@ public class FieldWithInternalAnnotationTest {
             .contains("net.corda.example.field.LocalInvisibleAnnotation");
 
         Path api = pathOf(testProjectDir, "build", "api", "field-internal-annotation.txt");
-        assertThat(api.toFile()).isFile();
+        assertThat(api).isRegularFile();
         assertEquals("public class net.corda.example.field.HasVisibleField extends java.lang.Object\n" +
             "  public <init>()\n" +
             "  public String hasInvisibleAnnotations\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/InternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/InternalAnnotationTest.java
@@ -46,7 +46,7 @@ public class InternalAnnotationTest {
         assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = pathOf(testProjectDir, "build", "api", "internal-annotation.txt");
-        assertThat(api.toFile()).isFile();
+        assertThat(api).isRegularFile();
         assertEquals("", CopyUtils.toString(api));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/InternalFieldTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/InternalFieldTest.java
@@ -42,7 +42,7 @@ public class InternalFieldTest {
         assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = pathOf(testProjectDir, "build", "api", "internal-field.txt");
-        assertThat(api.toFile()).isFile();
+        assertThat(api).isRegularFile();
         assertEquals(
             "public class net.corda.example.WithInternalField extends java.lang.Object\n" +
             "  public <init>()\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/InternalMethodTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/InternalMethodTest.java
@@ -41,7 +41,7 @@ public class InternalMethodTest {
         assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = pathOf(testProjectDir, "build", "api", "internal-method.txt");
-        assertThat(api.toFile()).isFile();
+        assertThat(api).isRegularFile();
         assertEquals(
             "public class net.corda.example.WithInternalMethod extends java.lang.Object\n" +
             "  public <init>()\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/InternalPackageTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/InternalPackageTest.java
@@ -44,7 +44,7 @@ public class InternalPackageTest {
         assertThat(output).contains("net.corda.internal.InvisibleClass");
 
         Path api = pathOf(testProjectDir, "build", "api", "internal-package.txt");
-        assertThat(api.toFile()).isFile();
+        assertThat(api).isRegularFile();
         assertEquals(
     "public class net.corda.VisibleClass extends java.lang.Object\n" +
             "  public <init>()\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinAnnotationsTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinAnnotationsTest.java
@@ -42,7 +42,7 @@ public class KotlinAnnotationsTest {
         assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = pathOf(testProjectDir, "build", "api", "kotlin-annotations.txt");
-        assertThat(api.toFile()).isFile();
+        assertThat(api).isRegularFile();
         assertEquals(
             "public final class net.corda.example.HasJvmField extends java.lang.Object\n" +
             "  public <init>()\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinInternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinInternalAnnotationTest.java
@@ -44,7 +44,7 @@ public class KotlinInternalAnnotationTest {
         assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = pathOf(testProjectDir, "build", "api", "kotlin-internal-annotation.txt");
-        assertThat(api.toFile()).isFile();
+        assertThat(api).isRegularFile();
         assertEquals(
             "public final class net.corda.example.kotlin.AnnotatedClass extends java.lang.Object\n" +
             "  public <init>()\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinLambdasTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinLambdasTest.java
@@ -44,7 +44,7 @@ public class KotlinLambdasTest {
         assertThat(output).contains("net.corda.example.LambdaExpressions$testing$$inlined$schedule$1");
 
         Path api = pathOf(testProjectDir, "build", "api", "kotlin-lambdas.txt");
-        assertThat(api.toFile()).isFile();
+        assertThat(api).isRegularFile();
         assertEquals("public final class net.corda.example.LambdaExpressions extends java.lang.Object\n" +
             "  public <init>()\n" +
             "  public final void testing(kotlin.Unit)\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinVarargMethodTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinVarargMethodTest.java
@@ -40,7 +40,7 @@ public class KotlinVarargMethodTest {
         assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = pathOf(testProjectDir, "build", "api", "kotlin-vararg-method.txt");
-        assertThat(api.toFile()).isFile();
+        assertThat(api).isRegularFile();
         assertEquals("public interface net.corda.example.KotlinVarargMethod\n" +
             "  public abstract void action(Object...)\n" +
             "##\n", CopyUtils.toString(api));

--- a/api-scanner/src/test/java/net/corda/plugins/MethodWithInternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/MethodWithInternalAnnotationTest.java
@@ -46,7 +46,7 @@ public class MethodWithInternalAnnotationTest {
             .contains("net.corda.example.method.LocalInvisibleAnnotation");
 
         Path api = pathOf(testProjectDir, "build", "api", "method-internal-annotation.txt");
-        assertThat(api.toFile()).isFile();
+        assertThat(api).isRegularFile();
         assertEquals("public class net.corda.example.method.HasVisibleMethod extends java.lang.Object\n" +
             "  public <init>()\n" +
             "  public void hasInvisibleAnnotations()\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/VarargMethodTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/VarargMethodTest.java
@@ -40,7 +40,7 @@ public class VarargMethodTest {
         assertEquals(SUCCESS, scanApi.getOutcome());
 
         Path api = pathOf(testProjectDir, "build", "api", "vararg-method.txt");
-        assertThat(api.toFile()).isFile();
+        assertThat(api).isRegularFile();
         assertEquals("public interface net.corda.example.VarargMethod\n" +
             "  public abstract void action(Object...)\n" +
             "##\n", CopyUtils.toString(api));


### PR DESCRIPTION
- Use `Path` API instead of `File` with AssertJ.
- Ensure `kotlin-reflect` has been downloaded before the tests try to use it.