### PR TITLE
Remove unnecessary ProGuard "dontwarn" rule.

### DIFF
--- a/jar-filter/kotlin-metadata/build.gradle
+++ b/jar-filter/kotlin-metadata/build.gradle
@@ -42,7 +42,6 @@ task metadata(type: ProGuardTask) {
     dontoptimize
     verbose
 
-    dontwarn 'com.sun.jna.**'
     dontwarn 'org.jetbrains.annotations.**'
     dontwarn 'org.jetbrains.kotlin.com.intellij.**'
     dontwarn 'org.jetbrains.kotlin.com.google.j2objc.annotations.**'


### PR DESCRIPTION
Remove `dontwarn` rule which hasn't been necessary since at least Kotlin 1.2.5x.