### PR TITLE
CORDA-2024: Upgrade to Kotlin 1.2.71.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         bouncycastle_version = '1.57'
         typesafe_config_version = '1.3.1'
         jsr305_version = '3.0.2'
-        kotlin_version = '1.2.70'
+        kotlin_version = '1.2.71'
         artifactory_plugin_version = '4.7.3'
         proguard_version = '6.0.3'
         snake_yaml_version = '1.19'

--- a/jar-filter/kotlin-metadata/build.gradle
+++ b/jar-filter/kotlin-metadata/build.gradle
@@ -17,6 +17,7 @@ configurations {
 
 dependencies {
     proguard "org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlin_version"
+    proguard "org.jetbrains.kotlin:kotlin-annotations-jvm:$kotlin_version"
     proguard "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     runtimeClasspath "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }
@@ -42,11 +43,8 @@ task metadata(type: ProGuardTask) {
     dontoptimize
     verbose
 
-    dontwarn 'kotlin.annotations.jvm.**'
     dontwarn 'org.jetbrains.kotlin.com.intellij.**'
-    dontwarn 'org.jetbrains.kotlin.com.google.j2objc.annotations.**'
-    dontwarn 'org.jetbrains.kotlin.com.google.errorprone.annotations.**'
-    dontwarn 'org.checkerframework.checker.**'
+    dontwarn 'org.jetbrains.kotlin.com.google.common.**'
     dontnote
 
     keep 'class org.jetbrains.kotlin.load.java.JvmAnnotationNames { *; }'
@@ -71,8 +69,7 @@ task validate(type: ProGuardTask) {
     dontoptimize
     verbose
 
-    dontwarn 'org.jetbrains.kotlin.com.google.errorprone.annotations.**'
-    dontwarn 'org.checkerframework.checker.**'
+    dontwarn 'org.jetbrains.kotlin.com.google.common.**'
     dontnote
 
     keep 'class *'


### PR DESCRIPTION
Upgrade to Kotlin 1.2.71 which has [these fixes](https://github.com/JetBrains/kotlin/releases/tag/v1.2.71).