### PR TITLE
Added gradle version check to the cordapp plugin

### DIFF
--- a/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
@@ -5,6 +5,9 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
 import org.gradle.jvm.tasks.Jar
 import java.io.File
+import java.io.FileInputStream
+import java.util.*
+import java.util.regex.Pattern
 
 /**
  * The Cordapp plugin will turn a project into a cordapp project which builds cordapp JARs with the correct format
@@ -24,6 +27,8 @@ class CordappPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         project.logger.info("Configuring ${project.name} as a cordapp")
 
+        verifyGradleVersion(project)
+
         Utils.createCompileConfiguration("cordapp", project)
         Utils.createCompileConfiguration("cordaCompile", project)
         Utils.createRuntimeConfiguration("cordaRuntime", project)
@@ -32,6 +37,34 @@ class CordappPlugin : Plugin<Project> {
         cordapp.setProject(project)
 
         configureCordappJar(project)
+    }
+
+    /**
+     * Verifies that the version of Gradle the project is built with matches gradle-wrapper config if one exists
+     */
+    private fun verifyGradleVersion(project: Project) {
+        val gradleWrapperConfig = File(project.rootProject.projectDir!!.absolutePath + "/gradle/wrapper/gradle-wrapper.properties")
+        if (gradleWrapperConfig.exists()) {
+            val props = Properties()
+            props.load(FileInputStream(gradleWrapperConfig))
+            val distributionUrl = props.getProperty("distributionUrl")
+            if (distributionUrl != null) {
+                val matcher = Pattern.compile(".*-(.*?)-[a-zA-Z]+.zip").matcher(distributionUrl)!!
+                if (matcher.matches() && matcher.groupCount() == 1) {
+                    val gradleWrapperVersion = matcher.group(1)!!
+                    val gradleProjectVersion = project.gradle.gradleVersion!!
+                    if (gradleWrapperVersion != gradleProjectVersion) {
+                        throw GradleException("Invalid Gradle version. Expected $gradleWrapperVersion but was $gradleProjectVersion. Please use ./gradlew to build the project. More information can be found here: https://docs.corda.net/cordapp-build-systems.html")
+                    }
+                } else {
+                    project.logger.warn("Couldn't determine Gradle version from the distributionUrl=$distributionUrl. Skipping Gradle version check.")
+                }
+            } else {
+                project.logger.warn("distributionUrl was not found in Gradle wrapper configuration. Skipping Gradle version check.")
+            }
+        } else {
+            project.logger.warn("Gradle wrapper configuration was not found in ${gradleWrapperConfig.path}. Skipping Gradle version check.")
+        }
     }
 
     /**

--- a/cordapp/src/main/kotlin/net/corda/plugins/Utils.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/Utils.kt
@@ -3,6 +3,7 @@ package net.corda.plugins
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.plugins.ExtraPropertiesExtension
+import kotlin.math.max
 
 /**
  * Mimics the "project.ext" functionality in groovy which provides a direct
@@ -31,6 +32,25 @@ class Utils {
                 project.configurations.single { it.name == "runtime" }.extendsFrom(configuration)
             }
         }
-    }
 
+        @JvmStatic
+        fun compareVersions(v1 : String, v2 : String) : Int {
+            fun parseVersionString(v : String) = v.split(".").flatMap { it.split("-") }.map {
+                try {
+                    Integer.valueOf(it)!!
+                } catch (e : NumberFormatException) {
+                    -1
+                }
+            }
+            val parsed1 = parseVersionString(v1)
+            val parsed2 = parseVersionString(v2)
+            for (i in 0 until max(parsed1.count(), parsed2.count())) {
+                val compareResult = parsed1.getOrElse(i) { 0 }.compareTo(parsed2.getOrElse(i) { 0 })
+                if (compareResult != 0) {
+                    return compareResult
+                }
+            }
+            return 0
+        }
+    }
 }

--- a/cordapp/src/test/kotlin/net/corda/plugins/VersionComparatorTest.kt
+++ b/cordapp/src/test/kotlin/net/corda/plugins/VersionComparatorTest.kt
@@ -1,0 +1,22 @@
+package net.corda.plugins
+
+import org.junit.Test
+
+class VersionComparatorTest {
+    @Test
+    fun test() {
+        assert(Utils.compareVersions("3.0.1", "3.0.0") > 0)
+        assert(Utils.compareVersions("2.2.8", "2.2.89") < 0)
+        assert(Utils.compareVersions("5.8.9", "5.8.9") == 0)
+        assert(Utils.compareVersions("5.8.9", "5.8") > 0)
+        assert(Utils.compareVersions("4.1", "4.1.1") < 0)
+        assert(Utils.compareVersions("4.1", "4.1.0.0") == 0)
+        assert(Utils.compareVersions("4.1-rc-1", "4.1.0.0") < 0)
+        assert(Utils.compareVersions( "4.1.0.0", "4.1-rc-1") > 0)
+        assert(Utils.compareVersions("4.1-rc-1", "4.1-rc-1") == 0)
+        assert(Utils.compareVersions("4.0", "4.1-rc-1") < 0)
+        assert(Utils.compareVersions("4-0.1", "4.0-1") == 0)
+        assert(Utils.compareVersions("4-0.2", "4.0-1") > 0)
+        assert(Utils.compareVersions("4-0.2", "4.0-2.1") < 0)
+    }
+}


### PR DESCRIPTION
This PR adds verfification of Gradle version that CorDapp is built with against the Gradle Wrapper config if one exists. This verification aims to save users from build-related issues if they use a wrong version of Gradle.