### PR TITLE
CORDA-1889: Update CordFormation to make deploying itself as a CorDapp optional.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ### Version 4.0.29
 
+* `cordformation`: Allow us not to deploy cordformation's project as another cordapp to all nodes.
+
 ### Version 4.0.28
 
 * `quasar-utils`: Add `quasar-core` to the `compileClasspath` configuration, and its transitive dependencies to the `runtimeClasspath` configuration.

--- a/cordform-common/build.gradle
+++ b/cordform-common/build.gradle
@@ -12,6 +12,9 @@ repositories {
 }
 
 dependencies {
+    // *Only* for Gradle's task annotations!
+    compileOnly gradleApi()
+
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     // JSR 305: Nullability annotations

--- a/cordform-common/src/main/java/net/corda/cordform/CordformNode.java
+++ b/cordform-common/src/main/java/net/corda/cordform/CordformNode.java
@@ -3,6 +3,8 @@ package net.corda.cordform;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -25,6 +27,7 @@ public class CordformNode implements NodeDefinition {
      */
     private String name;
 
+    @Input
     public String getName() {
         return name;
     }
@@ -51,12 +54,15 @@ public class CordformNode implements NodeDefinition {
      *
      * Incorrect configurations will not cause a DSL error.
      */
+    @Input
     public List<Map<String, Object>> rpcUsers = emptyList();
 
     /**
      * Apply the notary configuration if this node is a notary. The map is the config structure of
      * net.corda.node.services.config.NotaryConfig
      */
+    @Optional
+    @Input
     public Map<String, Object> notary = null;
 
     public Map<String, Object> extraConfig = null;
@@ -64,6 +70,8 @@ public class CordformNode implements NodeDefinition {
     /**
      * Copy files into the node relative directory './drivers'.
      */
+    @Optional
+    @Input
     public List<String> drivers = null;
 
     protected Config config = ConfigFactory.empty();
@@ -88,6 +96,7 @@ public class CordformNode implements NodeDefinition {
      * @return This node's P2P address.
      */
     @Nonnull
+    @Input
     public String getP2pAddress() {
         return config.getString("p2pAddress");
     }
@@ -124,6 +133,8 @@ public class CordformNode implements NodeDefinition {
      * Returns the RPC address for this node, or null if one hasn't been specified.
      */
     @Nullable
+    @Optional
+    @Input
     public String getRpcAddress() {
         if (config.hasPath("rpcSettings.address")) {
             return config.getConfig("rpcSettings").getString("address");
@@ -158,6 +169,8 @@ public class CordformNode implements NodeDefinition {
      * Returns the address of the web server that will connect to the node, or null if one hasn't been specified.
      */
     @Nullable
+    @Optional
+    @Input
     public String getWebAddress() {
         return getOptionalString("webAddress");
     }
@@ -196,6 +209,8 @@ public class CordformNode implements NodeDefinition {
         this.configFile = configFile;
     }
 
+    @Optional
+    @Input
     public String getConfigFile() {
         return configFile;
     }

--- a/cordform-common/src/main/java/net/corda/cordform/RpcSettings.java
+++ b/cordform-common/src/main/java/net/corda/cordform/RpcSettings.java
@@ -3,6 +3,7 @@ package net.corda.cordform;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
+import org.gradle.api.tasks.Input;
 
 public final class RpcSettings {
 
@@ -11,10 +12,12 @@ public final class RpcSettings {
     private int port = 10003;
     private int adminPort = 10005;
 
+    @Input
     public int getPort() {
         return port;
     }
 
+    @Input
     public int getAdminPort() {
         return adminPort;
     }

--- a/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
@@ -5,6 +5,7 @@ import net.corda.cordform.CordformDefinition
 import org.gradle.api.DefaultTask
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME
 import org.slf4j.Logger
 import java.io.File
@@ -32,7 +33,11 @@ open class Baseform : DefaultTask() {
      */
     @Suppress("MemberVisibilityCanBePrivate")
     var definitionClass: String? = null
+
+    @OutputDirectory
     var directory = defaultDirectory
+
+    @Input
     protected val nodes = mutableListOf<Node>()
 
     /**
@@ -42,6 +47,16 @@ open class Baseform : DefaultTask() {
      */
     fun directory(directory: String) {
         this.directory = Paths.get(directory)
+    }
+
+    /**
+     * Sets the directory to install nodes into.
+     * This provides a Gradle-friendly [File] interface.
+     *
+     * @param directory The directory the nodes will be installed into.
+     */
+    fun directory(directory: File) {
+        this.directory = directory.toPath()
     }
 
     /**

--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordapp.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordapp.kt
@@ -1,14 +1,27 @@
 package net.corda.plugins
 
 import org.gradle.api.Project
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 import java.io.File
 
-open class Cordapp private constructor(val coordinates: String?, val project: Project?) {
+open class Cordapp private constructor(
+    @get:[Optional Input] val coordinates: String?,
+    @get:[Optional Input] val project: Project?
+) {
     constructor(coordinates: String) : this(coordinates, null)
     constructor(cordappProject: Project) : this(null, cordappProject)
 
     // The configuration text that will be written
+    @Optional
+    @Input
     internal var config: String? = null
+
+    /**
+     * Determines whether or not CordFormation will deploy this CorDapp into Corda.
+     */
+    @Input
+    var deploy: Boolean = true
 
     /**
      * Set the configuration text that will be written to the cordapp's configuration file

--- a/cordformation/src/main/kotlin/net/corda/plugins/Dockerform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Dockerform.kt
@@ -1,9 +1,5 @@
 package net.corda.plugins
 
-import org.apache.tools.ant.filters.FixCrLfFilter
-import org.gradle.api.DefaultTask
-import org.gradle.api.plugins.JavaPluginConvention
-import org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME
 import org.gradle.api.tasks.TaskAction
 import org.yaml.snakeyaml.DumperOptions
 import java.nio.file.Path


### PR DESCRIPTION
A CordFormation project does not necessarily build a CorDapp itself. Add a new
```
nodeDefaults {}
```
block to the task, which defines initial configuration that will be applied to every node. Also enhance the `cordapp` block to support
```
deploy = {true | false}
```
This allows the DSL to declare the following:
```
nodeDefaults {
    projectCordapp {
        deploy = false
    }
}
```