### PR TITLE
CORDA-1807: Exclude all files of excluded Gradle dependencies from CorDapps.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,10 +4,9 @@
 
 ### Version 4.0.26
 
+* `cordapp`: Remove `cordaCompile` and `cordaRuntime` dependencies from the CorDapp's transitive dependencies.
 * `cordformation`: Use latest version of jolokia, when version not found in project settings.
 * `cordformation`: The `sshd` port entry in `node` produces an entry in `node.conf` that matches the config API.
-
-### Version 4.0.26
 
 ### Version 4.0.25
 

--- a/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
@@ -1,6 +1,8 @@
 package net.corda.plugins
 
 import org.gradle.api.*
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.Dependency
 import org.gradle.jvm.tasks.Jar
 import java.io.File
 
@@ -95,6 +97,10 @@ class CordappPlugin : Plugin<Project> {
                 project.logger.info("Including dependency in CorDapp JAR: $it")
             }
         }
-        return filteredDeps.map { runtimeConfiguration.files(it) }.flatten().toSet()
+        return filteredDeps.toUniqueFiles(runtimeConfiguration) - excludeDeps.toUniqueFiles(runtimeConfiguration)
+    }
+
+    private fun Iterable<Dependency>.toUniqueFiles(configuration: Configuration): Set<File> {
+        return map { configuration.files(it) }.flatten().toSet()
     }
 }


### PR DESCRIPTION
A Gradle dependency can consist of several files (i.e. transitive dependencies), and some of those files may also belong to other dependencies. Ensure that we exclude _all_ files belonging to the `cordapp`, `cordaCompile` and `cordaRuntime` configurations from the CorDapp fat jar.