### PR TITLE
CORDA-1854: Update Gradle configuration for plugin projects

### DIFF
--- a/api-scanner/build.gradle
+++ b/api-scanner/build.gradle
@@ -5,7 +5,6 @@ apply plugin: 'java-gradle-plugin'
 description "Generates a summary of the artifact's public API"
 
 repositories {
-    mavenLocal()
     mavenCentral()
     jcenter()
 }

--- a/api-scanner/src/main/java/net/corda/plugins/ApiPrintWriter.java
+++ b/api-scanner/src/main/java/net/corda/plugins/ApiPrintWriter.java
@@ -78,7 +78,7 @@ public class ApiPrintWriter extends PrintWriter {
             String vararg = paramTypes.removeLast();
             paramTypes.add(vararg.substring(0, vararg.length() - 2) + "...");
         }
-        append(paramTypes.stream().collect(joining(", ")));
+        append(String.join(", ", paramTypes));
         println(')');
     }
 

--- a/api-scanner/src/test/java/net/corda/plugins/GradleProject.java
+++ b/api-scanner/src/test/java/net/corda/plugins/GradleProject.java
@@ -17,7 +17,6 @@ import java.util.Collections;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
-import static java.util.stream.Collectors.joining;
 import static net.corda.plugins.CopyUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.gradle.testkit.runner.TaskOutcome.*;
