### PR TITLE
Remove Groovy Closure from JarFilter DSL and simplify Kotlin/Gradle usage.

### DIFF
--- a/jar-filter/README.md
+++ b/jar-filter/README.md
@@ -9,9 +9,23 @@ We use this plugin together with ProGuard to generate Corda's `core-deterministi
 modules. See [here](https://github.com/corda/corda/blob/master/docs/source/deterministic-modules.rst) for more information.
 
 ## Usage
-This plugin is automatically available on Gradle's classpath since it lives in Corda's `buildSrc` directory.
-You need only `import` the plugin's task classes in the `build.gradle` file and then use them to declare
-tasks.
+The plugin only needs to be added to the Gradle plugin classpath to make its task classes available. You can then use
+these classes to declare tasks in your `build.gradle` files.
+```gradle
+buildscript {
+    repositories {
+        gradlePluginPortal()
+    }
+
+    classpath "net.corda.plugins:jar-filter:$jar-filter-version"
+}
+```
+or
+```gradle
+plugins {
+    id 'net.corda.plugins.jar-filter' version '$jar-filter-version' apply false
+}
+```
 
 You can enable the tasks' logging output using Gradle's `--info` or `--debug` command-line options.
 

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/FilterAnnotations.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/FilterAnnotations.kt
@@ -1,0 +1,17 @@
+package net.corda.gradle.jarfilter
+
+import org.gradle.api.tasks.Input
+
+open class FilterAnnotations {
+    @get:Input
+    var forDelete: Set<String> = emptySet()
+
+    @get:Input
+    var forStub: Set<String> = emptySet()
+
+    @get:Input
+    var forRemove: Set<String> = emptySet()
+
+    @get:Input
+    var forSanitise: Set<String> = emptySet()
+}

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTask.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTask.kt
@@ -60,7 +60,7 @@ open class MetaFixerTask : DefaultTask() {
         try {
             for (jar in jars) {
                 logger.info("Reading from {}", jar)
-                MetaFix(jar).use { it.run() }
+                MetaFix(jar).use(MetaFix::run)
             }
         } catch (e: Exception) {
             rethrowAsUncheckedException(e)
@@ -68,7 +68,7 @@ open class MetaFixerTask : DefaultTask() {
     }
 
     @get:OutputFiles
-    val metafixed: FileCollection get() = project.files(jars.files.map(this::toMetaFixed))
+    val metafixed: FileCollection get() = project.files(jars.map(::toMetaFixed))
 
     private fun toMetaFixed(source: File) = File(outputDir, source.name.replace(JAR_PATTERN, "$suffix\$1"))
 

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/Utils.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/Utils.kt
@@ -14,7 +14,7 @@ import java.util.zip.ZipEntry.STORED
 import kotlin.math.max
 import kotlin.text.RegexOption.*
 
-internal val JAR_PATTERN = "(\\.jar)$".toRegex(IGNORE_CASE)
+internal val JAR_PATTERN = "(\\.jar)\$".toRegex(IGNORE_CASE)
 
 // Use the same constant file timestamp as Gradle.
 private val CONSTANT_TIME: FileTime = FileTime.fromMillis(

--- a/jar-filter/src/test/resources/abstract-function/build.gradle
+++ b/jar-filter/src/test/resources/abstract-function/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
 }
 

--- a/jar-filter/src/test/resources/delete-and-stub/build.gradle
+++ b/jar-filter/src/test/resources/delete-and-stub/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
 }
 

--- a/jar-filter/src/test/resources/delete-constructor/build.gradle
+++ b/jar-filter/src/test/resources/delete-constructor/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
 }
 

--- a/jar-filter/src/test/resources/delete-extension-val/build.gradle
+++ b/jar-filter/src/test/resources/delete-extension-val/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
 }
 

--- a/jar-filter/src/test/resources/delete-field/build.gradle
+++ b/jar-filter/src/test/resources/delete-field/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 }
 
 jar {

--- a/jar-filter/src/test/resources/delete-file-typealias/build.gradle
+++ b/jar-filter/src/test/resources/delete-file-typealias/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 }
 
 jar {

--- a/jar-filter/src/test/resources/delete-function/build.gradle
+++ b/jar-filter/src/test/resources/delete-function/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
 }
 

