### PR TITLE
CORDA-2092: Remove duplicate Jolokia files from CorDapp fat jars

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 ### Version 4.0.31
 
+* `cordformation`: Exclude transitive dependencies from Jolokia agent.
 * `cordformation`: Support for Signature Constraints - the plugin signs all Cordapp JARs by default with Corda development key. It can be disabled or configured to generate ad-hoc keyStore/key or use an external keyStore.
 * `cordapp`: Support for Signature Constraints - the plugin signs Cordapp JAR by default with Corda development key, it can be disabled or configured to use an external keyStore.
 

--- a/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
@@ -60,8 +60,8 @@ class CordappPlugin : Plugin<Project> {
             attributes["Name"] = cordapp.info?.name ?: "${project.group}.${jarTask.baseName}"
             attributes["Implementation-Version"] = cordapp.info?.version ?: project.version
             attributes["Implementation-Vendor"] = cordapp.info?.vendor ?: UNKNOWN
-            targetPlatformVersion?.let { attributes["Target-Platform-Version"] = it }
-            minimumPlatformVersion?.let { attributes["Min-Platform-Version"] = it }
+            attributes["Target-Platform-Version"] = targetPlatformVersion
+            attributes["Min-Platform-Version"] = minimumPlatformVersion
             if (attributes["Implementation-Vendor"] == UNKNOWN) {
                 project.logger.warn("CordApp's vendor is \"$UNKNOWN\". Please specify it in \"cordapp.info.vendor\".")
             }
@@ -81,7 +81,7 @@ class CordappPlugin : Plugin<Project> {
         }
         jarTask.dependsOn(task)
 
-        val signTask = project.task("signJar") { it.doLast { sign(project, cordapp.signing) } }
+        val signTask = project.task("signJar").doLast { sign(project, cordapp.signing) }
         jarTask.finalizedBy(signTask)
     }
 
@@ -150,7 +150,7 @@ class CordappPlugin : Plugin<Project> {
         return filteredDeps.toUniqueFiles(runtimeConfiguration) - excludeDeps.toUniqueFiles(runtimeConfiguration)
     }
 
-    private fun checkVersionInfo(): Pair<Int?, Int?> {
+    private fun checkVersionInfo(): Pair<Int, Int> {
         // If the minimum platform version is not set, default to 1.
         val minimumPlatformVersion: Int = cordapp.info?.minimumPlatformVersion ?: 1
         val targetPlatformVersion = cordapp.info?.targetPlatformVersion ?: throw InvalidUserDataException("Target version was not set and could not be determined from the project's Corda dependency. Please specify the target version of your CorDapp.")

--- a/cordapp/src/main/kotlin/net/corda/plugins/Utils.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/Utils.kt
@@ -61,7 +61,7 @@ class Utils {
         @JvmStatic
         fun createTempFileFromResource(resourcePath: String, tempFileName: String, tempFileExtension: String): Path {
             val path = Files.createTempFile(tempFileName, tempFileExtension)
-            javaClass.classLoader.getResourceAsStream(resourcePath).use {
+            this::class.java.classLoader.getResourceAsStream(resourcePath).use {
                 Files.copy(it, path, StandardCopyOption.REPLACE_EXISTING)
             }
             path.toFile().deleteOnExit()

--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
@@ -44,7 +44,7 @@ class Cordformation : Plugin<Project> {
                 throw IllegalStateException("No $jarName JAR found. Have you deployed the Corda project to Maven? Looked for \"$jarName-$releaseVersion.jar\"")
             } else {
                 val jar = maybeJar.singleFile
-                require(jar.isFile)
+                require(jar.isFile) { "$jar either does not exist or is not a file" }
                 return jar
             }
         }

--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
@@ -2,6 +2,7 @@ package net.corda.plugins
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.ModuleDependency
 import java.io.File
 
 /**
@@ -57,7 +58,9 @@ class Cordformation : Plugin<Project> {
         Utils.createRuntimeConfiguration(CORDFORMATION_TYPE, project)
         // TODO: improve how we re-use existing declared external variables from root gradle.build
         val jolokiaVersion = try { project.rootProject.ext<String>("jolokia_version") } catch (e: Exception) { "1.6.0" }
-        project.dependencies.add(CORDFORMATION_TYPE, "org.jolokia:jolokia-jvm:$jolokiaVersion:agent")
+        val jolokia = project.dependencies.add(CORDFORMATION_TYPE, "org.jolokia:jolokia-jvm:$jolokiaVersion:agent")
+        // The Jolokia agent is a fat jar really, so we don't want its transitive dependencies.
+        (jolokia as ModuleDependency).isTransitive = false
     }
 }
 


### PR DESCRIPTION
The Jolokia agent is a fat jar, so exclude any transitive dependencies it declares from the CorDapp.

Also fix some compiler warnings, and add an error message to a `require` statement.