### PR TITLE
CORDA-1263: Replace deprecated Kotlin artifacts.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 ### Version 4.0.14
 
-
+* `cordform-common`,`cordapp`: Replace deprecated `kotlin-stdlib-jre8` with `kotlin-stdlib-jdk8`.
 
 ### Version 4.0.13
 

--- a/cordapp/build.gradle
+++ b/cordapp/build.gradle
@@ -20,7 +20,7 @@ gradlePlugin {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }
 
 publish {

--- a/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
@@ -49,6 +49,7 @@ class CordappPlugin : Plugin<Project> {
         val excludes = listOf(
                 mapOf("group" to "org.jetbrains.kotlin", "name" to "kotlin-stdlib"),
                 mapOf("group" to "org.jetbrains.kotlin", "name" to "kotlin-stdlib-jre8"),
+                mapOf("group" to "org.jetbrains.kotlin", "name" to "kotlin-stdlib-jdk8"),
                 mapOf("group" to "org.jetbrains.kotlin", "name" to "kotlin-reflect"),
                 mapOf("group" to "co.paralleluniverse", "name" to "quasar-core")
         )

--- a/cordform-common/build.gradle
+++ b/cordform-common/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     // JSR 305: Nullability annotations
     compile "com.google.code.findbugs:jsr305:$jsr305_version"


### PR DESCRIPTION
Replace deprecated kotlin-stdlib-jre8 artifact with kotlin-stdlib-jdk8.