### PR TITLE
Fix Jar task's up-to-date validity broken by Jar signing task (CORDA-1915)

### DIFF
--- a/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
@@ -68,6 +68,8 @@ class CordappPlugin : Plugin<Project> {
             if (cordapp.signing.enabled) {
                 attributes["Sealed"] = "true"
             }
+        }.doLast {
+            sign(project, cordapp.signing)
         }
         task.doLast {
             jarTask.from(getDirectNonCordaDependencies(project).map {
@@ -83,9 +85,6 @@ class CordappPlugin : Plugin<Project> {
             }
         }
         jarTask.dependsOn(task)
-
-        val signTask = project.task("signJar").doLast { sign(project, cordapp.signing) }
-        jarTask.finalizedBy(signTask)
     }
 
     private fun sign(project: Project, signing: Signing) {


### PR DESCRIPTION
Addition of the signJar Task running after jar task by CORDA-1915 has broken up-to-date validity of the first one. CorDapp signed by default caused Jar task to be always out-of-sync, the signJar task was overwriting the Jar task output, delete the signJar task and move signing as part of the Jar task so it's output is unchanged by other task.