### PR TITLE
ENT-2059 Cordformation shouldn't add configFile property to node.conf

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ### Version 4.0.24
 
+* `cordformation`: ENT-2059 The optional `configFile` element of the `node` entry ìs no longer added to `node.conf` as it was never used by the node and it's used internally by `cordformation` only.
+
 ### Version 4.0.23
 
 * `publish-utils`: CORDA-1576 Support publishing non-default JAR artifacts.

--- a/cordform-common/src/main/java/net/corda/cordform/CordformNode.java
+++ b/cordform-common/src/main/java/net/corda/cordform/CordformNode.java
@@ -186,8 +186,14 @@ public class CordformNode implements NodeDefinition {
      * @param configFile The file path.
      */
     public void configFile(String configFile) {
-        setValue("configFile", configFile);
+        this.configFile = configFile;
     }
+
+    public String getConfigFile() {
+        return configFile;
+    }
+
+    private String configFile = null;
 
     private String getOptionalString(String path) {
         return config.hasPath(path) ? config.getString(path) : null;

--- a/cordform-common/src/main/java/net/corda/cordform/CordformNode.java
+++ b/cordform-common/src/main/java/net/corda/cordform/CordformNode.java
@@ -180,6 +180,8 @@ public class CordformNode implements NodeDefinition {
         config = settings.addTo("rpcSettings", config);
     }
 
+    private String configFile;
+
     /**
      * Set the path to a file with optional properties, which are appended to the generated node.conf file.
      *
@@ -192,8 +194,6 @@ public class CordformNode implements NodeDefinition {
     public String getConfigFile() {
         return configFile;
     }
-
-    private String configFile = null;
 
     private String getOptionalString(String path) {
         return config.hasPath(path) ? config.getString(path) : null;

--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -384,7 +384,7 @@ open class Node @Inject constructor(private val project: Project) : CordformNode
         val optionalConfig: File? = when {
             project.findProperty(configFileProperty) != null -> //provided by -PconfigFile command line property when running Gradle task
                 File(project.findProperty(configFileProperty) as String)
-            config.hasPath(configFileProperty) -> File(config.getString(configFileProperty))
+            configFile != null -> File(configFile)
             else -> null
         }
 


### PR DESCRIPTION
Cordform task adds `configFile` to the generated node.conf.
Gradle element `configFile` inside `node` is just an intermediate placeholder for the Gradle task, 
it was never used by the node as a property in node.conf.
A node strictly checks for allowed keys in node.conf and `configFile` is not allowed/accepted.

The change prevents 'leaking' `configFile` as node property.