### PR TITLE
CORDA-1027 Anthony make api annotations more readable

### DIFF
--- a/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
+++ b/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
@@ -45,6 +45,8 @@ public class ScanApi extends DefaultTask {
        blacklist.add("kotlin.jvm.JvmField");
        blacklist.add("kotlin.jvm.JvmOverloads");
        blacklist.add("kotlin.jvm.JvmStatic");
+       blacklist.add("kotlin.Deprecated");
+       blacklist.add("java.lang.Deprecated");
        blacklist.add(DEFAULT_INTERNAL_ANNOTATION);
        ANNOTATION_BLACKLIST = unmodifiableSet(blacklist);
     }

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedClassTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedClassTest.java
@@ -44,9 +44,18 @@ public class AnnotatedClassTest {
 
         Path api = pathOf(testProjectDir, "build", "api", "annotated-class.txt");
         assertThat(api).isRegularFile();
-        assertThat(Files.readAllLines(api)).containsOnlyOnce(
-            "@net.corda.annotation.AlsoInherited @net.corda.annotation.IsInherited @net.corda.annotation.NotInherited public class net.corda.example.HasInheritedAnnotation extends java.lang.Object",
-            "@net.corda.annotation.AlsoInherited @net.corda.annotation.IsInherited public class net.corda.example.InheritingAnnotations extends net.corda.example.HasInheritedAnnotation"
-        );
+        assertEquals(
+            "@AlsoInherited\n" +
+            "@IsInherited\n" +
+            "@NotInherited\n" +
+            "public class net.corda.example.HasInheritedAnnotation extends java.lang.Object\n" +
+            "  public <init>()\n" +
+            "##\n" +
+            "@AlsoInherited\n" +
+            "@IsInherited\n" +
+            "public class net.corda.example.InheritingAnnotations extends net.corda.example.HasInheritedAnnotation\n" +
+            "  public <init>()\n" +
+            "##", CopyUtils.toString(api));
+
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedFieldTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedFieldTest.java
@@ -44,9 +44,20 @@ public class AnnotatedFieldTest {
 
         Path api = pathOf(testProjectDir, "build", "api", "annotated-field.txt");
         assertThat(api).isRegularFile();
-        assertThat(Files.readAllLines(api)).containsOnlyOnce(
-            "public class net.corda.example.HasAnnotatedField extends java.lang.Object",
-            "  @net.corda.example.A @net.corda.example.B @net.corda.example.C public static final String ANNOTATED_FIELD = \"<string-value>\""
-        );
+        assertEquals(
+            "public @interface net.corda.example.A\n" +
+            "##\n" +
+            "public @interface net.corda.example.B\n" +
+            "##\n" +
+            "public @interface net.corda.example.C\n" +
+            "##\n" +
+            "public class net.corda.example.HasAnnotatedField extends java.lang.Object\n" +
+            "  public <init>()\n" +
+            "  @A\n" +
+            "  @B\n" +
+            "  @C\n" +
+            "  public static final String ANNOTATED_FIELD = \"<string-value>\"\n" +
+            "##", CopyUtils.toString(api));
+
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedInterfaceTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedInterfaceTest.java
@@ -44,9 +44,13 @@ public class AnnotatedInterfaceTest {
 
         Path api = pathOf(testProjectDir, "build", "api", "annotated-interface.txt");
         assertThat(api).isRegularFile();
-        assertThat(Files.readAllLines(api)).containsOnlyOnce(
-            "@net.corda.annotation.AlsoInherited @net.corda.annotation.IsInherited @net.corda.annotation.NotInherited public interface net.corda.example.HasInheritedAnnotation",
-            "@net.corda.annotation.AlsoInherited @net.corda.annotation.IsInherited public interface net.corda.example.InheritingAnnotations extends net.corda.example.HasInheritedAnnotation"
-        );
+        assertEquals(
+            "@AlsoInherited\n" +
+            "@IsInherited\n" +
+            "@NotInherited\n" +
+            "public interface net.corda.example.HasInheritedAnnotation\n" +
+            "##\n" +
+            "public interface net.corda.example.InheritingAnnotations extends net.corda.example.HasInheritedAnnotation\n" +
+            "##", CopyUtils.toString(api));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedMethodTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedMethodTest.java
@@ -52,7 +52,10 @@ public class AnnotatedMethodTest {
             "##\n" +
             "public class net.corda.example.HasAnnotatedMethod extends java.lang.Object\n" +
             "  public <init>()\n" +
-            "  @net.corda.example.A @net.corda.example.B @net.corda.example.C public void hasAnnotation()\n" +
+            "  @A\n" +
+            "  @B\n" +
+            "  @C\n" +
+            "  public void hasAnnotation()\n" +
             "##\n" +
             "public class net.corda.example.HasDeprecatedMethod extends java.lang.Object\n" +
             "  public <init>()\n" +

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedMethodTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedMethodTest.java
@@ -11,7 +11,6 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static net.corda.plugins.CopyUtils.*;
@@ -44,9 +43,20 @@ public class AnnotatedMethodTest {
 
         Path api = pathOf(testProjectDir, "build", "api", "annotated-method.txt");
         assertThat(api).isRegularFile();
-        assertThat(Files.readAllLines(api)).containsOnlyOnce(
-            "public class net.corda.example.HasAnnotatedMethod extends java.lang.Object",
-            "  @net.corda.example.A @net.corda.example.B @net.corda.example.C public void hasAnnotation()"
-        );
+        assertEquals(
+            "public @interface net.corda.example.A\n" +
+            "##\n" +
+            "public @interface net.corda.example.B\n" +
+            "##\n" +
+            "public @interface net.corda.example.C\n" +
+            "##\n" +
+            "public class net.corda.example.HasAnnotatedMethod extends java.lang.Object\n" +
+            "  public <init>()\n" +
+            "  @net.corda.example.A @net.corda.example.B @net.corda.example.C public void hasAnnotation()\n" +
+            "##\n" +
+            "public class net.corda.example.HasDeprecatedMethod extends java.lang.Object\n" +
+            "  public <init>()\n" +
+            "  public void isDeprecated()\n" +
+            "##", CopyUtils.toString(api));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinAnnotationsTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinAnnotationsTest.java
@@ -48,11 +48,13 @@ public class KotlinAnnotationsTest {
         assertEquals(
             "public final class net.corda.example.HasDeprecatedFunctions extends java.lang.Object\n" +
             "  public <init>()\n" +
-            "  @org.jetbrains.annotations.NotNull public final String doSomething()\n" +
+            "  @NotNull\n" +
+            "  public final String doSomething()\n" +
             "##\n" +
             "public final class net.corda.example.HasJvmField extends java.lang.Object\n" +
             "  public <init>()\n" +
-            "  @org.jetbrains.annotations.NotNull public final String stringValue = \"Hello World\"\n" +
+            "  @NotNull\n" +
+            "  public final String stringValue = \"Hello World\"\n" +
             "##\n" +
             "public final class net.corda.example.HasJvmStaticFunction extends java.lang.Object\n" +
             "  public <init>()\n" +
@@ -67,8 +69,10 @@ public class KotlinAnnotationsTest {
             "  public <init>(String)\n" +
             "  public <init>(String, String)\n" +
             "  public <init>(String, String, int)\n" +
-            "  @org.jetbrains.annotations.NotNull public final String getNotNullable()\n" +
-            "  @org.jetbrains.annotations.Nullable public final String getNullable()\n" +
+            "  @NotNull\n" +
+            "  public final String getNotNullable()\n" +
+            "  @Nullable\n" +
+            "  public final String getNullable()\n" +
             "  public final int getNumber()\n" +
             "##", CopyUtils.toString(api));
     }

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinAnnotationsTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinAnnotationsTest.java
@@ -3,7 +3,9 @@ package net.corda.plugins;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
+
 import static org.gradle.testkit.runner.TaskOutcome.*;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,10 +32,10 @@ public class KotlinAnnotationsTest {
     @Test
     public void testKotlinAnnotations() throws IOException {
         BuildResult result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArgsForTasks("scanApi"))
-            .withPluginClasspath()
-            .build();
+                .withProjectDir(testProjectDir.getRoot())
+                .withArguments(getGradleArgsForTasks("scanApi"))
+                .withPluginClasspath()
+                .build();
         String output = result.getOutput();
         System.out.println(output);
 
@@ -44,6 +46,10 @@ public class KotlinAnnotationsTest {
         Path api = pathOf(testProjectDir, "build", "api", "kotlin-annotations.txt");
         assertThat(api).isRegularFile();
         assertEquals(
+            "public final class net.corda.example.HasDeprecatedFunctions extends java.lang.Object\n" +
+            "  public <init>()\n" +
+            "  @org.jetbrains.annotations.NotNull public final String doSomething()\n" +
+            "##\n" +
             "public final class net.corda.example.HasJvmField extends java.lang.Object\n" +
             "  public <init>()\n" +
             "  @org.jetbrains.annotations.NotNull public final String stringValue = \"Hello World\"\n" +

--- a/api-scanner/src/test/resources/annotated-method/java/net/corda/example/HasDeprecatedMethod.java
+++ b/api-scanner/src/test/resources/annotated-method/java/net/corda/example/HasDeprecatedMethod.java
@@ -1,0 +1,6 @@
+package net.corda.example;
+
+public class HasDeprecatedMethod {
+    @Deprecated
+    public void isDeprecated() { System.out.println("IS DEPRECATED");}
+}

--- a/api-scanner/src/test/resources/kotlin-annotations/kotlin/net/corda/example/HasDeprecatedFunctions.kt
+++ b/api-scanner/src/test/resources/kotlin-annotations/kotlin/net/corda/example/HasDeprecatedFunctions.kt
@@ -1,0 +1,6 @@
+package net.corda.example
+
+class HasDeprecatedFunctions @Deprecated("Dont use this anymore!") constructor () {
+    @Deprecated("Dont use this anymore!")
+    fun doSomething() = "123"
+}


### PR DESCRIPTION
* Add deprecated annotations to blacklist
* Add a couple of tests for deprecated annotations
* Make annotations go on their own line so addition of a new annotation doesn't break api compatability
* Remove package names from annotations to make the file more human readable
* Moar tests