### PR TITLE
[CORDA-1649]: Add default `quasar_version` and `quasar_group` to quasar-utils plugin, so it's not require to specify them manually.

### DIFF
--- a/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
@@ -10,8 +10,8 @@ import org.gradle.api.tasks.JavaExec
  */
 class QuasarPlugin implements Plugin<Project> {
 
-    private defaultGroup = "co.paralleluniverse"
-    private defaultVersion = "0.7.10"
+    static defaultGroup = "co.paralleluniverse"
+    static defaultVersion = "0.7.10"
 
     @Override
     void apply(Project project) {

--- a/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
@@ -9,14 +9,21 @@ import org.gradle.api.tasks.JavaExec
  * QuasarPlugin creates a "quasar" configuration and adds quasar as a dependency.
  */
 class QuasarPlugin implements Plugin<Project> {
+
+    private defaultGroup = "co.paralleluniverse"
+    private defaultVersion = "0.7.10"
+
     @Override
     void apply(Project project) {
         Utils.createRuntimeConfiguration("cordaRuntime", project)
 
         project.configurations.create("quasar")
+
+        def quasarGroup = project.rootProject.hasProperty("quasar_group") ? project.rootProject.ext.quasar_group : defaultGroup
+        def quasarVersion = project.rootProject.hasProperty("quasar_version") ? project.rootProject.ext.quasar_version : defaultVersion
 //        To add a local .jar dependency:
 //        project.dependencies.add("quasar", project.files("${project.rootProject.projectDir}/lib/quasar.jar"))
-        project.dependencies.add("quasar", "${project.rootProject.ext.quasar_group}:quasar-core:${project.rootProject.ext.quasar_version}:jdk8@jar")
+        project.dependencies.add("quasar", "${quasarGroup}:quasar-core:${quasarVersion}:jdk8@jar")
         project.dependencies.add("cordaRuntime", project.configurations.getByName("quasar"))
 
         project.tasks.withType(Test) {

--- a/quasar-utils/src/test/groovy/net/corda/plugins/QuasarPluginTest.groovy
+++ b/quasar-utils/src/test/groovy/net/corda/plugins/QuasarPluginTest.groovy
@@ -17,17 +17,10 @@ class QuasarPluginTest {
 
     @Test
     void checkIsRuntime() {
-        def quasarVersion = "0.7.9"
+        def quasarVersion = "0.7.10"
 
         def buildFile = testProjectDir.newFile("build.gradle")
         buildFile.text = """
-buildscript {
-    ext {
-        quasar_group = 'co.paralleluniverse'
-        quasar_version = '$quasarVersion'
-    }
-}
-
 plugins {
     id 'java'
     id 'net.corda.plugins.quasar-utils' apply false


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORDA-1649