### PR TITLE
Update ProGuard to use files rather than strings

### DIFF
--- a/jar-filter/kotlin-metadata/build.gradle
+++ b/jar-filter/kotlin-metadata/build.gradle
@@ -27,13 +27,13 @@ def originalJar = configurations.proguard.files.find { it.name.startsWith("kotli
 import proguard.gradle.ProGuardTask
 task metadata(type: ProGuardTask) {
     injars originalJar, filter: 'META-INF/MANIFEST.MF,META-INF/metadata*.kotlin_module,**.class'
-    outjars "$buildDir/libs/${project.name}-${kotlin_version}.jar"
+    outjars file("$buildDir/libs/${project.name}-${kotlin_version}.jar")
 
-    libraryjars "$javaHome/lib/rt.jar"
-    libraryjars "$javaHome/../lib/tools.jar"
+    libraryjars file("$javaHome/lib/rt.jar")
+    libraryjars file("$javaHome/../lib/tools.jar")
     configurations.proguard.forEach {
         if (originalJar != it) {
-            libraryjars it.path, filter: '!META-INF/versions/**'
+            libraryjars it, filter: '!META-INF/versions/**'
         }
     }
 
@@ -60,9 +60,9 @@ def metadataJar = metadata.outputs.files.singleFile
 
 task validate(type: ProGuardTask) {
     injars metadataJar
-    libraryjars "$javaHome/lib/rt.jar"
+    libraryjars file("$javaHome/lib/rt.jar")
     configurations.runtimeOnly.forEach {
-        libraryjars it.path, filter: '!META-INF/versions/**'
+        libraryjars it, filter: '!META-INF/versions/**'
     }
 
     keepattributes '*'

--- a/jar-filter/kotlin-metadata/build.gradle
+++ b/jar-filter/kotlin-metadata/build.gradle
@@ -11,14 +11,14 @@ repositories {
 
 configurations {
     proguard
-    runtimeOnly
-    configurations.default.extendsFrom runtimeOnly
+    runtimeClasspath
+    configurations.default.extendsFrom runtimeClasspath
 }
 
 dependencies {
     proguard "org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlin_version"
     proguard "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    runtimeOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    runtimeClasspath "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }
 
 def javaHome = System.getProperty('java.home')
@@ -61,7 +61,7 @@ def metadataJar = metadata.outputs.files.singleFile
 task validate(type: ProGuardTask) {
     injars metadataJar
     libraryjars file("$javaHome/lib/rt.jar")
-    configurations.runtimeOnly.forEach {
+    configurations.runtimeClasspath.forEach {
         libraryjars it, filter: '!META-INF/versions/**'
     }
 


### PR DESCRIPTION
Prefer files over strings, which is hopefully more forgiving on Windows.