### PR TITLE
CORDA-1301: Also exclude versions of dependencies that were created via jitpack.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ### Version 4.0.11
 
+* `cordapp`: Ensure that jitpack versions of dependencies are also excluded from the "fat jar" [CORDA-1301].
+
 ### Version 4.0.10
 
 * `cordformation`: Fixes a crash in Dockerform. 

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 ### Version 4.0.11
 
-* `cordapp`: Ensure that jitpack versions of dependencies are also excluded from the "fat jar" [CORDA-1301].
+* `quasar-utils`: Add quasar-core to cordaRuntime. This ensures that it is excluded from "fat jar" CorDapps [CORDA-1301].
 
 ### Version 4.0.10
 

--- a/cordapp/build.gradle
+++ b/cordapp/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'kotlin'
+apply plugin: 'java-gradle-plugin'
 apply plugin: 'net.corda.plugins.publish-utils'
 apply plugin: 'com.jfrog.artifactory'
 
@@ -9,8 +10,16 @@ repositories {
     jcenter()
 }
 
+gradlePlugin {
+    plugins {
+        cordappPlugin {
+            id = 'net.corda.plugins.cordapp'
+            implementationClass = 'net.corda.plugins.CordappPlugin'
+        }
+    }
+}
+
 dependencies {
-    compile gradleApi()
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
 }
 

--- a/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
@@ -9,6 +9,7 @@ import java.io.File
  * The Cordapp plugin will turn a project into a cordapp project which builds cordapp JARs with the correct format
  * and with the information needed to run on Corda.
  */
+@Suppress("UNUSED")
 class CordappPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         project.logger.info("Configuring ${project.name} as a cordapp")