@@ -51,7 +50,7 @@ public class GradleProject implements TestRule {
     }
 
     public String getApiText() throws IOException {
-        return getApiLines().stream().collect(joining("\n"));
+        return String.join("\n", getApiLines());
     }
 
     public String getOutput() {
@@ -64,6 +63,8 @@ public class GradleProject implements TestRule {
             @Override
             public void evaluate() throws Throwable {
                 installResource(projectDir, name + "/build.gradle");
+                installResource(projectDir, "repositories.gradle");
+                installResource(projectDir, "settings.gradle");
                 installResource(projectDir, "gradle.properties");
 
                 BuildResult result = GradleRunner.create()

--- a/api-scanner/src/test/resources/annotated-class/build.gradle
+++ b/api-scanner/src/test/resources/annotated-class/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'java'
     id 'net.corda.plugins.api-scanner'
 }
+apply from: 'repositories.gradle'
 
 description 'Test annotation inheritance across classes'
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
 
 sourceSets {
     main {

--- a/api-scanner/src/test/resources/annotated-field/build.gradle
+++ b/api-scanner/src/test/resources/annotated-field/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'java'
     id 'net.corda.plugins.api-scanner'
 }
+apply from: 'repositories.gradle'
 
 description 'Test annotation behaviour for a field'
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
 
 sourceSets {
     main {

--- a/api-scanner/src/test/resources/annotated-interface/build.gradle
+++ b/api-scanner/src/test/resources/annotated-interface/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'java'
     id 'net.corda.plugins.api-scanner'
 }
+apply from: 'repositories.gradle'
 
 description 'Test annotation inheritance across interfaces'
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
 
 sourceSets {
     main {

--- a/api-scanner/src/test/resources/annotated-method/build.gradle
+++ b/api-scanner/src/test/resources/annotated-method/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'java'
     id 'net.corda.plugins.api-scanner'
 }
+apply from: 'repositories.gradle'
 
 description 'Test annotation behaviour for a method'
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
 
 sourceSets {
     main {

--- a/api-scanner/src/test/resources/basic-annotation/build.gradle
+++ b/api-scanner/src/test/resources/basic-annotation/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'java'
     id 'net.corda.plugins.api-scanner'
 }
+apply from: 'repositories.gradle'
 
 description 'Test behaviour of a basic Java annotation'
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
 
 sourceSets {
     main {

--- a/api-scanner/src/test/resources/basic-class/build.gradle
+++ b/api-scanner/src/test/resources/basic-class/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'java'
     id 'net.corda.plugins.api-scanner'
 }
+apply from: 'repositories.gradle'
 
 description 'Test behaviour of a basic Java class'
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
 
 sourceSets {
     main {

--- a/api-scanner/src/test/resources/basic-interface/build.gradle
+++ b/api-scanner/src/test/resources/basic-interface/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'java'
     id 'net.corda.plugins.api-scanner'
 }
+apply from: 'repositories.gradle'
 
 description 'Test behaviour of a basic Java interface'
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
 
 sourceSets {
     main {

--- a/api-scanner/src/test/resources/class-internal-annotation/build.gradle
+++ b/api-scanner/src/test/resources/class-internal-annotation/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'java'
     id 'net.corda.plugins.api-scanner'
 }
+apply from: 'repositories.gradle'
 
 description 'Test behaviour of internal annotations on classes'
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
 
 sourceSets {
     main {

--- a/api-scanner/src/test/resources/extended-class/build.gradle
+++ b/api-scanner/src/test/resources/extended-class/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'java'
     id 'net.corda.plugins.api-scanner'
 }
+apply from: 'repositories.gradle'
 
 description 'Test behaviour of an extended Java class'
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
 
 sourceSets {
     main {

--- a/api-scanner/src/test/resources/extended-interface/build.gradle
+++ b/api-scanner/src/test/resources/extended-interface/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'java'
     id 'net.corda.plugins.api-scanner'
 }
+apply from: 'repositories.gradle'
 
 description 'Test behaviour of an extended Java interface'
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
 
 sourceSets {
     main {

--- a/api-scanner/src/test/resources/field-internal-annotation/build.gradle
+++ b/api-scanner/src/test/resources/field-internal-annotation/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'java'
     id 'net.corda.plugins.api-scanner'
 }
+apply from: 'repositories.gradle'
 
 description 'Test behaviour of internal annotations on fields'
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
 
 sourceSets {
     main {

--- a/api-scanner/src/test/resources/internal-annotation/build.gradle
+++ b/api-scanner/src/test/resources/internal-annotation/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'java'
     id 'net.corda.plugins.api-scanner'
 }
+apply from: 'repositories.gradle'
 
 description 'Test behaviour of @CordaInternal annotations'
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
 
 sourceSets {
     main {

--- a/api-scanner/src/test/resources/internal-field/build.gradle
+++ b/api-scanner/src/test/resources/internal-field/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'java'
     id 'net.corda.plugins.api-scanner'
 }
+apply from: 'repositories.gradle'
 
 description 'Test behaviour of @CordaInternal annotation on fields'
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
 
 sourceSets {
     main {

--- a/api-scanner/src/test/resources/internal-method/build.gradle
+++ b/api-scanner/src/test/resources/internal-method/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'java'
     id 'net.corda.plugins.api-scanner'
 }
+apply from: 'repositories.gradle'
 
 description 'Test behaviour of @CordaInternal annotation on methods'
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
 
 sourceSets {
     main {

--- a/api-scanner/src/test/resources/internal-package/build.gradle
+++ b/api-scanner/src/test/resources/internal-package/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'java'
     id 'net.corda.plugins.api-scanner'
 }
+apply from: 'repositories.gradle'
 
 description 'Test behaviour of an internal package'
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
 
 sourceSets {
     main {

--- a/api-scanner/src/test/resources/kotlin-annotations/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-annotations/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'net.corda.plugins.api-scanner'
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
 }
+apply from: 'repositories.gradle'
 
 description 'Test appearance of Kotlin-specific annotations'
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
 
 sourceSets {
     main {

--- a/api-scanner/src/test/resources/kotlin-auto-generated-class/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-auto-generated-class/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'net.corda.plugins.api-scanner'
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
 }
+apply from: 'repositories.gradle'
 
 description 'Test appearance of Kotlin lambdas'
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
 
 sourceSets {
     main {

--- a/api-scanner/src/test/resources/kotlin-internal-annotation/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-internal-annotation/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'net.corda.plugins.api-scanner'
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
 }
+apply from: 'repositories.gradle'
 
 description 'Test appearance of internal Corda annotations in Kotlin'
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
 
 sourceSets {
     main {

--- a/api-scanner/src/test/resources/kotlin-lambdas/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-lambdas/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'net.corda.plugins.api-scanner'
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
 }
+apply from: 'repositories.gradle'
 
 description 'Test appearance of Kotlin lambdas'
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
 
 sourceSets {
     main {

--- a/api-scanner/src/test/resources/kotlin-vararg-method/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-vararg-method/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'net.corda.plugins.api-scanner'
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
 }
+apply from: 'repositories.gradle'
 
 description 'Test appearance of Kotlin vararg functions'
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
 
 sourceSets {
     main {

--- a/api-scanner/src/test/resources/method-internal-annotation/build.gradle
+++ b/api-scanner/src/test/resources/method-internal-annotation/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'java'
     id 'net.corda.plugins.api-scanner'
 }
+apply from: 'repositories.gradle'
 
 description 'Test behaviour of internal annotations on methods'
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
 
 sourceSets {
     main {

--- a/api-scanner/src/test/resources/repositories.gradle
+++ b/api-scanner/src/test/resources/repositories.gradle
@@ -1,0 +1,3 @@
+repositories {
+    mavenCentral()
+}

--- a/api-scanner/src/test/resources/settings.gradle
+++ b/api-scanner/src/test/resources/settings.gradle
@@ -1,0 +1,6 @@
+// Common settings for all Gradle test projects.
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+    }
+}

--- a/api-scanner/src/test/resources/vararg-method/build.gradle
+++ b/api-scanner/src/test/resources/vararg-method/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'net.corda.plugins.api-scanner'
     id 'java'
 }
+apply from: 'repositories.gradle'
 
 description 'Test appearance of Java vararg functions'
-
-repositories {
-    mavenLocal()
-    mavenCentral()
-}
 
 sourceSets {
     main {

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,17 @@ allprojects {
     version gradle_plugins_version
     group 'net.corda.plugins'
 
+    tasks.withType(JavaCompile).all {
+        options.encoding = 'UTF-8'
+    }
+
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+        kotlinOptions {
+            jvmTarget = "1.8"
+            freeCompilerArgs = ['-Xjvm-default=enable']
+        }
+    }
+
     tasks.withType(Test) {
         // Prevent the project from creating temporary files outside of the build directory.
         systemProperty 'java.io.tmpdir', buildDir.absolutePath

--- a/cordformation/build.gradle
+++ b/cordformation/build.gradle
@@ -1,13 +1,3 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 apply plugin: 'kotlin'
 apply plugin: 'java-gradle-plugin'
 

--- a/jar-filter/build.gradle
+++ b/jar-filter/build.gradle
@@ -22,20 +22,19 @@ gradlePlugin {
     automatedPublishing = false
 }
 
+allprojects {
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+        kotlinOptions {
+            jvmTarget = "1.8"
+            freeCompilerArgs = ['-Xjvm-default=enable']
+        }
+    }
+}
+
 configurations {
     plugin
     shadow
     jacocoRuntime
-}
-
-processTestResources {
-    filesMatching('**/build.gradle') {
-        expand(['kotlin_version': kotlin_version])
-    }
-    filesMatching('gradle.properties') {
-        expand(['jacocoAgent': configurations.jacocoRuntime.asPath.replace('\\', '/'),
-                'buildDir': buildDir])
-    }
 }
 
 dependencies {
@@ -54,6 +53,16 @@ dependencies {
     testImplementation project(':jar-filter:unwanteds')
 
     jacocoRuntime "org.jacoco:org.jacoco.agent:${jacoco.toolVersion}:runtime"
+}
+
+processTestResources {
+    filesMatching('**/build.gradle') {
+        expand(['kotlin_version': kotlin_version])
+    }
+    filesMatching('gradle.properties') {
+        expand(['jacocoAgent': configurations.jacocoRuntime.asPath.replace('\\', '/'),
+                'buildDir': buildDir])
+    }
 }
 
 jar {

--- a/jar-filter/build.gradle
+++ b/jar-filter/build.gradle
@@ -22,15 +22,6 @@ gradlePlugin {
     automatedPublishing = false
 }
 
-allprojects {
-    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-        kotlinOptions {
-            jvmTarget = "1.8"
-            freeCompilerArgs = ['-Xjvm-default=enable']
-        }
-    }
-}
-
 configurations {
     plugin
     shadow

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/JarFilterTask.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/JarFilterTask.kt
@@ -98,7 +98,7 @@ open class JarFilterTask : DefaultTask() {
         }
         checkDistinctAnnotations()
         try {
-            jars.forEach { jar ->
+            for (jar in jars) {
                 logger.info("Filtering {}", jar)
                 Filter(jar).run()
             }

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTask.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTask.kt
@@ -58,7 +58,7 @@ open class MetaFixerTask : DefaultTask() {
     fun fixMetadata() {
         logger.info("Fixing Kotlin @Metadata")
         try {
-            jars.forEach { jar ->
+            for (jar in jars) {
                 logger.info("Reading from {}", jar)
                 MetaFix(jar).use { it.run() }
             }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteAndStubTests.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteAndStubTests.kt
@@ -131,6 +131,8 @@ class DeleteAndStubTests {
                     }
                 }
                 assertThat("unwantedVar not found", kotlin.declaredMemberProperties, hasItem(unwantedVar))
+                assertThat("getUnwantedVar() not found", kotlin.javaDeclaredMethods, hasItem(getUnwantedVar))
+                assertThat("setUnwantedVar() not found", kotlin.javaDeclaredMethods, hasItem(setUnwantedVar))
                 assertThat("stringData() not found", kotlin.declaredMemberFunctions, hasItem(stringData))
             }
         }
@@ -156,6 +158,7 @@ class DeleteAndStubTests {
                     assertEquals(MESSAGE, (obj as HasUnwantedVal).unwantedVal)
                 }
                 assertThat("unwantedVal not found", kotlin.declaredMemberProperties, hasItem(unwantedVal))
+                assertThat("getUnwantedVal() not found", kotlin.javaDeclaredMethods, hasItem(getUnwantedVal))
                 assertThat("stringData() not found", kotlin.declaredMemberFunctions, hasItem(stringData))
             }
         }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteNestedClassTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteNestedClassTest.kt
@@ -1,7 +1,7 @@
 package net.corda.gradle.jarfilter
 
 import net.corda.gradle.jarfilter.asm.classMetadata
-import net.corda.gradle.jarfilter.matcher.isClass
+import net.corda.gradle.jarfilter.matcher.isKClass
 import org.assertj.core.api.Assertions.*
 import org.hamcrest.core.IsCollectionContaining.hasItem
 import org.hamcrest.core.IsNot.not
@@ -23,10 +23,10 @@ class DeleteNestedClassTest {
         private const val WANTED_SUBCLASS = "$SEALED_CLASS\$Wanted"
         private const val UNWANTED_SUBCLASS = "$SEALED_CLASS\$Unwanted"
 
-        private val keptClass = isClass(KEPT_CLASS)
-        private val deletedClass = isClass(DELETED_CLASS)
-        private val wantedSubclass = isClass(WANTED_SUBCLASS)
-        private val unwantedSubclass = isClass(UNWANTED_SUBCLASS)
+        private val keptClass = isKClass(KEPT_CLASS)
+        private val deletedClass = isKClass(DELETED_CLASS)
+        private val wantedSubclass = isKClass(WANTED_SUBCLASS)
+        private val unwantedSubclass = isKClass(UNWANTED_SUBCLASS)
 
         private val testProjectDir = TemporaryFolder()
         private val testProject = JarFilterProject(testProjectDir, "delete-nested-class")

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/matcher/JavaMatchers.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/matcher/JavaMatchers.kt
@@ -8,15 +8,17 @@ import org.hamcrest.core.IsEqual.*
 import java.lang.reflect.Method
 import kotlin.reflect.KClass
 
-fun isMethod(name: Matcher<in String>, returnType: Matcher<in Class<*>>, vararg parameters: Matcher<in Class<*>>): Matcher<Method> {
+fun isMethod(name: Matcher<in String>, returnType: Matcher<in String>, vararg parameters: Matcher<in String>): Matcher<Method> {
     return MethodMatcher(name, returnType, *parameters)
 }
 
 fun isMethod(name: String, returnType: Class<*>, vararg parameters: Class<*>): Matcher<Method> {
-    return isMethod(equalTo(name), equalTo(returnType), *parameters.toMatchers())
+    return isMethod(equalTo(name), matches(returnType), *parameters.toMatchers())
 }
 
-private fun Array<out Class<*>>.toMatchers() = map(::equalTo).toTypedArray()
+fun matches(type: Class<*>): Matcher<in String> = equalTo(type.name)
+
+private fun Array<out Class<*>>.toMatchers() = map(::matches).toTypedArray()
 
 val KClass<*>.javaDeclaredMethods: List<Method> get() = java.declaredMethods.toList()
 
@@ -25,23 +27,23 @@ val KClass<*>.javaDeclaredMethods: List<Method> get() = java.declaredMethods.toL
  */
 private class MethodMatcher(
     private val name: Matcher<in String>,
-    private val returnType: Matcher<in Class<*>>,
-    vararg parameters: Matcher<in Class<*>>
+    private val returnType: Matcher<in String>,
+    vararg parameters: Matcher<in String>
 ) : DiagnosingMatcher<Method>() {
     private val parameters = listOf(*parameters)
 
     override fun describeTo(description: Description) {
         description.appendText("Method[name as ").appendDescriptionOf(name)
             .appendText(", returnType as ").appendDescriptionOf(returnType)
-            .appendText(", parameters as '")
+            .appendText(", parameters as (")
         if (parameters.isNotEmpty()) {
             val param = parameters.iterator()
-            description.appendValue(param.next())
+            description.appendDescriptionOf(param.next())
             while (param.hasNext()) {
-                description.appendText(",").appendValue(param.next())
+                description.appendText(",").appendDescriptionOf(param.next())
             }
         }
-        description.appendText("']")
+        description.appendText(")]")
     }
 
     override fun matches(obj: Any?, mismatch: Description): Boolean {
@@ -51,26 +53,28 @@ private class MethodMatcher(
         }
 
         val method: Method = obj as? Method ?: return false
+        mismatch.appendText("name is ").appendValue(method.name)
         if (!name.matches(method.name)) {
-            mismatch.appendText("name is ").appendValue(method.name)
             return false
         }
         method.returnType.apply {
-            if (!returnType.matches(this)) {
-                mismatch.appendText("returnType is ").appendValue(this.name)
+            if (!returnType.matches(name)) {
+                mismatch.appendText(" with returnType ").appendValue(name)
                 return false
             }
         }
 
-        if (method.parameterTypes.size != parameters.size) {
-            mismatch.appendText("number of parameters is ").appendValue(method.parameterTypes.size)
-                    .appendText(", parameters=").appendValueList("[", ",", "]", method.parameterTypes)
+        val parameterCount = method.parameterTypes.size
+        if (parameterCount != parameters.size) {
+            mismatch.appendText(" with ")
+                    .appendValue(parameterCount).appendText(" parameter").appendText(if (parameterCount == 1) " " else "s ")
+                    .appendValueList("(", ",", ")", method.parameterTypes.map(Class<*>::getName))
             return false
         }
 
-        for ((i, param) in method.parameterTypes.withIndex()) {
-            if (!parameters[i].matches(param)) {
-                mismatch.appendText("parameter[").appendValue(i).appendText("] is ").appendValue(param)
+        for ((i, paramType) in method.parameterTypes.withIndex()) {
+            if (!parameters[i].matches(paramType.name)) {
+                mismatch.appendText(" where parameter").appendValue(i).appendText(" has type ").appendValue(paramType.name)
                 return false
             }
         }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/matcher/JavaMatchers.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/matcher/JavaMatchers.kt
@@ -68,13 +68,11 @@ private class MethodMatcher(
             return false
         }
 
-        var i = 0
-        method.parameterTypes.forEach { param ->
+        for ((i, param) in method.parameterTypes.withIndex()) {
             if (!parameters[i].matches(param)) {
                 mismatch.appendText("parameter[").appendValue(i).appendText("] is ").appendValue(param)
                 return false
             }
-            ++i
         }
         return true
     }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/matcher/KotlinMatchers.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/matcher/KotlinMatchers.kt
@@ -94,13 +94,11 @@ private class KFunctionMatcher(
             return false
         }
 
-        var i = 0
-        function.valueParameters.forEach { param ->
+        for ((i, param) in function.valueParameters.withIndex()) {
             if (!parameters[i].matches(param)) {
                 mismatch.appendText("parameter[").appendValue(i).appendText("] is ").appendValue(param)
                 return false
             }
-            ++i
         }
         return true
     }


### PR DESCRIPTION
Update the Gradle projects to make it easier to test them against EAP versions of Kotlin. This mainly involves reducing the number of places where we need to add the `kotlin-eap` repository.

Also ensure that the Kotlin compiler is configured for JarFilter plugin.