### PR TITLE
Upgrade to Kotlin 1.2.60.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         bouncycastle_version = '1.57'
         typesafe_config_version = '1.3.1'
         jsr305_version = '3.0.2'
-        kotlin_version = '1.2.51'
+        kotlin_version = '1.2.60'
         artifactory_plugin_version = '4.7.3'
         proguard_version = '6.0.3'
         snake_yaml_version = '1.19'

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/Elements.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/Elements.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlin.metadata.deserialization.TypeTable
 import org.jetbrains.kotlin.metadata.deserialization.returnType
 import org.jetbrains.kotlin.metadata.jvm.JvmProtoBuf
 import org.jetbrains.kotlin.metadata.jvm.deserialization.ClassMapperLite
+import org.jetbrains.kotlin.metadata.jvm.deserialization.JvmMemberSignature
 import org.jetbrains.kotlin.metadata.jvm.deserialization.JvmProtoBufUtil
 import org.objectweb.asm.Opcodes.ACC_SYNTHETIC
 import java.util.*
@@ -117,6 +118,8 @@ internal fun JvmProtoBuf.JvmPropertySignature.toSetter(nameResolver: NameResolve
 
 internal fun JvmProtoBuf.JvmMethodSignature.toMethodElement(nameResolver: NameResolver)
     = MethodElement(nameResolver.getString(name), nameResolver.getString(desc))
+
+internal fun JvmMemberSignature.Method.toMethodElement() = MethodElement(name, desc)
 
 /**
  * This logic is based heavily on [JvmProtoBufUtil.getJvmFieldSignature].

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTransformer.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTransformer.kt
@@ -96,7 +96,7 @@ internal abstract class MetaFixerTransformer<out T : MessageLite>(
         var idx = 0
         removed@ while (idx < functions.size) {
             val function = functions[idx]
-            val signature = JvmProtoBufUtil.getJvmMethodSignature(function, nameResolver, typeTable)
+            val signature = JvmProtoBufUtil.getJvmMethodSignature(function, nameResolver, typeTable)?.asString()
             if (signature != null) {
                 if (!actualMethods.contains(signature)) {
                     logger.info("-- removing method: {}", signature)
@@ -122,7 +122,7 @@ internal abstract class MetaFixerTransformer<out T : MessageLite>(
         var idx = 0
         removed@ while (idx < constructors.size) {
             val constructor = constructors[idx]
-            val signature = JvmProtoBufUtil.getJvmConstructorSignature(constructor, nameResolver, typeTable)
+            val signature = JvmProtoBufUtil.getJvmConstructorSignature(constructor, nameResolver, typeTable)?.asString()
             if (signature != null) {
                 if (!actualMethods.contains(signature)) {
                     logger.info("-- removing constructor: {}", signature)

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetadataTransformer.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetadataTransformer.kt
@@ -104,8 +104,8 @@ internal abstract class MetadataTransformer<out T : MessageLite>(
 
         for (idx in 0 until constructors.size) {
             val constructor = constructors[idx]
-            val signature = JvmProtoBufUtil.getJvmConstructorSignature(constructor, nameResolver, typeTable)
-            if (signature == deleted.signature) {
+            val signature = JvmProtoBufUtil.getJvmConstructorSignature(constructor, nameResolver, typeTable)?.toMethodElement()
+            if (signature == deleted) {
                 if (IS_SECONDARY.get(constructor.flags)) {
                     logger.info("-- removing constructor: {}", deleted.signature)
                 } else {
@@ -113,7 +113,7 @@ internal abstract class MetadataTransformer<out T : MessageLite>(
                 }
                 constructors.removeAt(idx)
                 return true
-            } else if (signature == deletedPrimary?.signature) {
+            } else if (signature == deletedPrimary) {
                 constructors[idx] = constructor.toBuilder()
                     .updateValueParameters(ProtoBuf.ValueParameter::clearDeclaresDefaultValue)
                     .build()
@@ -130,8 +130,8 @@ internal abstract class MetadataTransformer<out T : MessageLite>(
         for (idx in 0 until functions.size) {
             val function = functions[idx]
             if (nameResolver.getString(function.name) == deleted.name) {
-                val signature = JvmProtoBufUtil.getJvmMethodSignature(function, nameResolver, typeTable)
-                if (signature == deleted.signature) {
+                val signature = JvmProtoBufUtil.getJvmMethodSignature(function, nameResolver, typeTable)?.toMethodElement()
+                if (signature == deleted) {
                     logger.info("-- removing function: {}", deleted.signature)
                     functions.removeAt(idx)
                     return true

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/SanitisingTransformer.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/SanitisingTransformer.kt
@@ -49,8 +49,8 @@ class SanitisingTransformer(visitor: ClassVisitor, logger: Logger, private val u
         for (constructor in message.constructorList) {
             if (!IS_SECONDARY.get(constructor.flags)) {
                 val signature = getJvmConstructorSignature(constructor, nameResolver, typeTable) ?: break
-                primaryConstructor = MethodElement("<init>", signature.drop("<init>".length))
-                logger.log(level, "Class {} has primary constructor {}", className, signature)
+                primaryConstructor = signature.toMethodElement()
+                logger.log(level, "Class {} has primary constructor {}", className, signature.asString())
                 break
             }
         }


### PR DESCRIPTION
Update JarFilter for the changes to Kotlin's metadata classes. Note that these classes are shaded and so JarFilter's only external Kotlin dependency is for `kotlin-stdlib-jdk8`.