@@ -31,10 +32,16 @@ class CordappPlugin : Plugin<Project> {
         val task = project.task("configureCordappFatJar")
         val jarTask = project.tasks.getByName("jar") as Jar
         task.doLast {
-            jarTask.from(getDirectNonCordaDependencies(project).map { project.zipTree(it)}).apply {
+            jarTask.from(getDirectNonCordaDependencies(project).map {
+                project.logger.info("CorDapp dependency: ${it.name}")
+                project.zipTree(it)
+            }).apply {
                 exclude("META-INF/*.SF")
                 exclude("META-INF/*.DSA")
                 exclude("META-INF/*.RSA")
+                exclude("META-INF/*.MF")
+                exclude("META-INF/LICENSE")
+                exclude("META-INF/NOTICE")
             }
         }
         jarTask.dependsOn(task)
@@ -57,11 +64,12 @@ class CordappPlugin : Plugin<Project> {
         val directDeps = runtimeConfiguration.allDependencies - excludeDeps
         // We want to filter out anything Corda related or provided by Corda, like kotlin-stdlib and quasar
         val filteredDeps = directDeps.filter { dep ->
-            excludes.none { exclude -> (exclude["group"] == dep.group) && (exclude["name"] == dep.name) }
+            excludes.none { exclude -> (exclude["name"] == dep.name) && (
+                    (exclude["group"] == dep.group) || dep.group?.startsWith("com.github.corda.") ?: false) }
         }
         filteredDeps.forEach {
             // net.corda or com.r3.corda.enterprise may be a core dependency which shouldn't be included in this cordapp so give a warning
-            val group = it.group?.toString() ?: ""
+            val group = it.group ?: ""
             if (group.startsWith("net.corda.") || group.startsWith("com.r3.corda.enterprise.")) {
                 project.logger.warn("You appear to have included a Corda platform component ($it) using a 'compile' or 'runtime' dependency." +
                         "This can cause node stability problems. Please use 'corda' instead." +

--- a/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
@@ -16,10 +16,7 @@ class CordappPlugin : Plugin<Project> {
 
         Utils.createCompileConfiguration("cordapp", project)
         Utils.createCompileConfiguration("cordaCompile", project)
-
-        val configuration: Configuration = project.configurations.create("cordaRuntime")
-        configuration.isTransitive = false
-        project.configurations.single { it.name == "runtime" }.extendsFrom(configuration)
+        Utils.createRuntimeConfiguration("cordaRuntime", project)
 
         configureCordappJar(project)
     }
@@ -64,8 +61,7 @@ class CordappPlugin : Plugin<Project> {
         val directDeps = runtimeConfiguration.allDependencies - excludeDeps
         // We want to filter out anything Corda related or provided by Corda, like kotlin-stdlib and quasar
         val filteredDeps = directDeps.filter { dep ->
-            excludes.none { exclude -> (exclude["name"] == dep.name) && (
-                    (exclude["group"] == dep.group) || dep.group?.startsWith("com.github.corda.") ?: false) }
+            excludes.none { exclude -> (exclude["group"] == dep.group) && (exclude["name"] == dep.name) }
         }
         filteredDeps.forEach {
             // net.corda or com.r3.corda.enterprise may be a core dependency which shouldn't be included in this cordapp so give a warning

--- a/cordapp/src/main/kotlin/net/corda/plugins/Utils.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/Utils.kt
@@ -21,6 +21,9 @@ class Utils {
                 project.configurations.single { it.name == "compile" }.extendsFrom(configuration)
             }
         }
+
+        // This function is called from the groovy quasar-utils plugin.
+        @JvmStatic
         fun createRuntimeConfiguration(name: String, project: Project) {
             if(!project.configurations.any { it.name == name }) {
                 val configuration = project.configurations.create(name)

--- a/cordapp/src/main/kotlin/net/corda/plugins/Utils.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/Utils.kt
@@ -1,13 +1,12 @@
 package net.corda.plugins
 
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.plugins.ExtraPropertiesExtension
 
 /**
  * Mimics the "project.ext" functionality in groovy which provides a direct
- * accessor to the "ext" extention (See: ExtraPropertiesExtension)
+ * accessor to the "ext" extension (See: ExtraPropertiesExtension)
  */
 @Suppress("UNCHECKED_CAST")
 fun <T : Any> Project.ext(name: String): T = (extensions.findByName("ext") as ExtraPropertiesExtension).get(name) as T
@@ -15,7 +14,6 @@ fun Project.configuration(name: String): Configuration = configurations.single {
 
 class Utils {
     companion object {
-        @JvmStatic
         fun createCompileConfiguration(name: String, project: Project) {
             if(!project.configurations.any { it.name == name }) {
                 val configuration = project.configurations.create(name)

--- a/cordapp/src/main/resources/META-INF/gradle-plugins/net.corda.plugins.cordapp.properties
+++ b/cordapp/src/main/resources/META-INF/gradle-plugins/net.corda.plugins.cordapp.properties
@@ -1,1 +1,0 @@
-implementation-class=net.corda.plugins.CordappPlugin

--- a/quasar-utils/build.gradle
+++ b/quasar-utils/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'groovy'
-apply plugin: 'maven-publish'
+apply plugin: 'java-gradle-plugin'
 apply plugin: 'net.corda.plugins.publish-utils'
 apply plugin: 'com.jfrog.artifactory'
 
@@ -9,9 +9,17 @@ repositories {
     mavenCentral()
 }
 
+gradlePlugin {
+    plugins {
+        quasarPlugin {
+            id = 'net.corda.plugins.quasar-utils'
+            implementationClass = 'net.corda.plugins.QuasarPlugin'
+        }
+    }
+}
+
 dependencies {
-    compile gradleApi()
-    compile localGroovy()
+    compile project(':cordapp')
 }
 
 publish {

--- a/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
@@ -9,12 +9,15 @@ import org.gradle.api.tasks.JavaExec
  * QuasarPlugin creates a "quasar" configuration and adds quasar as a dependency.
  */
 class QuasarPlugin implements Plugin<Project> {
+    @Override
     void apply(Project project) {
+        Utils.createRuntimeConfiguration("cordaRuntime", project)
+
         project.configurations.create("quasar")
 //        To add a local .jar dependency:
 //        project.dependencies.add("quasar", project.files("${project.rootProject.projectDir}/lib/quasar.jar"))
         project.dependencies.add("quasar", "${project.rootProject.ext.quasar_group}:quasar-core:${project.rootProject.ext.quasar_version}:jdk8@jar")
-        project.dependencies.add("runtime", project.configurations.getByName("quasar"))
+        project.dependencies.add("cordaRuntime", project.configurations.getByName("quasar"))
 
         project.tasks.withType(Test) {
             jvmArgs "-javaagent:${project.configurations.quasar.singleFile}"

--- a/quasar-utils/src/main/resources/META-INF/gradle-plugins/net.corda.plugins.quasar-utils.properties
+++ b/quasar-utils/src/main/resources/META-INF/gradle-plugins/net.corda.plugins.quasar-utils.properties
@@ -1,1 +1,0 @@
-implementation-class=net.corda.plugins.QuasarPlugin


### PR DESCRIPTION
CorDapps are supposed to exclude `quasar-core` from their "fat jars". However, we have switched to a "jitpack" version of `quasar-core` which has `group=com.github.corda.quasar` instead of `group=co.paralleluniverse`. So extend the pattern-matching to handle jitpack artifacts in the `com.github.corda` namespace.

And while I'm here, fix some compiler warnings and upgrade the plugin to use `java-gradle-plugin`.