--- a/jar-filter/src/test/resources/delete-inner-lambda/build.gradle
+++ b/jar-filter/src/test/resources/delete-inner-lambda/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
 }
 

--- a/jar-filter/src/test/resources/delete-lazy/build.gradle
+++ b/jar-filter/src/test/resources/delete-lazy/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
 }
 

--- a/jar-filter/src/test/resources/delete-multifile/build.gradle
+++ b/jar-filter/src/test/resources/delete-multifile/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 }
 
 jar {

--- a/jar-filter/src/test/resources/delete-nested-class/build.gradle
+++ b/jar-filter/src/test/resources/delete-nested-class/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 }
 
 jar {

--- a/jar-filter/src/test/resources/delete-object/build.gradle
+++ b/jar-filter/src/test/resources/delete-object/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
 }
 

--- a/jar-filter/src/test/resources/delete-sealed-subclass/build.gradle
+++ b/jar-filter/src/test/resources/delete-sealed-subclass/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
 }
 

--- a/jar-filter/src/test/resources/delete-static-field/build.gradle
+++ b/jar-filter/src/test/resources/delete-static-field/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 }
 
 jar {

--- a/jar-filter/src/test/resources/delete-static-function/build.gradle
+++ b/jar-filter/src/test/resources/delete-static-function/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
 }
 

--- a/jar-filter/src/test/resources/delete-static-val/build.gradle
+++ b/jar-filter/src/test/resources/delete-static-val/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 }
 
 jar {

--- a/jar-filter/src/test/resources/delete-static-var/build.gradle
+++ b/jar-filter/src/test/resources/delete-static-var/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 }
 
 jar {

--- a/jar-filter/src/test/resources/delete-val-property/build.gradle
+++ b/jar-filter/src/test/resources/delete-val-property/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
 }
 

--- a/jar-filter/src/test/resources/delete-var-property/build.gradle
+++ b/jar-filter/src/test/resources/delete-var-property/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
 }
 

--- a/jar-filter/src/test/resources/interface-function/build.gradle
+++ b/jar-filter/src/test/resources/interface-function/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
 }
 

--- a/jar-filter/src/test/resources/remove-annotations/build.gradle
+++ b/jar-filter/src/test/resources/remove-annotations/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
 }
 

--- a/jar-filter/src/test/resources/sanitise-delete-constructor/build.gradle
+++ b/jar-filter/src/test/resources/sanitise-delete-constructor/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
 }
 

--- a/jar-filter/src/test/resources/sanitise-stub-constructor/build.gradle
+++ b/jar-filter/src/test/resources/sanitise-stub-constructor/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
 }
 

--- a/jar-filter/src/test/resources/stub-constructor/build.gradle
+++ b/jar-filter/src/test/resources/stub-constructor/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
 }
 

--- a/jar-filter/src/test/resources/stub-function/build.gradle
+++ b/jar-filter/src/test/resources/stub-function/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
 }
 

--- a/jar-filter/src/test/resources/stub-static-function/build.gradle
+++ b/jar-filter/src/test/resources/stub-static-function/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
 }
 

--- a/jar-filter/src/test/resources/stub-val-property/build.gradle
+++ b/jar-filter/src/test/resources/stub-val-property/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
 }
 

--- a/jar-filter/src/test/resources/stub-var-property/build.gradle
+++ b/jar-filter/src/test/resources/stub-var-property/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
-    id 'net.corda.plugins.jar-filter'
+    id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
 
@@ -16,7 +16,7 @@ sourceSets {
 }
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
 }
 


### PR DESCRIPTION
There is no functional change here; I have only tidied up some documentation and Kotlin/Gradle usage.
- Remove the Groovy `Closure` from JarFilter's DSL and replace it with a Kotlin `Action`.
- Fix regular expression for jars.
- Use fewer lambdas.
- Update the README now that `JarFilter` has been migrated out of Corda's `buildSrc`.
