### PR TITLE
Remove the special nature of the publish-utils name property.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,38 @@
 
 ## Version 4
 
+### Version 4.0.7
+
+* `publish-utils`: Setting the `name` property no longer triggers configuration. This is now applied after the project has been evaluated.
+* `publish-utils`: Add `publishJavadoc` property so that publishing Javadoc can be optional.
+
+### Version 4.0.6
+
+* `api-scanner`: Field annotations are now written out in alphanumerical order. The `@JvmField` annotation is no longer written at all.
+
+### Version 4.0.5
+
+* `cordformation`: Fix webserver startup when headless.
+
+### Version 4.0.4
+
+* `api-scanner`: Class/interface/method annotations are now written out in alphanumerical order.
+* `api-scanner`: Handle methods with vararg parameters correctly.
+
+### Version 4.0.3
+
+* `cordformation`: Fix parsing of unknown node configuration properties.
+
+### Version 4.0.2
+
+* `cordformation`: Add `NetworkParameters` contract implementation whitelist.
+
+### Version 4.0.1
+
+* `cordformation`: Use updated rpc users config format.
+
+### Version 4.0.0
+
 * Split repository from [Corda](https://github.com/corda/corda) repository.
 
 ## Pre-version 4

--- a/publish-utils/build.gradle
+++ b/publish-utils/build.gradle
@@ -36,7 +36,7 @@ gradlePlugin {
     plugins {
         publishUtilsPlugin {
             id = 'net.corda.plugins.publish-utils'
-            implementationClass = 'net.corda.plugins.PublishTasks'
+            implementationClass = 'net.corda.plugins.PublishPlugin'
         }
     }
 }

--- a/publish-utils/src/main/groovy/net/corda/plugins/ProjectPublishExtension.groovy
+++ b/publish-utils/src/main/groovy/net/corda/plugins/ProjectPublishExtension.groovy
@@ -1,26 +1,15 @@
 package net.corda.plugins
 
 class ProjectPublishExtension {
-    private PublishTasks task
 
-    void setPublishTask(PublishTasks task) {
-        this.task = task
+    ProjectPublishExtension(String name) {
+        this.name = name
     }
 
     /**
-     * Use a different name from the current project name for publishing.
-     * Set this after all other settings that need to be configured
+     * This is the name that we will publish the module as.
      */
-    void name(String name) {
-        task.setPublishName(name)
-    }
-
-    /**
-     * Get the publishing name for this project.
-     */
-    String name() {
-        return task.getPublishName()
-    }
+    String name
 
     /**
      * True when we do not want to publish default Java components

--- a/publish-utils/src/main/groovy/net/corda/plugins/PublishPlugin.groovy
+++ b/publish-utils/src/main/groovy/net/corda/plugins/PublishPlugin.groovy
@@ -3,8 +3,6 @@ package net.corda.plugins
 import org.gradle.api.*
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.Project
-import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.api.publish.maven.MavenPom
 import net.corda.plugins.bintray.*
 
 /**
@@ -16,154 +14,56 @@ import net.corda.plugins.bintray.*
  * in BintrayConfigExtension.
  */
 class PublishPlugin implements Plugin<Project> {
-    Project project
-    String publishName
-    ProjectPublishExtension publishConfig
+    private ProjectPublishExtension publishConfig
 
+    String getPublishName() { publishConfig.name }
+
+    @Override
     void apply(Project project) {
-        this.project = project
-        this.publishName = project.name
+        createExtensions(project)
+        createConfigurations(project)
+        createPlugins(project)
+        createTasks(project)
 
-        createTasks()
-        createExtensions()
-        createConfigurations()
-    }
-
-    /**
-     * This call must come at the end of any publish block because it configures the publishing and any
-     * values set after this call in the DSL will not be configured properly (and will use the default value)
-     */
-    void setPublishName(String publishName) {
-        project.logger.info("Changing publishing name from ${project.name} to $publishName")
-        this.publishName = publishName
-        checkAndConfigurePublishing()
-    }
-
-    void checkAndConfigurePublishing() {
-        project.logger.info("Checking whether to publish $publishName")
-        def bintrayConfig = project.rootProject.extensions.findByType(BintrayConfigExtension.class)
-        if((bintrayConfig != null) && (bintrayConfig.publications) && (bintrayConfig.publications.findAll { it == publishName }.size() > 0)) {
-            configurePublishing(bintrayConfig)
+        project.afterEvaluate {
+            project.logger.info("Publishing ${project.name} as $publishName")
+            new Publisher(project, publishConfig).execute()
         }
     }
 
-    void configurePublishing(BintrayConfigExtension bintrayConfig) {
-        project.logger.info("Configuring bintray for $publishName")
-        configureMavenPublish(bintrayConfig)
-        configureBintray(bintrayConfig)
-    }
-
-    void configureMavenPublish(BintrayConfigExtension bintrayConfig) {
-        project.logger.info("Configuring maven publish for $publishName")
-        project.apply([plugin: 'maven-publish'])
-        project.publishing.publications.create(publishName, MavenPublication) {
-            groupId project.group
-            artifactId publishName
-
-            if (publishConfig.publishSources) {
-                project.logger.info("Publishing sources for $publishName")
-                artifact project.tasks.sourceJar
-            }
-            if (publishConfig.publishJavadoc) {
-                project.logger.info("Publishing javadoc for $publishName")
-                artifact project.tasks.javadocJar
-            }
-
-            project.configurations.publish.artifacts.each {
-                project.logger.info("Adding artifact: ${it.file}")
-                delegate.artifact it
-            }
-
-            if (!publishConfig.disableDefaultJar && !publishConfig.publishWar) {
-                from project.components.java
-            } else if (publishConfig.publishWar) {
-                from project.components.web
-            }
-
-            extendPomForMavenCentral(pom, bintrayConfig)
-        }
-        project.task("install", dependsOn: "publishToMavenLocal")
-    }
-
-    // Maven central requires all of the below fields for this to be a valid POM
-    void extendPomForMavenCentral(MavenPom pom, BintrayConfigExtension config) {
-        pom.withXml {
-            asNode().children().last() + {
-                resolveStrategy = DELEGATE_FIRST
-                name publishName
-                description project.description
-                url config.projectUrl
-                scm {
-                    url config.vcsUrl
-                }
-
-                licenses {
-                    license {
-                        name config.license.name
-                        url config.license.url
-                        distribution config.license.url
-                    }
-                }
-
-                developers {
-                    developer {
-                        id config.developer.id
-                        name config.developer.name
-                        email config.developer.email
-                    }
-                }
-            }
-        }
-    }
-
-    void configureBintray(BintrayConfigExtension bintrayConfig) {
-        project.apply([plugin: 'com.jfrog.bintray'])
-        project.bintray {
-            user = bintrayConfig.user
-            key = bintrayConfig.key
-            publications = [ publishName ]
-            dryRun = bintrayConfig.dryRun ?: false
-            pkg {
-                repo = bintrayConfig.repo
-                name = publishName
-                userOrg = bintrayConfig.org
-                licenses = bintrayConfig.licenses
-
-                version {
-                    gpg {
-                        sign = bintrayConfig.gpgSign ?: false
-                        passphrase = bintrayConfig.gpgPassphrase
-                    }
-                }
-            }
-        }
-    }
-
-    void createTasks() {
-        if(project.hasProperty('classes')) {
+    void createTasks(Project project) {
+        if (project.hasProperty('classes')) {
             project.task("sourceJar", type: Jar, dependsOn: project.classes) {
                 classifier = 'sources'
                 from project.sourceSets.main.allSource
             }
         }
 
-        if(project.hasProperty('javadoc')) {
+        if (project.hasProperty('javadoc')) {
             project.task("javadocJar", type: Jar, dependsOn: project.javadoc) {
                 classifier = 'javadoc'
                 from project.javadoc.destinationDir
             }
         }
+
+        // Create the install task here so that modules can overwrite it (if required).
+        project.task("install", dependsOn: "publishToMavenLocal")
     }
 
-    void createExtensions() {
-        if(project == project.rootProject) {
+    void createExtensions(Project project) {
+        publishConfig = project.extensions.create("publish", ProjectPublishExtension, project.name)
+
+        if (project == project.rootProject) {
             project.extensions.create("bintrayConfig", BintrayConfigExtension)
         }
-        publishConfig = project.extensions.create("publish", ProjectPublishExtension)
-        publishConfig.setPublishTask(this)
     }
 
-    void createConfigurations() {
+    void createConfigurations(Project project) {
         project.configurations.create("publish")
+    }
+
+    void createPlugins(Project project) {
+        project.apply([plugin: 'maven-publish'])
+        project.apply([plugin: 'com.jfrog.bintray'])
     }
 }

--- a/publish-utils/src/main/groovy/net/corda/plugins/PublishPlugin.groovy
+++ b/publish-utils/src/main/groovy/net/corda/plugins/PublishPlugin.groovy
@@ -15,7 +15,7 @@ import net.corda.plugins.bintray.*
  * To use this plugin you can add a new configuration block (extension) to your root build.gradle. See the fields
  * in BintrayConfigExtension.
  */
-class PublishTasks implements Plugin<Project> {
+class PublishPlugin implements Plugin<Project> {
     Project project
     String publishName
     ProjectPublishExtension publishConfig

--- a/publish-utils/src/main/groovy/net/corda/plugins/Publisher.groovy
+++ b/publish-utils/src/main/groovy/net/corda/plugins/Publisher.groovy
@@ -1,0 +1,115 @@
+package net.corda.plugins
+
+import net.corda.plugins.bintray.BintrayConfigExtension
+import org.gradle.api.Project
+import org.gradle.api.publish.maven.MavenPom
+import org.gradle.api.publish.maven.MavenPublication
+
+class Publisher {
+    private final Project project
+    private final ProjectPublishExtension publishConfig
+
+    String getPublishName() { publishConfig.name }
+
+    Publisher(Project project, ProjectPublishExtension config) {
+        this.project = project
+        this.publishConfig = config
+    }
+
+    void execute() {
+        project.logger.info("Checking whether to publish $publishName")
+        def bintrayConfig = project.rootProject.extensions.findByType(BintrayConfigExtension.class)
+        if ((bintrayConfig != null) && bintrayConfig.publications && (bintrayConfig.publications.findAll { it == publishName }.size() > 0)) {
+            configurePublishing(bintrayConfig)
+        }
+    }
+
+    private void configurePublishing(BintrayConfigExtension bintrayConfig) {
+        project.logger.info("Configuring bintray for $publishName")
+        configureMavenPublish(bintrayConfig)
+        configureBintray(bintrayConfig)
+    }
+
+    private void configureMavenPublish(BintrayConfigExtension bintrayConfig) {
+        project.logger.info("Configuring maven publish for $publishName")
+        project.publishing.publications.create(publishName, MavenPublication) { maven ->
+            maven.groupId project.group
+            maven.artifactId publishName
+
+            if (publishConfig.publishSources) {
+                project.logger.info("Publishing sources for $publishName")
+                maven.artifact project.tasks.sourceJar
+            }
+            if (publishConfig.publishJavadoc) {
+                project.logger.info("Publishing javadoc for $publishName")
+                maven.artifact project.tasks.javadocJar
+            }
+
+            project.configurations.publish.artifacts.each {
+                project.logger.info("Adding artifact: ${it.file}")
+                delegate.artifact it
+            }
+
+            if (!publishConfig.disableDefaultJar && !publishConfig.publishWar) {
+                maven.from project.components.java
+            } else if (publishConfig.publishWar) {
+                maven.from project.components.web
+            }
+
+            extendPomForMavenCentral(pom, bintrayConfig)
+        }
+    }
+
+    // Maven central requires all of the below fields for this to be a valid POM
+    private void extendPomForMavenCentral(MavenPom pom, BintrayConfigExtension config) {
+        pom.withXml {
+            asNode().children().last() + {
+                resolveStrategy = DELEGATE_FIRST
+                name publishName
+                description project.description
+                url config.projectUrl
+                scm {
+                    url config.vcsUrl
+                }
+
+                licenses {
+                    license {
+                        name config.license.name
+                        url config.license.url
+                        distribution config.license.url
+                    }
+                }
+
+                developers {
+                    developer {
+                        id config.developer.id
+                        name config.developer.name
+                        email config.developer.email
+                    }
+                }
+            }
+        }
+    }
+
+    private void configureBintray(BintrayConfigExtension bintrayConfig) {
+        project.bintray {
+            user = bintrayConfig.user
+            key = bintrayConfig.key
+            publications = [ publishName ]
+            dryRun = bintrayConfig.dryRun ?: false
+            pkg {
+                repo = bintrayConfig.repo
+                name = publishName
+                userOrg = bintrayConfig.org
+                licenses = bintrayConfig.licenses
+
+                version {
+                    gpg {
+                        sign = bintrayConfig.gpgSign ?: false
+                        passphrase = bintrayConfig.gpgPassphrase
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Refactor `publish-utils` to configure publication during the `afterEvaluate` handler.