### PR TITLE
Update publish-utils so that publishing javadoc is optional.

### DIFF
--- a/publish-utils/build.gradle
+++ b/publish-utils/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'groovy'
+apply plugin: 'java-gradle-plugin'
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.jfrog.artifactory'
@@ -23,15 +24,21 @@ buildscript {
     }
 }
 
-version "$gradle_plugins_version"
-
-dependencies {
-    compile gradleApi()
-    compile localGroovy()
-}
+group 'net.corda.plugins'
+version gradle_plugins_version
 
 repositories {
+    mavenLocal()
     mavenCentral()
+}
+
+gradlePlugin {
+    plugins {
+        publishUtilsPlugin {
+            id = 'net.corda.plugins.publish-utils'
+            implementationClass = 'net.corda.plugins.PublishTasks'
+        }
+    }
 }
 
 task("sourceJar", type: Jar, dependsOn: classes) {
@@ -76,7 +83,7 @@ publishing {
 
             pom.withXml {
                 asNode().children().last() + {
-                    resolveStrategy = Closure.DELEGATE_FIRST
+                    resolveStrategy = DELEGATE_FIRST
                     name 'publish-utils'
                     description 'A small gradle plugin that adds a couple of convenience functions for publishing to Maven'
                     url 'https://github.com/corda/corda'
@@ -106,4 +113,4 @@ publishing {
 }
 
 // Aliasing the publishToMavenLocal for simplicity.
-task(install, dependsOn: 'publishToMavenLocal')
+task install (dependsOn: 'publishToMavenLocal')

--- a/publish-utils/src/main/groovy/net/corda/plugins/ProjectPublishExtension.groovy
+++ b/publish-utils/src/main/groovy/net/corda/plugins/ProjectPublishExtension.groovy
@@ -36,4 +36,9 @@ class ProjectPublishExtension {
      * True if publishing sources to remote repositories
      */
     Boolean publishSources = true
+
+    /**
+     * True if publishing javadoc to remote repositories
+     */
+    Boolean publishJavadoc = true
 }

--- a/publish-utils/src/main/groovy/net/corda/plugins/PublishTasks.groovy
+++ b/publish-utils/src/main/groovy/net/corda/plugins/PublishTasks.groovy
@@ -2,7 +2,6 @@ package net.corda.plugins
 
 import org.gradle.api.*
 import org.gradle.api.tasks.bundling.Jar
-import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.api.Project
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.MavenPom
@@ -35,7 +34,7 @@ class PublishTasks implements Plugin<Project> {
      * values set after this call in the DSL will not be configured properly (and will use the default value)
      */
     void setPublishName(String publishName) {
-        project.logger.info("Changing publishing name from ${project.name} to ${publishName}")
+        project.logger.info("Changing publishing name from ${project.name} to $publishName")
         this.publishName = publishName
         checkAndConfigurePublishing()
     }
@@ -49,7 +48,7 @@ class PublishTasks implements Plugin<Project> {
     }
 
     void configurePublishing(BintrayConfigExtension bintrayConfig) {
-        project.logger.info("Configuring bintray for ${publishName}")
+        project.logger.info("Configuring bintray for $publishName")
         configureMavenPublish(bintrayConfig)
         configureBintray(bintrayConfig)
     }
@@ -65,10 +64,13 @@ class PublishTasks implements Plugin<Project> {
                 project.logger.info("Publishing sources for $publishName")
                 artifact project.tasks.sourceJar
             }
-            artifact project.tasks.javadocJar
+            if (publishConfig.publishJavadoc) {
+                project.logger.info("Publishing javadoc for $publishName")
+                artifact project.tasks.javadocJar
+            }
 
             project.configurations.publish.artifacts.each {
-                project.logger.debug("Adding artifact: $it")
+                project.logger.info("Adding artifact: ${it.file}")
                 delegate.artifact it
             }
 
@@ -87,7 +89,7 @@ class PublishTasks implements Plugin<Project> {
     void extendPomForMavenCentral(MavenPom pom, BintrayConfigExtension config) {
         pom.withXml {
             asNode().children().last() + {
-                resolveStrategy = Closure.DELEGATE_FIRST
+                resolveStrategy = DELEGATE_FIRST
                 name publishName
                 description project.description
                 url config.projectUrl

--- a/publish-utils/src/main/resources/META-INF/gradle-plugins/net.corda.plugins.publish-utils.properties
+++ b/publish-utils/src/main/resources/META-INF/gradle-plugins/net.corda.plugins.publish-utils.properties
@@ -1,1 +1,0 @@
-implementation-class=net.corda.plugins.PublishTasks


### PR DESCRIPTION
Add an option to the `publish` extension so that we can choose not to publish the javadoc artifact.
Also upgrade the plugin to use `java-gradle-plugin` and fix some compiler warnings.