### PR TITLE
Simplify Gradle wrapper configuration.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ artifactory {
     }
 }
 
-task wrapper(type: Wrapper) {
+wrapper {
     gradleVersion = "4.4.1"
     distributionType = Wrapper.DistributionType.ALL
 }


### PR DESCRIPTION
Configure Gradle's wrapper via its extension, as we're supposed to.