### PR TITLE
ENT-2035 Cordform copies files to drivers directory

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ### Version 4.0.24
 
+* `cordformation`,  The `node` entry has a new optional element `drivers`, which is a list of JAR files to be copied to the `./driver` subdirectory relative to node directory (ENT-2035).
+
 ### Version 4.0.23
 
 * `publish-utils`: CORDA-1576 Support publishing non-default JAR artifacts.

--- a/cordform-common/src/main/java/net/corda/cordform/CordformNode.java
+++ b/cordform-common/src/main/java/net/corda/cordform/CordformNode.java
@@ -61,6 +61,11 @@ public class CordformNode implements NodeDefinition {
 
     public Map<String, Object> extraConfig = null;
 
+    /**
+     * Copy files into the node relative directory './drivers'.
+     */
+    public List<String> drivers = null;
+
     protected Config config = ConfigFactory.empty();
 
     public Config getConfig() {

--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordform.kt
@@ -62,6 +62,7 @@ open class Cordform : Baseform() {
         nodes.forEach(Node::installConfig)
         installCordaJar()
         installRunScript()
+        nodes.forEach(Node::installDrivers)
         bootstrapNetwork()
         nodes.forEach(Node::build)
     }

--- a/cordformation/src/main/kotlin/net/corda/plugins/Dockerform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Dockerform.kt
@@ -45,6 +45,7 @@ open class Dockerform : Baseform() {
         initializeConfiguration()
         nodes.forEach(Node::installDockerConfig)
         installCordaJar()
+        nodes.forEach(Node::installDrivers)
         bootstrapNetwork()
         nodes.forEach(Node::buildDocker)
 

--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -318,6 +318,7 @@ open class Node @Inject constructor(private val project: Project) : CordformNode
             Files.write(configFile, config.toByteArray())
         }
     }
+
     /**
      * Installs the configuration file to the root directory and detokenises it.
      */

--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -184,6 +184,7 @@ open class Node @Inject constructor(private val project: Project) : CordformNode
             installWebserverJar()
         }
         installAgentJar()
+        installDrivers()
         installCordappConfigs()
         installConfig()
     }
@@ -268,11 +269,22 @@ open class Node @Inject constructor(private val project: Project) : CordformNode
             // TODO: revisit when classifier attribute is added. eg && (it.classifier = "agent")
         }.first()  // should always be the jolokia agent fat jar: eg. jolokia-jvm-1.3.7-agent.jar
         project.logger.info("Jolokia agent jar: $agentJar")
-        if (agentJar.isFile) {
+        copyToDriversDir(agentJar)
+    }
+
+    internal fun installDrivers() {
+        drivers?.let {
+            project.logger.info("Copy $it to './drivers' directory")
+            it.forEach { path ->  copyToDriversDir(File(path)) }
+        }
+    }
+
+    private fun copyToDriversDir(file: File) {
+        if (file.isFile) {
             val driversDir = File(nodeDir, "drivers")
             project.copy {
                 it.apply {
-                    from(agentJar)
+                    from(file)
                     into(driversDir)
                 }
             }
@@ -306,7 +318,6 @@ open class Node @Inject constructor(private val project: Project) : CordformNode
             Files.write(configFile, config.toByteArray())
         }
     }
-
     /**
      * Installs the configuration file to the root directory and detokenises it.
      */


### PR DESCRIPTION
Cordform Gradle task can now copy jar files to `./driver` subdirectory relative to node directory. 
The list of file can be specified by `drivers` list in `node` element.
Using `ext.drivers` and `drivers = ext.drivers`in node element the  list reused for all nodes or concatenated to have both specific and common values.

Example:
`task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
      ...
      node {
          ...
          name "O=Notary Service,L=Zurich,C=CH"
          drivers = ['/lib/jars/my_jar.jar']
          ...
      }
}`
The file `my_jar.jar` will be placed into `Notary Service/driver` subdirectory.