### PR TITLE
ENT-1871 Rebrand R3Corda to Corda Enterprise 

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -1,4 +1,4 @@
-gradlePluginsVersion=4.0.21-SNAPSHOT
+gradlePluginsVersion=4.0.22
 kotlinVersion=1.2.41
 platformVersion=3
 guavaVersion=21.0

--- a/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
@@ -87,7 +87,7 @@ class CordappPlugin : Plugin<Project> {
         filteredDeps.forEach {
             // net.corda or com.r3.corda.enterprise may be a core dependency which shouldn't be included in this cordapp so give a warning
             val group = it.group ?: ""
-            if (group.startsWith("net.corda.") || group.startsWith("com.r3.corda.enterprise.")) {
+            if (group.startsWith("net.corda.") || group.startsWith("com.r3.corda.")) {
                 project.logger.warn("You appear to have included a Corda platform component ($it) using a 'compile' or 'runtime' dependency." +
                         "This can cause node stability problems. Please use 'corda' instead." +
                         "See http://docs.corda.net/cordapp-build-systems.html")

--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
@@ -38,7 +38,7 @@ class Cordformation : Plugin<Project> {
         fun verifyAndGetRuntimeJar(project: Project, jarName: String): File {
             val releaseVersion = project.rootProject.ext<String>("corda_release_version")
             val maybeJar = project.configuration("runtime").filter {
-                "$jarName-$releaseVersion.jar" in it.toString() || "$jarName-r3-$releaseVersion.jar" in it.toString()
+                "$jarName-$releaseVersion.jar" in it.toString() || "$jarName-enterprise-$releaseVersion.jar" in it.toString()
             }
             if (maybeJar.isEmpty) {
                 throw IllegalStateException("No $jarName JAR found. Have you deployed the Corda project to Maven? Looked for \"$jarName-$releaseVersion.jar\"")


### PR DESCRIPTION
Jar file has been renamed from
`corda-R3.<version>-<component>.jar`
to
`corda-enterprise.<version>-<component>.jar`  

Other minor fix to incorrect package exclusion path.