### PR TITLE
Add JaCoCo support to the API Scanner.

### DIFF
--- a/api-scanner/build.gradle
+++ b/api-scanner/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: 'jacoco'
 apply plugin: 'java-gradle-plugin'
 apply plugin: 'net.corda.plugins.publish-utils'
 apply plugin: 'com.jfrog.artifactory'
@@ -20,6 +21,10 @@ gradlePlugin {
     }
 }
 
+configurations {
+    jacocoRuntime
+}
+
 dependencies {
     compile "io.github.lukehutch:fast-classpath-scanner:2.7.0"
     testCompile project(':api-scanner:annotations')
@@ -30,11 +35,16 @@ dependencies {
     // on the Kotlin classes in the test/resources directory.
     testCompile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     testCompile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    jacocoRuntime "org.jacoco:org.jacoco.agent:${jacoco.toolVersion}:runtime"
 }
 
 processTestResources {
     filesMatching('**/kotlin-*/build.gradle') {
         expand(['kotlin_version': kotlin_version])
+    }
+    filesMatching('gradle.properties') {
+        expand(['jacocoAgent': configurations.jacocoRuntime.asPath,
+                'buildDir': buildDir])
     }
 }
 

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedClassTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedClassTest.java
@@ -1,50 +1,26 @@
 package net.corda.plugins;
 
-import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.BuildTask;
-import org.gradle.testkit.runner.GradleRunner;
-import static org.gradle.testkit.runner.TaskOutcome.*;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 
-import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.Assert.*;
 
 public class AnnotatedClassTest {
-    @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final GradleProject testProject = new GradleProject(testProjectDir, "annotated-class");
 
-    @Before
-    public void setup() throws IOException {
-        File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("annotated-class/build.gradle", buildFile);
-    }
+    @Rule
+    public TestRule rules = RuleChain.outerRule(testProjectDir).around(testProject);
 
     @Test
     public void testAnnotatedClass() throws IOException {
-        BuildResult result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArgsForTasks("scanApi"))
-            .withPluginClasspath()
-            .build();
-        String output = result.getOutput();
-        System.out.println(output);
-
-        BuildTask scanApi = result.task(":scanApi");
-        assertNotNull(scanApi);
-        assertEquals(SUCCESS, scanApi.getOutcome());
-
-        Path api = pathOf(testProjectDir, "build", "api", "annotated-class.txt");
-        assertThat(api).isRegularFile();
-        assertThat(Files.readAllLines(api)).containsOnlyOnce(
+        assertThat(Files.readAllLines(testProject.getApi())).containsOnlyOnce(
             "@net.corda.annotation.AlsoInherited @net.corda.annotation.IsInherited @net.corda.annotation.NotInherited public class net.corda.example.HasInheritedAnnotation extends java.lang.Object",
             "@net.corda.annotation.AlsoInherited @net.corda.annotation.IsInherited public class net.corda.example.InheritingAnnotations extends net.corda.example.HasInheritedAnnotation"
         );

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedFieldTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedFieldTest.java
@@ -1,50 +1,26 @@
 package net.corda.plugins;
 
-import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.BuildTask;
-import org.gradle.testkit.runner.GradleRunner;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 
-import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.gradle.testkit.runner.TaskOutcome.*;
-import static org.junit.Assert.*;
 
 public class AnnotatedFieldTest {
-    @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final GradleProject testProject = new GradleProject(testProjectDir, "annotated-field");
 
-    @Before
-    public void setup() throws IOException {
-        File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("annotated-field/build.gradle", buildFile);
-    }
+    @Rule
+    public TestRule rules = RuleChain.outerRule(testProjectDir).around(testProject);
 
     @Test
     public void testAnnotatedField() throws IOException {
-        BuildResult result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArgsForTasks("scanApi"))
-            .withPluginClasspath()
-            .build();
-        String output = result.getOutput();
-        System.out.println(output);
-
-        BuildTask scanApi = result.task(":scanApi");
-        assertNotNull(scanApi);
-        assertEquals(SUCCESS, scanApi.getOutcome());
-
-        Path api = pathOf(testProjectDir, "build", "api", "annotated-field.txt");
-        assertThat(api).isRegularFile();
-        assertThat(Files.readAllLines(api)).containsOnlyOnce(
+        assertThat(Files.readAllLines(testProject.getApi())).containsOnlyOnce(
             "public class net.corda.example.HasAnnotatedField extends java.lang.Object",
             "  @net.corda.example.A @net.corda.example.B @net.corda.example.C public static final String ANNOTATED_FIELD = \"<string-value>\""
         );

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedInterfaceTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedInterfaceTest.java
@@ -1,50 +1,26 @@
 package net.corda.plugins;
 
-import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.BuildTask;
-import org.gradle.testkit.runner.GradleRunner;
-import static org.gradle.testkit.runner.TaskOutcome.*;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 
-import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.Assert.*;
 
 public class AnnotatedInterfaceTest {
-    @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final GradleProject testProject = new GradleProject(testProjectDir, "annotated-interface");
 
-    @Before
-    public void setup() throws IOException {
-        File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("annotated-interface/build.gradle", buildFile);
-    }
+    @Rule
+    public TestRule rules = RuleChain.outerRule(testProjectDir).around(testProject);
 
     @Test
     public void testAnnotatedInterface() throws IOException {
-        BuildResult result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArgsForTasks("scanApi"))
-            .withPluginClasspath()
-            .build();
-        String output = result.getOutput();
-        System.out.println(output);
-
-        BuildTask scanApi = result.task(":scanApi");
-        assertNotNull(scanApi);
-        assertEquals(SUCCESS, scanApi.getOutcome());
-
-        Path api = pathOf(testProjectDir, "build", "api", "annotated-interface.txt");
-        assertThat(api).isRegularFile();
-        assertThat(Files.readAllLines(api)).containsOnlyOnce(
+        assertThat(Files.readAllLines(testProject.getApi())).containsOnlyOnce(
             "@net.corda.annotation.AlsoInherited @net.corda.annotation.IsInherited @net.corda.annotation.NotInherited public interface net.corda.example.HasInheritedAnnotation",
             "@net.corda.annotation.AlsoInherited @net.corda.annotation.IsInherited public interface net.corda.example.InheritingAnnotations extends net.corda.example.HasInheritedAnnotation"
         );

--- a/api-scanner/src/test/java/net/corda/plugins/AnnotatedMethodTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/AnnotatedMethodTest.java
@@ -1,50 +1,26 @@
 package net.corda.plugins;
 
-import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.BuildTask;
-import org.gradle.testkit.runner.GradleRunner;
-import static org.gradle.testkit.runner.TaskOutcome.*;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 
-import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.Assert.*;
 
 public class AnnotatedMethodTest {
-    @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final GradleProject testProject = new GradleProject(testProjectDir, "annotated-method");
 
-    @Before
-    public void setup() throws IOException {
-        File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("annotated-method/build.gradle", buildFile);
-    }
+    @Rule
+    public TestRule rules = RuleChain.outerRule(testProjectDir).around(testProject);
 
     @Test
     public void testAnnotatedMethod() throws IOException {
-        BuildResult result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArgsForTasks("scanApi"))
-            .withPluginClasspath()
-            .build();
-        String output = result.getOutput();
-        System.out.println(output);
-
-        BuildTask scanApi = result.task(":scanApi");
-        assertNotNull(scanApi);
-        assertEquals(SUCCESS, scanApi.getOutcome());
-
-        Path api = pathOf(testProjectDir, "build", "api", "annotated-method.txt");
-        assertThat(api).isRegularFile();
-        assertThat(Files.readAllLines(api)).containsOnlyOnce(
+        assertThat(Files.readAllLines(testProject.getApi())).containsOnlyOnce(
             "public class net.corda.example.HasAnnotatedMethod extends java.lang.Object",
             "  @net.corda.example.A @net.corda.example.B @net.corda.example.C public void hasAnnotation()"
         );

--- a/api-scanner/src/test/java/net/corda/plugins/BasicAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/BasicAnnotationTest.java
@@ -1,50 +1,26 @@
 package net.corda.plugins;
 
-import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.BuildTask;
-import org.gradle.testkit.runner.GradleRunner;
-import static org.gradle.testkit.runner.TaskOutcome.*;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 
-import static net.corda.plugins.CopyUtils.*;
-import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class BasicAnnotationTest {
-    @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final GradleProject testProject = new GradleProject(testProjectDir, "basic-annotation");
 
-    @Before
-    public void setup() throws IOException {
-        File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("basic-annotation/build.gradle", buildFile);
-    }
+    @Rule
+    public TestRule rules = RuleChain.outerRule(testProjectDir).around(testProject);
 
     @Test
     public void testBasicAnnotation() throws IOException {
-        BuildResult result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArgsForTasks("scanApi"))
-            .withPluginClasspath()
-            .build();
-        String output = result.getOutput();
-        System.out.println(output);
-
-        BuildTask scanApi = result.task(":scanApi");
-        assertNotNull(scanApi);
-        assertEquals(SUCCESS, scanApi.getOutcome());
-
-        Path api = pathOf(testProjectDir, "build", "api", "basic-annotation.txt");
-        assertThat(api).isRegularFile();
         assertEquals(
             "public @interface net.corda.example.BasicAnnotation\n" +
-            "##", CopyUtils.toString(api));
+            "##", CopyUtils.toString(testProject.getApi()));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/BasicClassTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/BasicClassTest.java
@@ -1,52 +1,28 @@
 package net.corda.plugins;
 
-import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.BuildTask;
-import org.gradle.testkit.runner.GradleRunner;
-import static org.gradle.testkit.runner.TaskOutcome.*;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 
-import static net.corda.plugins.CopyUtils.*;
-import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class BasicClassTest {
-    @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final GradleProject testProject = new GradleProject(testProjectDir, "basic-class");
 
-    @Before
-    public void setup() throws IOException {
-        File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("basic-class/build.gradle", buildFile);
-    }
+    @Rule
+    public TestRule rules = RuleChain.outerRule(testProjectDir).around(testProject);
 
     @Test
     public void testBasicClass() throws IOException {
-        BuildResult result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArgsForTasks("scanApi"))
-            .withPluginClasspath()
-            .build();
-        String output = result.getOutput();
-        System.out.println(output);
-
-        BuildTask scanApi = result.task(":scanApi");
-        assertNotNull(scanApi);
-        assertEquals(SUCCESS, scanApi.getOutcome());
-
-        Path api = pathOf(testProjectDir, "build", "api", "basic-class.txt");
-        assertThat(api).isRegularFile();
         assertEquals(
             "public class net.corda.example.BasicClass extends java.lang.Object\n" +
             "  public <init>(String)\n" +
             "  public String getName()\n" +
-            "##", CopyUtils.toString(api));
+            "##", CopyUtils.toString(testProject.getApi()));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/BasicInterfaceTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/BasicInterfaceTest.java
@@ -1,51 +1,27 @@
 package net.corda.plugins;
 
-import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.BuildTask;
-import org.gradle.testkit.runner.GradleRunner;
-import static org.gradle.testkit.runner.TaskOutcome.*;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 
-import static net.corda.plugins.CopyUtils.*;
-import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class BasicInterfaceTest {
-    @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final GradleProject testProject = new GradleProject(testProjectDir, "basic-interface");
 
-    @Before
-    public void setup() throws IOException {
-        File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("basic-interface/build.gradle", buildFile);
-    }
+    @Rule
+    public TestRule rules = RuleChain.outerRule(testProjectDir).around(testProject);
 
     @Test
     public void testBasicInterface() throws IOException {
-        BuildResult result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArgsForTasks("scanApi"))
-            .withPluginClasspath()
-            .build();
-        String output = result.getOutput();
-        System.out.println(output);
-
-        BuildTask scanApi = result.task(":scanApi");
-        assertNotNull(scanApi);
-        assertEquals(SUCCESS, scanApi.getOutcome());
-
-        Path api = pathOf(testProjectDir, "build", "api", "basic-interface.txt");
-        assertThat(api).isRegularFile();
         assertEquals(
             "public interface net.corda.example.BasicInterface\n" +
             "  public abstract java.math.BigInteger getBigNumber()\n" +
-            "##", CopyUtils.toString(api));
+            "##", CopyUtils.toString(testProject.getApi()));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/ClassWithInternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/ClassWithInternalAnnotationTest.java
@@ -1,52 +1,28 @@
 package net.corda.plugins;
 
-import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.BuildTask;
-import org.gradle.testkit.runner.GradleRunner;
-import static org.gradle.testkit.runner.TaskOutcome.*;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 
-import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class ClassWithInternalAnnotationTest {
-    @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final GradleProject testProject = new GradleProject(testProjectDir, "class-internal-annotation");
 
-    @Before
-    public void setup() throws IOException {
-        File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("class-internal-annotation/build.gradle", buildFile);
-    }
+    @Rule
+    public TestRule rules = RuleChain.outerRule(testProjectDir).around(testProject);
 
     @Test
     public void testClassWithInternalAnnotation() throws IOException {
-        BuildResult result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArgsForTasks("scanApi"))
-            .withPluginClasspath()
-            .build();
-        String output = result.getOutput();
-        System.out.println(output);
-
-        BuildTask scanApi = result.task(":scanApi");
-        assertNotNull(scanApi);
-        assertEquals(SUCCESS, scanApi.getOutcome());
-
-        assertThat(output).contains("net.corda.example.InvisibleAnnotation");
-
-        Path api = pathOf(testProjectDir, "build", "api", "class-internal-annotation.txt");
-        assertThat(api).isRegularFile();
+        assertThat(testProject.getOutput()).contains("net.corda.example.InvisibleAnnotation");
         assertEquals("public class net.corda.example.AnnotatedClass extends java.lang.Object\n" +
             "  public <init>()\n" +
-            "##", CopyUtils.toString(api));
+            "##", CopyUtils.toString(testProject.getApi()));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/CopyUtils.java
+++ b/api-scanner/src/test/java/net/corda/plugins/CopyUtils.java
@@ -13,13 +13,17 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 public final class CopyUtils {
     private static final String testGradleUserHome = System.getProperty("test.gradle.user.home", "");
 
     private CopyUtils() {
+    }
+
+    public static long installResource(TemporaryFolder folder, String resourceName) throws IOException {
+        File buildFile = folder.newFile(resourceName.substring(1 + resourceName.lastIndexOf('/')));
+        return copyResourceTo(resourceName, buildFile);
     }
 
     public static long copyResourceTo(String resourceName, Path target) throws IOException {
@@ -33,7 +37,8 @@ public final class CopyUtils {
     }
 
     public static String toString(Path file) throws IOException {
-        return Files.readAllLines(file, UTF_8).stream()
+        // This uses UTF-8 by default.
+        return Files.readAllLines(file).stream()
                 .collect(Collectors.joining("\n"));
     }
 

--- a/api-scanner/src/test/java/net/corda/plugins/ExtendedClassTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/ExtendedClassTest.java
@@ -1,51 +1,27 @@
 package net.corda.plugins;
 
-import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.BuildTask;
-import org.gradle.testkit.runner.GradleRunner;
-import static org.gradle.testkit.runner.TaskOutcome.*;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 
-import static net.corda.plugins.CopyUtils.*;
-import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class ExtendedClassTest {
-    @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final GradleProject testProject = new GradleProject(testProjectDir, "extended-class");
 
-    @Before
-    public void setup() throws IOException {
-        File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("extended-class/build.gradle", buildFile);
-    }
+    @Rule
+    public TestRule rules = RuleChain.outerRule(testProjectDir).around(testProject);
 
     @Test
     public void testExtendedClass() throws IOException {
-        BuildResult result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArgsForTasks("scanApi"))
-            .withPluginClasspath()
-            .build();
-        String output = result.getOutput();
-        System.out.println(output);
-
-        BuildTask scanApi = result.task(":scanApi");
-        assertNotNull(scanApi);
-        assertEquals(SUCCESS, scanApi.getOutcome());
-
-        Path api = pathOf(testProjectDir, "build", "api", "extended-class.txt");
-        assertThat(api).isRegularFile();
         assertEquals(
             "public class net.corda.example.ExtendedClass extends java.io.FilterInputStream\n" +
             "  public <init>(java.io.InputStream)\n" +
-            "##", CopyUtils.toString(api));
+            "##", CopyUtils.toString(testProject.getApi()));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/ExtendedInterfaceTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/ExtendedInterfaceTest.java
@@ -1,52 +1,28 @@
 package net.corda.plugins;
 
-import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.BuildTask;
-import org.gradle.testkit.runner.GradleRunner;
-import static org.gradle.testkit.runner.TaskOutcome.*;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 
-import static net.corda.plugins.CopyUtils.*;
-import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class ExtendedInterfaceTest {
-    @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final GradleProject testProject = new GradleProject(testProjectDir, "extended-interface");
 
-    @Before
-    public void setup() throws IOException {
-        File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("extended-interface/build.gradle", buildFile);
-    }
+    @Rule
+    public TestRule rules = RuleChain.outerRule(testProjectDir).around(testProject);
 
     @Test
     public void testExtendedInterface() throws IOException {
-        BuildResult result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArgsForTasks("scanApi"))
-            .withPluginClasspath()
-            .build();
-        String output = result.getOutput();
-        System.out.println(output);
-
-        BuildTask scanApi = result.task(":scanApi");
-        assertNotNull(scanApi);
-        assertEquals(SUCCESS, scanApi.getOutcome());
-
-        Path api = pathOf(testProjectDir, "build", "api", "extended-interface.txt");
-        assertThat(api).isRegularFile();
         assertEquals(
             "public interface net.corda.example.ExtendedInterface extends java.util.concurrent.Future\n" +
             "  public abstract String getName()\n" +
             "  public abstract void setName(String)\n" +
-            "##", CopyUtils.toString(api));
+            "##", CopyUtils.toString(testProject.getApi()));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/FieldWithInternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/FieldWithInternalAnnotationTest.java
@@ -1,55 +1,31 @@
 package net.corda.plugins;
 
-import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.BuildTask;
-import org.gradle.testkit.runner.GradleRunner;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 
-import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.gradle.testkit.runner.TaskOutcome.*;
 import static org.junit.Assert.*;
 
 public class FieldWithInternalAnnotationTest {
-    @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final GradleProject testProject = new GradleProject(testProjectDir, "field-internal-annotation");
 
-    @Before
-    public void setup() throws IOException {
-        File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("field-internal-annotation/build.gradle", buildFile);
-    }
+    @Rule
+    public TestRule rules = RuleChain.outerRule(testProjectDir).around(testProject);
 
     @Test
     public void testFieldWithInternalAnnotations() throws IOException {
-        BuildResult result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArgsForTasks("scanApi"))
-            .withPluginClasspath()
-            .build();
-        String output = result.getOutput();
-        System.out.println(output);
-
-        BuildTask scanApi = result.task(":scanApi");
-        assertNotNull(scanApi);
-        assertEquals(SUCCESS, scanApi.getOutcome());
-
-        assertThat(output)
+        assertThat(testProject.getOutput())
             .contains("net.corda.example.field.InvisibleAnnotation")
             .contains("net.corda.example.field.LocalInvisibleAnnotation");
-
-        Path api = pathOf(testProjectDir, "build", "api", "field-internal-annotation.txt");
-        assertThat(api).isRegularFile();
         assertEquals("public class net.corda.example.field.HasVisibleField extends java.lang.Object\n" +
             "  public <init>()\n" +
             "  public String hasInvisibleAnnotations\n" +
-            "##", CopyUtils.toString(api));
+            "##", CopyUtils.toString(testProject.getApi()));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/GradleProject.java
+++ b/api-scanner/src/test/java/net/corda/plugins/GradleProject.java
@@ -1,0 +1,67 @@
+package net.corda.plugins;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.nio.file.Path;
+
+import static net.corda.plugins.CopyUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.gradle.testkit.runner.TaskOutcome.*;
+import static org.junit.Assert.*;
+
+/**
+ * JUnit rule to execute the scanApi Gradle task. This rule should be chained with TemporaryFolder.
+ */
+public class GradleProject implements TestRule {
+    private final TemporaryFolder projectDir;
+    private final String name;
+
+    private String output;
+    private Path api;
+
+    public GradleProject(TemporaryFolder projectDir, String name) {
+        this.projectDir = projectDir;
+        this.name = name;
+    }
+
+    public Path getApi() {
+        return api;
+    }
+
+    public String getOutput() {
+        return output;
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                installResource(projectDir, name + "/build.gradle");
+                installResource(projectDir, "gradle.properties");
+
+                BuildResult result = GradleRunner.create()
+                    .withProjectDir(projectDir.getRoot())
+                    .withArguments(getGradleArgsForTasks("scanApi"))
+                    .withPluginClasspath()
+                    .build();
+                output = result.getOutput();
+                System.out.println(output);
+
+                BuildTask scanApi = result.task(":scanApi");
+                assertNotNull(scanApi);
+                assertEquals(SUCCESS, scanApi.getOutcome());
+
+                api = pathOf(projectDir, "build", "api", name + ".txt");
+                assertThat(api).isRegularFile();
+                base.evaluate();
+            }
+        };
+    }
+}

--- a/api-scanner/src/test/java/net/corda/plugins/InternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/InternalAnnotationTest.java
@@ -1,52 +1,28 @@
 package net.corda.plugins;
 
-import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.BuildTask;
-import org.gradle.testkit.runner.GradleRunner;
-import static org.gradle.testkit.runner.TaskOutcome.*;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 
-import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class InternalAnnotationTest {
-    @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final GradleProject testProject = new GradleProject(testProjectDir, "internal-annotation");
 
-    @Before
-    public void setup() throws IOException {
-        File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("internal-annotation/build.gradle", buildFile);
-    }
+    @Rule
+    public TestRule rules = RuleChain.outerRule(testProjectDir).around(testProject);
 
     @Test
     public void testInternalAnnotations() throws IOException {
-        BuildResult result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArgsForTasks("scanApi"))
-            .withPluginClasspath()
-            .build();
-        String output = result.getOutput();
-        System.out.println(output);
-
-        assertThat(output)
+        assertThat(testProject.getOutput())
             .contains("net.corda.core.CordaInternal")
             .contains("net.corda.example.CordaInternal");
-
-        BuildTask scanApi = result.task(":scanApi");
-        assertNotNull(scanApi);
-        assertEquals(SUCCESS, scanApi.getOutcome());
-
-        Path api = pathOf(testProjectDir, "build", "api", "internal-annotation.txt");
-        assertThat(api).isRegularFile();
-        assertEquals("", CopyUtils.toString(api));
+        assertEquals("", CopyUtils.toString(testProject.getApi()));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/InternalFieldTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/InternalFieldTest.java
@@ -1,51 +1,27 @@
 package net.corda.plugins;
 
-import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.BuildTask;
-import org.gradle.testkit.runner.GradleRunner;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 
-import static net.corda.plugins.CopyUtils.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.gradle.testkit.runner.TaskOutcome.*;
 import static org.junit.Assert.*;
 
 public class InternalFieldTest {
-    @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final GradleProject testProject = new GradleProject(testProjectDir, "internal-field");
 
-    @Before
-    public void setup() throws IOException {
-        File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("internal-field/build.gradle", buildFile);
-    }
+    @Rule
+    public TestRule rules = RuleChain.outerRule(testProjectDir).around(testProject);
 
     @Test
     public void testInternalField() throws IOException {
-        BuildResult result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArgsForTasks("scanApi"))
-            .withPluginClasspath()
-            .build();
-        String output = result.getOutput();
-        System.out.println(output);
-
-        BuildTask scanApi = result.task(":scanApi");
-        assertNotNull(scanApi);
-        assertEquals(SUCCESS, scanApi.getOutcome());
-
-        Path api = pathOf(testProjectDir, "build", "api", "internal-field.txt");
-        assertThat(api).isRegularFile();
         assertEquals(
             "public class net.corda.example.WithInternalField extends java.lang.Object\n" +
             "  public <init>()\n" +
-            "##", CopyUtils.toString(api));
+            "##", CopyUtils.toString(testProject.getApi()));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/InternalMethodTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/InternalMethodTest.java
@@ -1,50 +1,27 @@
 package net.corda.plugins;
 
-import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.BuildTask;
-import org.gradle.testkit.runner.GradleRunner;
-import static org.gradle.testkit.runner.TaskOutcome.*;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
 import java.io.*;
-import java.nio.file.Path;
 
-import static net.corda.plugins.CopyUtils.*;
-import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class InternalMethodTest {
-    @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final GradleProject testProject = new GradleProject(testProjectDir, "internal-method");
 
-    @Before
-    public void setup() throws IOException {
-        File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("internal-method/build.gradle", buildFile);
-    }
+    @Rule
+    public TestRule rules = RuleChain.outerRule(testProjectDir).around(testProject);
 
     @Test
     public void testInternalMethod() throws IOException {
-        BuildResult result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArgsForTasks("scanApi"))
-            .withPluginClasspath()
-            .build();
-        String output = result.getOutput();
-        System.out.println(output);
-
-        BuildTask scanApi = result.task(":scanApi");
-        assertNotNull(scanApi);
-        assertEquals(SUCCESS, scanApi.getOutcome());
-
-        Path api = pathOf(testProjectDir, "build", "api", "internal-method.txt");
-        assertThat(api).isRegularFile();
         assertEquals(
             "public class net.corda.example.WithInternalMethod extends java.lang.Object\n" +
             "  public <init>()\n" +
-            "##", CopyUtils.toString(api));
+            "##", CopyUtils.toString(testProject.getApi()));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/InternalPackageTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/InternalPackageTest.java
@@ -1,53 +1,29 @@
 package net.corda.plugins;
 
-import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.BuildTask;
-import org.gradle.testkit.runner.GradleRunner;
-import static org.gradle.testkit.runner.TaskOutcome.*;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 
-import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class InternalPackageTest {
-    @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final GradleProject testProject = new GradleProject(testProjectDir, "internal-package");
 
-    @Before
-    public void setup() throws IOException {
-        File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("internal-package/build.gradle", buildFile);
-    }
+    @Rule
+    public TestRule rules = RuleChain.outerRule(testProjectDir).around(testProject);
 
     @Test
     public void testInternalPackageIsIgnored() throws IOException {
-        BuildResult result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArgsForTasks("scanApi"))
-            .withPluginClasspath()
-            .build();
-        String output = result.getOutput();
-        System.out.println(output);
-
-        BuildTask scanApi = result.task(":scanApi");
-        assertNotNull(scanApi);
-        assertEquals(SUCCESS, scanApi.getOutcome());
-
-        assertThat(output).contains("net.corda.internal.InvisibleClass");
-
-        Path api = pathOf(testProjectDir, "build", "api", "internal-package.txt");
-        assertThat(api).isRegularFile();
+        assertThat(testProject.getOutput()).contains("net.corda.internal.InvisibleClass");
         assertEquals(
     "public class net.corda.VisibleClass extends java.lang.Object\n" +
             "  public <init>()\n" +
-            "##", CopyUtils.toString(api));
+            "##", CopyUtils.toString(testProject.getApi()));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinAnnotationsTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinAnnotationsTest.java
@@ -1,48 +1,24 @@
 package net.corda.plugins;
 
-import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.BuildTask;
-import org.gradle.testkit.runner.GradleRunner;
-import static org.gradle.testkit.runner.TaskOutcome.*;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 
-import static net.corda.plugins.CopyUtils.*;
-import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class KotlinAnnotationsTest {
-    @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final GradleProject testProject = new GradleProject(testProjectDir, "kotlin-annotations");
 
-    @Before
-    public void setup() throws IOException {
-        File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("kotlin-annotations/build.gradle", buildFile);
-    }
+    @Rule
+    public TestRule rules = RuleChain.outerRule(testProjectDir).around(testProject);
 
     @Test
     public void testKotlinAnnotations() throws IOException {
-        BuildResult result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArgsForTasks("scanApi"))
-            .withPluginClasspath()
-            .build();
-        String output = result.getOutput();
-        System.out.println(output);
-
-        BuildTask scanApi = result.task(":scanApi");
-        assertNotNull(scanApi);
-        assertEquals(SUCCESS, scanApi.getOutcome());
-
-        Path api = pathOf(testProjectDir, "build", "api", "kotlin-annotations.txt");
-        assertThat(api).isRegularFile();
         assertEquals(
             "public final class net.corda.example.HasJvmField extends java.lang.Object\n" +
             "  public <init>()\n" +
@@ -64,6 +40,6 @@ public class KotlinAnnotationsTest {
             "  @org.jetbrains.annotations.NotNull public final String getNotNullable()\n" +
             "  @org.jetbrains.annotations.Nullable public final String getNullable()\n" +
             "  public final int getNumber()\n" +
-            "##", CopyUtils.toString(api));
+            "##", CopyUtils.toString(testProject.getApi()));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinInternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinInternalAnnotationTest.java
@@ -1,53 +1,29 @@
 package net.corda.plugins;
 
-import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.BuildTask;
-import org.gradle.testkit.runner.GradleRunner;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 
-import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
 import static org.junit.Assert.*;
 
 public class KotlinInternalAnnotationTest {
-    @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final GradleProject testProject = new GradleProject(testProjectDir, "kotlin-internal-annotation");
 
-    @Before
-    public void setup() throws IOException {
-        File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("kotlin-internal-annotation/build.gradle", buildFile);
-    }
+    @Rule
+    public TestRule rules = RuleChain.outerRule(testProjectDir).around(testProject);
 
     @Test
     public void testKotlinInternalAnnotation() throws IOException {
-        BuildResult result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArgsForTasks("scanApi"))
-            .withPluginClasspath()
-            .build();
-        String output = result.getOutput();
-        System.out.println(output);
-
-        assertThat(output).contains("net.corda.example.kotlin.CordaInternal");
-
-        BuildTask scanApi = result.task(":scanApi");
-        assertNotNull(scanApi);
-        assertEquals(SUCCESS, scanApi.getOutcome());
-
-        Path api = pathOf(testProjectDir, "build", "api", "kotlin-internal-annotation.txt");
-        assertThat(api).isRegularFile();
+        assertThat(testProject.getOutput()).contains("net.corda.example.kotlin.CordaInternal");
         assertEquals(
             "public final class net.corda.example.kotlin.AnnotatedClass extends java.lang.Object\n" +
             "  public <init>()\n" +
-            "##", CopyUtils.toString(api));
+            "##", CopyUtils.toString(testProject.getApi()));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinLambdasTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinLambdasTest.java
@@ -1,53 +1,29 @@
 package net.corda.plugins;
 
-import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.BuildTask;
-import org.gradle.testkit.runner.GradleRunner;
-import static org.gradle.testkit.runner.TaskOutcome.*;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 
-import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class KotlinLambdasTest {
-    @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final GradleProject testProject = new GradleProject(testProjectDir, "kotlin-lambdas");
 
-    @Before
-    public void setup() throws IOException {
-        File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("kotlin-lambdas/build.gradle", buildFile);
-    }
+    @Rule
+    public TestRule rules = RuleChain.outerRule(testProjectDir).around(testProject);
 
     @Test
     public void testKotlinLambdas() throws IOException {
-        BuildResult result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArgsForTasks("scanApi"))
-            .withPluginClasspath()
-            .build();
-        String output = result.getOutput();
-        System.out.println(output);
-
-        BuildTask scanApi = result.task(":scanApi");
-        assertNotNull(scanApi);
-        assertEquals(SUCCESS, scanApi.getOutcome());
-
-        assertThat(output).contains("net.corda.example.LambdaExpressions$testing$$inlined$schedule$1");
-
-        Path api = pathOf(testProjectDir, "build", "api", "kotlin-lambdas.txt");
-        assertThat(api).isRegularFile();
+        assertThat(testProject.getOutput()).contains("net.corda.example.LambdaExpressions$testing$$inlined$schedule$1");
         assertEquals("public final class net.corda.example.LambdaExpressions extends java.lang.Object\n" +
             "  public <init>()\n" +
             "  public final void testing(kotlin.Unit)\n" +
-            "##", CopyUtils.toString(api));
+            "##", CopyUtils.toString(testProject.getApi()));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/KotlinVarargMethodTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/KotlinVarargMethodTest.java
@@ -4,7 +4,9 @@ import org.gradle.testkit.runner.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,33 +18,16 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
 import static org.junit.Assert.*;
 
 public class KotlinVarargMethodTest {
-    @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final GradleProject testProject = new GradleProject(testProjectDir, "kotlin-vararg-method");
 
-    @Before
-    public void setup() throws IOException {
-        File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("kotlin-vararg-method/build.gradle", buildFile);
-    }
+    @Rule
+    public TestRule rules = RuleChain.outerRule(testProjectDir).around(testProject);
 
     @Test
     public void testKotlinVarargMethod() throws IOException {
-        BuildResult result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArgsForTasks("scanApi"))
-            .withPluginClasspath()
-            .build();
-        String output = result.getOutput();
-        System.out.println(output);
-
-        BuildTask scanApi = result.task(":scanApi");
-        assertNotNull(scanApi);
-        assertEquals(SUCCESS, scanApi.getOutcome());
-
-        Path api = pathOf(testProjectDir, "build", "api", "kotlin-vararg-method.txt");
-        assertThat(api).isRegularFile();
         assertEquals("public interface net.corda.example.KotlinVarargMethod\n" +
             "  public abstract void action(Object...)\n" +
-            "##", CopyUtils.toString(api));
+            "##", CopyUtils.toString(testProject.getApi()));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/MethodWithInternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/MethodWithInternalAnnotationTest.java
@@ -1,55 +1,32 @@
 package net.corda.plugins;
 
-import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.BuildTask;
-import org.gradle.testkit.runner.GradleRunner;
-import static org.gradle.testkit.runner.TaskOutcome.*;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 
-import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
 
 public class MethodWithInternalAnnotationTest {
-    @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final GradleProject testProject = new GradleProject(testProjectDir, "method-internal-annotation");
 
-    @Before
-    public void setup() throws IOException {
-        File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("method-internal-annotation/build.gradle", buildFile);
-    }
+    @Rule
+    public TestRule rules = RuleChain.outerRule(testProjectDir).around(testProject);
 
     @Test
     public void testMethodWithInternalAnnotations() throws IOException {
-        BuildResult result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArgsForTasks("scanApi"))
-            .withPluginClasspath()
-            .build();
-        String output = result.getOutput();
-        System.out.println(output);
-
-        BuildTask scanApi = result.task(":scanApi");
-        assertNotNull(scanApi);
-        assertEquals(SUCCESS, scanApi.getOutcome());
-
-        assertThat(output)
+        assertThat(testProject.getOutput())
             .contains("net.corda.example.method.InvisibleAnnotation")
             .contains("net.corda.example.method.LocalInvisibleAnnotation");
 
-        Path api = pathOf(testProjectDir, "build", "api", "method-internal-annotation.txt");
-        assertThat(api).isRegularFile();
         assertEquals("public class net.corda.example.method.HasVisibleMethod extends java.lang.Object\n" +
             "  public <init>()\n" +
             "  public void hasInvisibleAnnotations()\n" +
-            "##", CopyUtils.toString(api));
+            "##", CopyUtils.toString(testProject.getApi()));
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/VarargMethodTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/VarargMethodTest.java
@@ -1,48 +1,26 @@
 package net.corda.plugins;
 
-import org.gradle.testkit.runner.*;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 
-import static net.corda.plugins.CopyUtils.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
 import static org.junit.Assert.*;
 
 public class VarargMethodTest {
-    @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private final GradleProject testProject = new GradleProject(testProjectDir, "vararg-method");
 
-    @Before
-    public void setup() throws IOException {
-        File buildFile = testProjectDir.newFile("build.gradle");
-        copyResourceTo("vararg-method/build.gradle", buildFile);
-    }
+    @Rule
+    public TestRule rules = RuleChain.outerRule(testProjectDir).around(testProject);
 
     @Test
     public void testVarargMethod() throws IOException {
-        BuildResult result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withArguments(getGradleArgsForTasks("scanApi"))
-            .withPluginClasspath()
-            .build();
-        String output = result.getOutput();
-        System.out.println(output);
-
-        BuildTask scanApi = result.task(":scanApi");
-        assertNotNull(scanApi);
-        assertEquals(SUCCESS, scanApi.getOutcome());
-
-        Path api = pathOf(testProjectDir, "build", "api", "vararg-method.txt");
-        assertThat(api).isRegularFile();
         assertEquals("public interface net.corda.example.VarargMethod\n" +
             "  public abstract void action(Object...)\n" +
-            "##", CopyUtils.toString(api));
+            "##", CopyUtils.toString(testProject.getApi()));
     }
 }

--- a/api-scanner/src/test/resources/gradle.properties
+++ b/api-scanner/src/test/resources/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-javaagent:$jacocoAgent=destfile="$buildDir/jacoco/test.exec",includes=net/corda/plugins/**


### PR DESCRIPTION
Apply the JaCoCo plugin to the API Scanner's unit tests. Also simplify these unit tests with a JUnit rule-chain.