### PR TITLE
CORDA-1832: Add transitive dependencies of Quasar agent to runtime configuration.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ### Version 4.0.28
 
+* `quasar-utils`: Ensure that `quasar-core`'s transitive dependencies are added to the `runtimeClasspath` configuration.
+
 ### Version 4.0.27
 
 * `jar-filter`: Initial import from Corda.

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 ### Version 4.0.28
 
-* `quasar-utils`: Ensure that `quasar-core`'s transitive dependencies are added to the `runtimeClasspath` configuration.
+* `quasar-utils`: Add `quasar-core` to the `compileClasspath` configuration, and its transitive dependencies to the `runtimeClasspath` configuration.
 
 ### Version 4.0.27
 

--- a/cordapp/src/main/kotlin/net/corda/plugins/Utils.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/Utils.kt
@@ -15,9 +15,10 @@ fun Project.configuration(name: String): Configuration = configurations.single {
 class Utils {
     companion object {
         fun createCompileConfiguration(name: String, project: Project) {
-            if(!project.configurations.any { it.name == name }) {
-                val configuration = project.configurations.create(name)
-                configuration.isTransitive = false
+            if (project.configurations.none { it.name == name }) {
+                val configuration = project.configurations.create(name) {
+                    it.isTransitive = false
+                }
                 project.configurations.single { it.name == "compile" }.extendsFrom(configuration)
             }
         }
@@ -25,9 +26,10 @@ class Utils {
         // This function is called from the groovy quasar-utils plugin.
         @JvmStatic
         fun createRuntimeConfiguration(name: String, project: Project) {
-            if(!project.configurations.any { it.name == name }) {
-                val configuration = project.configurations.create(name)
-                configuration.isTransitive = false
+            if (project.configurations.none { it.name == name }) {
+                val configuration = project.configurations.create(name) {
+                    it.isTransitive = false
+                }
                 project.configurations.single { it.name == "runtime" }.extendsFrom(configuration)
             }
         }

--- a/quasar-utils/build.gradle
+++ b/quasar-utils/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'groovy'
-apply plugin: 'java-gradle-plugin'
+plugins {
+    id 'groovy'
+    id 'java-gradle-plugin'
+}
 
 description 'A small gradle plugin for adding some basic Quasar tasks and configurations to reduce build.gradle bloat.'
 

--- a/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
@@ -16,7 +16,7 @@ class QuasarPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         Utils.createRuntimeConfiguration("cordaRuntime", project)
-        project.configurations.create("quasar")
+        def quasar = project.configurations.create("quasar")
 
         def rootProject = project.rootProject
         def quasarGroup = rootProject.hasProperty("quasar_group") ? rootProject.ext.quasar_group : defaultGroup
@@ -27,6 +27,8 @@ class QuasarPlugin implements Plugin<Project> {
             // Ensure that Quasar's transitive dependencies are available at runtime (only).
             it.transitive = true
         }
+        // This adds Quasar to the compile classpath WITHOUT any of its transitive dependencies.
+        project.dependencies.add("compileOnly", quasar)
 
         project.tasks.withType(Test).all {
             jvmArgs "-javaagent:${project.configurations.quasar.singleFile}"

--- a/quasar-utils/src/test/groovy/net/corda/plugins/QuasarPluginTest.groovy
+++ b/quasar-utils/src/test/groovy/net/corda/plugins/QuasarPluginTest.groovy
@@ -7,29 +7,25 @@ import org.junit.rules.TemporaryFolder
 
 import static org.assertj.core.api.Assertions.*
 import static org.gradle.testkit.runner.TaskOutcome.*
-import static org.junit.Assert.*
 
 class QuasarPluginTest {
     private static final String TEST_GRADLE_USER_HOME = System.getProperty("test.gradle.user.home", ".")
+    private static final String QUASAR_VERSION = QuasarPlugin.defaultVersion
 
     @Rule
     public final TemporaryFolder testProjectDir = new TemporaryFolder()
 
     @Test
-    void checkDefaultVersionIsRuntime() {
-        def quasarVersion = QuasarPlugin.defaultVersion
-
-        def buildFile = testProjectDir.newFile("build.gradle")
-        buildFile.text = """
+    void checkDefaultVersionIsUsed() {
+        def output = runGradleFor """
 plugins {
     id 'java'
     id 'net.corda.plugins.quasar-utils' apply false
 }
 
-description 'Show quasar-core added to runtime configurations'
+description 'Show quasar-core added to configurations'
     
 repositories {
-    mavenLocal()
     mavenCentral()
 }
 
@@ -39,39 +35,26 @@ jar {
     enabled = false
 }
 
-configurations.runtime.forEach {
-    println "runtime: \${it.name}"
+configurations.quasar.forEach {
+    println "quasar: \${it.name}"
 }
 
 configurations.cordaRuntime.forEach {
     println "cordaRuntime: \${it.name}"
 }
 """
-        def result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withArguments("--info", "build", "-g", TEST_GRADLE_USER_HOME)
-            .withPluginClasspath()
-            .build()
-        println result.output
-
-        def output = result.output.readLines()
         assertThat(output).containsOnlyOnce(
-            "runtime: quasar-core-$quasarVersion-jdk8.jar".toString(),
-            "cordaRuntime: quasar-core-$quasarVersion-jdk8.jar".toString()
+            "quasar: quasar-core-$QUASAR_VERSION-jdk8.jar".toString(),
+            "cordaRuntime: quasar-core-$QUASAR_VERSION-jdk8.jar".toString()
         )
-
-        def build = result.task(":build")
-        assertNotNull(build)
-        assertEquals(UP_TO_DATE, build.outcome)
     }
 
     @Test
-    void checkOverriddenVersionIsRuntime() {
+    void checkOverriddenVersionIsUsed() {
         def quasarVersion = "0.7.9"
-        assertNotEquals(quasarVersion, QuasarPlugin.defaultVersion)
+        assertThat(quasarVersion).isNotEqualTo(QUASAR_VERSION)
 
-        def buildFile = testProjectDir.newFile("build.gradle")
-        buildFile.text = """
+        def output = runGradleFor """
 buildscript {
     ext {
         quasar_group = 'co.paralleluniverse'
@@ -84,10 +67,9 @@ plugins {
     id 'net.corda.plugins.quasar-utils' apply false
 }
 
-description 'Show quasar-core added to runtime configurations'
+description 'Show quasar-core added to configurations'
     
 repositories {
-    mavenLocal()
     mavenCentral()
 }
 
@@ -97,29 +79,105 @@ jar {
     enabled = false
 }
 
-configurations.runtime.forEach {
-    println "runtime: \${it.name}"
+configurations.quasar.forEach {
+    println "quasar: \${it.name}"
 }
 
 configurations.cordaRuntime.forEach {
     println "cordaRuntime: \${it.name}"
 }
 """
-        def result = GradleRunner.create()
-                .withProjectDir(testProjectDir.getRoot())
-                .withArguments("--info", "build", "-g", TEST_GRADLE_USER_HOME)
-                .withPluginClasspath()
-                .build()
-        println result.output
-
-        def output = result.output.readLines()
         assertThat(output).containsOnlyOnce(
-                "runtime: quasar-core-$quasarVersion-jdk8.jar".toString(),
-                "cordaRuntime: quasar-core-$quasarVersion-jdk8.jar".toString()
+            "quasar: quasar-core-$quasarVersion-jdk8.jar".toString(),
+            "cordaRuntime: quasar-core-$quasarVersion-jdk8.jar".toString()
         )
 
+    }
+
+    @Test
+    void checkForTransitiveDependencies() {
+        def output = runGradleFor """
+plugins {
+    id 'java'
+    id 'net.corda.plugins.quasar-utils' apply false
+}
+
+description 'Show quasar-core added to configurations'
+    
+repositories {
+    mavenCentral()
+}
+
+apply plugin: 'net.corda.plugins.quasar-utils'
+
+jar {
+    enabled = false
+}
+
+configurations.quasar.forEach {
+    println "quasar: \${it.name}"
+}
+
+configurations.cordaRuntime.forEach {
+    println "cordaRuntime: \${it.name}"
+}
+
+configurations.runtimeClasspath.forEach {
+    println "runtimeClasspath: \${it.name}"
+}
+"""
+        assertThat(output.findAll { it.startsWith("quasar:") }).hasSize(1)
+        assertThat(output.findAll { it.startsWith("cordaRuntime:") }).hasSize(1)
+        assertThat(output.findAll { it.startsWith("runtimeClasspath:") }.size()).isGreaterThan(1)
+    }
+
+    @Test
+    void checkJVMArgsAddedForTests() {
+        def output = runGradleFor """
+plugins {
+    id 'java'
+    id 'net.corda.plugins.quasar-utils' apply false
+}
+
+description 'Show quasar-core added to test JVM arguments'
+
+repositories {
+    mavenCentral()
+}
+
+apply plugin: 'net.corda.plugins.quasar-utils'
+
+jar {
+    enabled = false
+}
+
+test {
+    allJvmArgs.forEach {
+        println "TEST-JVM: \${it}"
+    }
+}
+"""
+        assertThat(output).anyMatch {
+            it.startsWith("TEST-JVM: -javaagent:") && it.endsWith("quasar-core-$QUASAR_VERSION-jdk8.jar")
+        }.anyMatch {
+            it == "TEST-JVM: -Dco.paralleluniverse.fibers.verifyInstrumentation"
+        }
+    }
+
+    private List<String> runGradleFor(String script) {
+        def buildFile = testProjectDir.newFile("build.gradle")
+        buildFile.text = script
+        def result = GradleRunner.create()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments("--info", "build", "-g", TEST_GRADLE_USER_HOME)
+            .withPluginClasspath()
+            .build()
+        println result.output
+
         def build = result.task(":build")
-        assertNotNull(build)
-        assertEquals(UP_TO_DATE, build.outcome)
+        assertThat(build).isNotNull()
+        assertThat(build.outcome).isEqualTo(UP_TO_DATE)
+
+        return result.output.readLines()
     }
 }

--- a/quasar-utils/src/test/groovy/net/corda/plugins/QuasarPluginTest.groovy
+++ b/quasar-utils/src/test/groovy/net/corda/plugins/QuasarPluginTest.groovy
@@ -42,10 +42,15 @@ configurations.quasar.forEach {
 configurations.cordaRuntime.forEach {
     println "cordaRuntime: \${it.name}"
 }
+
+configurations.compileClasspath.forEach {
+    println "compileClasspath: \${it.name}"
+}
 """
         assertThat(output).containsOnlyOnce(
             "quasar: quasar-core-$QUASAR_VERSION-jdk8.jar".toString(),
-            "cordaRuntime: quasar-core-$QUASAR_VERSION-jdk8.jar".toString()
+            "cordaRuntime: quasar-core-$QUASAR_VERSION-jdk8.jar".toString(),
+            "compileClasspath: quasar-core-$QUASAR_VERSION-jdk8.jar".toString()
         )
     }
 
@@ -86,12 +91,16 @@ configurations.quasar.forEach {
 configurations.cordaRuntime.forEach {
     println "cordaRuntime: \${it.name}"
 }
+
+configurations.compileClasspath.forEach {
+    println "compileClasspath: \${it.name}"
+}
 """
         assertThat(output).containsOnlyOnce(
             "quasar: quasar-core-$quasarVersion-jdk8.jar".toString(),
-            "cordaRuntime: quasar-core-$quasarVersion-jdk8.jar".toString()
+            "cordaRuntime: quasar-core-$quasarVersion-jdk8.jar".toString(),
+            "compileClasspath: quasar-core-$quasarVersion-jdk8.jar".toString()
         )
-
     }
 
     @Test
@@ -122,12 +131,17 @@ configurations.cordaRuntime.forEach {
     println "cordaRuntime: \${it.name}"
 }
 
+configurations.compileClasspath.forEach {
+    println "compileClasspath: \${it.name}"
+}
+
 configurations.runtimeClasspath.forEach {
     println "runtimeClasspath: \${it.name}"
 }
 """
         assertThat(output.findAll { it.startsWith("quasar:") }).hasSize(1)
         assertThat(output.findAll { it.startsWith("cordaRuntime:") }).hasSize(1)
+        assertThat(output.findAll { it.startsWith("compileClasspath:") }).hasSize(1)
         assertThat(output.findAll { it.startsWith("runtimeClasspath:") }.size()).isGreaterThan(1)
     }
 

--- a/quasar-utils/src/test/groovy/net/corda/plugins/QuasarPluginTest.groovy
+++ b/quasar-utils/src/test/groovy/net/corda/plugins/QuasarPluginTest.groovy
@@ -35,21 +35,17 @@ jar {
     enabled = false
 }
 
-configurations.quasar.forEach {
-    println "quasar: \${it.name}"
-}
-
-configurations.cordaRuntime.forEach {
-    println "cordaRuntime: \${it.name}"
-}
-
-configurations.compileClasspath.forEach {
-    println "compileClasspath: \${it.name}"
+def configs = configurations.matching { it.name in ['quasar', 'cordaRuntime', 'compileOnly', 'compileClasspath'] }
+configs.collectEntries { [(it.name):it] }.forEach { name, files ->
+    files.forEach { file ->
+        println "\$name: \${file.name}"
+    }
 }
 """
         assertThat(output).containsOnlyOnce(
             "quasar: quasar-core-$QUASAR_VERSION-jdk8.jar".toString(),
             "cordaRuntime: quasar-core-$QUASAR_VERSION-jdk8.jar".toString(),
+            "compileOnly: quasar-core-$QUASAR_VERSION-jdk8.jar".toString(),
             "compileClasspath: quasar-core-$QUASAR_VERSION-jdk8.jar".toString()
         )
     }
@@ -84,21 +80,17 @@ jar {
     enabled = false
 }
 
-configurations.quasar.forEach {
-    println "quasar: \${it.name}"
-}
-
-configurations.cordaRuntime.forEach {
-    println "cordaRuntime: \${it.name}"
-}
-
-configurations.compileClasspath.forEach {
-    println "compileClasspath: \${it.name}"
+def configs = configurations.matching { it.name in ['quasar', 'cordaRuntime', 'compileOnly', 'compileClasspath'] }
+configs.collectEntries { [(it.name):it] }.forEach { name, files ->
+    files.forEach { file ->
+        println "\$name: \${file.name}"
+    }
 }
 """
         assertThat(output).containsOnlyOnce(
             "quasar: quasar-core-$quasarVersion-jdk8.jar".toString(),
             "cordaRuntime: quasar-core-$quasarVersion-jdk8.jar".toString(),
+            "compileOnly: quasar-core-$quasarVersion-jdk8.jar".toString(),
             "compileClasspath: quasar-core-$quasarVersion-jdk8.jar".toString()
         )
     }
@@ -123,24 +115,16 @@ jar {
     enabled = false
 }
 
-configurations.quasar.forEach {
-    println "quasar: \${it.name}"
-}
-
-configurations.cordaRuntime.forEach {
-    println "cordaRuntime: \${it.name}"
-}
-
-configurations.compileClasspath.forEach {
-    println "compileClasspath: \${it.name}"
-}
-
-configurations.runtimeClasspath.forEach {
-    println "runtimeClasspath: \${it.name}"
+def configs = configurations.matching { it.name in ['quasar', 'cordaRuntime', 'compileClasspath', 'compileOnly', 'runtimeClasspath'] }
+configs.collectEntries { [(it.name):it] }.forEach { name, files ->
+    files.forEach { file ->
+        println "\$name: \${file.name}"
+    }
 }
 """
         assertThat(output.findAll { it.startsWith("quasar:") }).hasSize(1)
         assertThat(output.findAll { it.startsWith("cordaRuntime:") }).hasSize(1)
+        assertThat(output.findAll { it.startsWith("compileOnly:") }).hasSize(1)
         assertThat(output.findAll { it.startsWith("compileClasspath:") }).hasSize(1)
         assertThat(output.findAll { it.startsWith("runtimeClasspath:") }.size()).isGreaterThan(1)
     }


### PR DESCRIPTION
We aren't interested in the transitive dependencies of anything added to the `quasar` or `cordaRuntime` configurations. But the Quasar agent still needs its transitive dependencies on the runtime classpath or it won't be able to execute.

- Ensure that `quasar-core` is added to Gradle's `runtimeClasspath` configuration along with all of its transitive dependencies.
- Also add `quasar-core` to the `compileOnly` configuration so that (say) its `@Suspendable` and `Strand` classes are present on the compile classpath.