### PR TITLE
CORDA-1224: Update API Scanner not to output `@JvmStatic` annotations.

### DIFF
--- a/api-scanner/build.gradle
+++ b/api-scanner/build.gradle
@@ -22,6 +22,7 @@ gradlePlugin {
 
 dependencies {
     compile "io.github.lukehutch:fast-classpath-scanner:2.7.0"
+    testCompile project(':api-scanner:annotations')
     testCompile "org.assertj:assertj-core:$assertj_version"
     testCompile "junit:junit:$junit_version"
 
@@ -29,7 +30,6 @@ dependencies {
     // on the Kotlin classes in the test/resources directory.
     testCompile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     testCompile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    testCompile project(':api-scanner:annotations')
 }
 
 processTestResources {

--- a/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
+++ b/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
@@ -44,6 +44,7 @@ public class ScanApi extends DefaultTask {
        Set<String> blacklist = new LinkedHashSet<>();
        blacklist.add("kotlin.jvm.JvmField");
        blacklist.add("kotlin.jvm.JvmOverloads");
+       blacklist.add("kotlin.jvm.JvmStatic");
        blacklist.add(DEFAULT_INTERNAL_ANNOTATION);
        ANNOTATION_BLACKLIST = unmodifiableSet(blacklist);
     }

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinAnnotationsTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinAnnotationsTest.java
@@ -50,11 +50,11 @@ public class KotlinAnnotationsTest {
             "##\n" +
             "public final class net.corda.example.HasJvmStaticFunction extends java.lang.Object\n" +
             "  public <init>()\n" +
-            "  @kotlin.jvm.JvmStatic public static final void doThing(String)\n" +
+            "  public static final void doThing(String)\n" +
             "  public static final net.corda.example.HasJvmStaticFunction$Companion Companion\n" +
             "##\n" +
             "public static final class net.corda.example.HasJvmStaticFunction$Companion extends java.lang.Object\n" +
-            "  @kotlin.jvm.JvmStatic public final void doThing(String)\n" +
+            "  public final void doThing(String)\n" +
             "##\n" +
             "public final class net.corda.example.HasOverloadedConstructor extends java.lang.Object\n" +
             "  public <init>()\n" +

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Version 4
 
+### Version 4.0.9
+
+`api-scanner`: Remove the `@JvmStatic` annotation from the generated output.
+
 ### Version 4.0.8
 
 `publish-utils`: Revert "Setting the `name` property no longer triggers configuration." because it breaks publishing to Artifactory.


### PR DESCRIPTION
The `@JvmStatic` annotation doesn't need to appear in the API output because it also causes the Kotlin compiler to generate `static final` modifiers. And it is only the `static final` modifiers that are important for the API.

This will allow us to improve the Java-friendliness of the API without the API Stability gate generating a lot of false-positives.