### PR TITLE
Resolve issues in Cordformation code

### DIFF
--- a/cordform-common/build.gradle
+++ b/cordform-common/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java'
 apply plugin: 'kotlin'
-apply plugin: 'maven-publish'
 apply plugin: 'net.corda.plugins.publish-utils'
 apply plugin: 'com.jfrog.artifactory'
 

--- a/cordformation/build.gradle
+++ b/cordformation/build.gradle
@@ -33,9 +33,16 @@ sourceSets {
     }
 }
 
-dependencies {
-    gradleApi()
+gradlePlugin {
+    plugins {
+        cordformationPlugin {
+            id = 'net.corda.plugins.cordformation'
+            implementationClass = 'net.corda.plugins.Cordformation'
+        }
+    }
+}
 
+dependencies {
     compile project(":cordapp")
     compile project(':cordform-common')
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
@@ -44,7 +51,7 @@ dependencies {
     noderunner "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     testCompile "junit:junit:$junit_version" // TODO: Unify with core
-    testCompile "org.assertj:assertj-core:3.8.0"
+    testCompile "org.assertj:assertj-core:$assertj_version"
     // Docker-compose file generation
     compile "org.yaml:snakeyaml:$snake_yaml_version"
 }

--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
@@ -3,7 +3,6 @@ package net.corda.plugins
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import java.io.File
-import java.io.InputStream
 
 /**
  * The Cordformation plugin deploys nodes to a directory in a state ready to be used by a developer for experimentation,

--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -27,8 +27,7 @@ open class Node @Inject constructor(private val project: Project) : CordformNode
     internal data class ResolvedCordapp(val jarFile: File, val config: String?)
 
     companion object {
-        @JvmStatic
-        val webJarName = "corda-webserver.jar"
+        const val webJarName = "corda-webserver.jar"
         private val configFileProperty = "configFile"
     }
 
@@ -305,7 +304,7 @@ open class Node @Inject constructor(private val project: Project) : CordformNode
         val cordappsDir = project.file(File(nodeDir, "cordapps"))
         cordappsDir.mkdirs()
         cordapps.filter { it.config != null }
-                .map { Pair<String, String>("${FilenameUtils.removeExtension(it.jarFile.name)}.conf", it.config!!) }
+                .map { Pair("${FilenameUtils.removeExtension(it.jarFile.name)}.conf", it.config!!) }
                 .forEach { project.file(File(cordappsDir, it.first)).writeText(it.second) }
     }
 

--- a/cordformation/src/main/resources/META-INF/gradle-plugins/net.corda.plugins.cordformation.properties
+++ b/cordformation/src/main/resources/META-INF/gradle-plugins/net.corda.plugins.cordformation.properties
@@ -1,1 +1,0 @@
-implementation-class=net.corda.plugins.Cordformation

--- a/cordformation/src/noderunner/kotlin/net/corda/plugins/NodeRunner.kt
+++ b/cordformation/src/noderunner/kotlin/net/corda/plugins/NodeRunner.kt
@@ -4,8 +4,8 @@ import java.awt.GraphicsEnvironment
 import java.io.File
 import java.util.*
 
-private val HEADLESS_FLAG = "--headless"
-private val CAPSULE_DEBUG_FLAG = "--capsule-debug"
+private const val HEADLESS_FLAG = "--headless"
+private const val CAPSULE_DEBUG_FLAG = "--capsule-debug"
 
 private val os by lazy {
     val osName = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH)
@@ -32,7 +32,7 @@ fun main(args: Array<String>) {
     val capsuleDebugMode = args.contains(CAPSULE_DEBUG_FLAG)
     val workingDir = File(System.getProperty("user.dir"))
     val javaArgs = args.filter { it != HEADLESS_FLAG && it != CAPSULE_DEBUG_FLAG }
-    val jvmArgs = if (capsuleDebugMode) listOf("-Dcapsule.log=verbose") else emptyList<String>()
+    val jvmArgs = if (capsuleDebugMode) listOf("-Dcapsule.log=verbose") else emptyList()
     println("Starting nodes in $workingDir")
     workingDir.listFiles { file -> file.isDirectory }.forEach { dir ->
         listOf(NodeJarType, WebJarType).forEach { jarType ->
@@ -106,7 +106,7 @@ private abstract class JavaCommand(
             val jolokiaConfig = java.lang.StringBuilder()
             jolokiaConfig.append("-javaagent:drivers/$jolokiaJar=port=$monitoringPort")
             if (jolokiaLogHandler.isNotEmpty()) {
-                jolokiaConfig.append(",logHandlerClass=${jolokiaLogHandler}")
+                jolokiaConfig.append(",logHandlerClass=$jolokiaLogHandler")
             }
             jvmArgs.add(jolokiaConfig.toString())
         }

--- a/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
@@ -1,6 +1,5 @@
 package net.corda.plugins
 
-import org.apache.commons.io.FileUtils
 import org.apache.commons.io.IOUtils
 import org.assertj.core.api.Assertions.*
 import org.junit.Before
@@ -8,9 +7,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
-import java.io.IOException
-import java.nio.charset.StandardCharsets
-import java.nio.file.Files
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 
@@ -18,12 +14,14 @@ class CordformTest {
     @Rule
     @JvmField
     val testProjectDir = TemporaryFolder()
-    private var buildFile: File? = null
+    private lateinit var buildFile: File
 
     private companion object {
-        val cordaFinanceJarName = "corda-finance-3.0-SNAPSHOT"
-        val localCordappJarName = "locally-built-cordapp"
-        val notaryNodeName = "Notary Service"
+        const val cordaFinanceJarName = "corda-finance-3.0-SNAPSHOT"
+        const val localCordappJarName = "locally-built-cordapp"
+        const val notaryNodeName = "Notary Service"
+
+        private val testGradleUserHome = System.getProperty("test.gradle.user.home", ".")
     }
 
     @Before
@@ -67,11 +65,11 @@ class CordformTest {
         createBuildFile(buildFileResourceName)
         return GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
-                .withArguments("deployNodes", "-s")
+                .withArguments("deployNodes", "-s", "--info", "-g", testGradleUserHome)
                 .withPluginClasspath()
     }
 
-    private fun createBuildFile(buildFileResourceName: String) = IOUtils.copy(javaClass.getResourceAsStream(buildFileResourceName), buildFile!!.outputStream())
+    private fun createBuildFile(buildFileResourceName: String) = IOUtils.copy(javaClass.getResourceAsStream(buildFileResourceName), buildFile.outputStream())
     private fun getNodeCordappJar(nodeName: String, cordappJarName: String) = File(testProjectDir.root, "build/nodes/$nodeName/cordapps/$cordappJarName.jar")
     private fun getNodeCordappConfig(nodeName: String, cordappJarName: String) = File(testProjectDir.root, "build/nodes/$nodeName/cordapps/$cordappJarName.conf")
 }


### PR DESCRIPTION
Resolves the following issues:
- Remove unused `import`s.
- Add `gradlePlugins` section to `build.gradle`.
- Declare simple `val` properties as `const`.
- Run Gradle test-kit with "--info" to provide better visibility for test failures.
- Configure tests to use host project's Gradle cache.