### PR TITLE
CORDA-2015: Upgrade to Kotlin 1.2.70.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         bouncycastle_version = '1.57'
         typesafe_config_version = '1.3.1'
         jsr305_version = '3.0.2'
-        kotlin_version = '1.2.61'
+        kotlin_version = '1.2.70'
         artifactory_plugin_version = '4.7.3'
         proguard_version = '6.0.3'
         snake_yaml_version = '1.19'

--- a/jar-filter/kotlin-metadata/build.gradle
+++ b/jar-filter/kotlin-metadata/build.gradle
@@ -42,10 +42,11 @@ task metadata(type: ProGuardTask) {
     dontoptimize
     verbose
 
-    dontwarn 'org.jetbrains.annotations.**'
+    dontwarn 'kotlin.annotations.jvm.**'
     dontwarn 'org.jetbrains.kotlin.com.intellij.**'
     dontwarn 'org.jetbrains.kotlin.com.google.j2objc.annotations.**'
     dontwarn 'org.jetbrains.kotlin.com.google.errorprone.annotations.**'
+    dontwarn 'org.checkerframework.checker.**'
     dontnote
 
     keep 'class org.jetbrains.kotlin.load.java.JvmAnnotationNames { *; }'
@@ -71,6 +72,7 @@ task validate(type: ProGuardTask) {
     verbose
 
     dontwarn 'org.jetbrains.kotlin.com.google.errorprone.annotations.**'
+    dontwarn 'org.checkerframework.checker.**'
     dontnote
 
     keep 'class *'


### PR DESCRIPTION
Upgrade to [Kotlin 1.2.70](https://blog.jetbrains.com/kotlin/2018/09/kotlin-1-2-70-is-out/).