### PR TITLE
CORDA-2171: Fix JarFilter deleting default lamba parameters for functions.

### DIFF
--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/FilterTransformer.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/FilterTransformer.kt
@@ -58,8 +58,8 @@ class FilterTransformer private constructor (
                   || super.hasUnwantedElements
 
     private fun isUnwantedClass(name: String): Boolean = unwantedElements.containsClass(name)
-    private fun hasDeletedSyntheticMethod(name: String): Boolean = deletedMethods.any { method ->
-        name.startsWith("$className\$${method.visibleName}\$")
+    private fun hasDeletedAnnotationsMethod(clsName: String): Boolean = deletedMethods.any { method ->
+        clsName.startsWith("$className\$${method.visibleName}\$") && method.isKotlinSynthetic("annotations")
     }
 
     override fun recreate(visitor: ClassVisitor) = FilterTransformer(
@@ -131,7 +131,7 @@ class FilterTransformer private constructor (
 
     override fun visitInnerClass(clsName: String, outerName: String?, innerName: String?, access: Int) {
         logger.debug("--- inner class {} [outer: {}, inner: {}]", clsName, outerName, innerName)
-        if (isUnwantedClass || hasDeletedSyntheticMethod(clsName)) {
+        if (isUnwantedClass || hasDeletedAnnotationsMethod(clsName)) {
             if (unwantedElements.addClass(clsName)) {
                 logger.info("- Deleted inner class {}", clsName)
             }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteOverloadedFunctionTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteOverloadedFunctionTest.kt
@@ -1,0 +1,82 @@
+package net.corda.gradle.jarfilter
+
+import net.corda.gradle.jarfilter.matcher.isFunction
+import org.assertj.core.api.Assertions.*
+import org.hamcrest.core.IsCollectionContaining.*
+import org.hamcrest.core.IsNot.*
+import org.junit.Assert.*
+import org.junit.ClassRule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.rules.TemporaryFolder
+import org.junit.rules.TestRule
+import kotlin.reflect.full.declaredFunctions
+import kotlin.test.assertFailsWith
+
+class DeleteOverloadedFunctionTest {
+    companion object {
+        private const val FUNCTION_CLASS = "net.corda.gradle.HasOverloadedFunction"
+        private const val LAMBDA_CLASS = "net.corda.gradle.HasOverloadWithLambda"
+
+        private val testProjectDir = TemporaryFolder()
+        private val testProject = JarFilterProject(testProjectDir, "delete-overloaded-function")
+        private val stringData1 = isFunction("stringData", String::class, String::class)
+        private val stringData2 = isFunction("stringData", String::class, Int::class, String::class)
+
+        @ClassRule
+        @JvmField
+        val rules: TestRule = RuleChain
+            .outerRule(testProjectDir)
+            .around(testProject)
+    }
+
+    @Test
+    fun deleteFunction() {
+        classLoaderFor(testProject.sourceJar).use { cl ->
+            with(cl.load<Any>(FUNCTION_CLASS)) {
+                newInstance().also {
+                    assertEquals(MESSAGE, getDeclaredMethod("stringData", String::class.java).invoke(it, MESSAGE))
+                    assertEquals("$NUMBER: $MESSAGE",
+                        getDeclaredMethod("stringData", Int::class.java, String::class.java).invoke(it, NUMBER, MESSAGE))
+                }
+                assertThat("stringData(String) not found", kotlin.declaredFunctions, hasItem(stringData1))
+                assertThat("stringData(Integer,String) not found", kotlin.declaredFunctions, hasItem(stringData2))
+            }
+        }
+
+        classLoaderFor(testProject.filteredJar).use { cl ->
+            with(cl.load<Any>(FUNCTION_CLASS)) {
+                newInstance().also {
+                    assertFailsWith<NoSuchMethodException> { getDeclaredMethod("stringData", String::class.java) }
+                    assertEquals("$NUMBER: $MESSAGE",
+                        getDeclaredMethod("stringData", Int::class.java, String::class.java).invoke(it, NUMBER, MESSAGE))
+                }
+                assertThat("stringData(String) still exists", kotlin.declaredFunctions, not(hasItem(stringData1)))
+                assertThat("stringData(Integer,String) not found", kotlin.declaredFunctions, hasItem(stringData2))
+            }
+        }
+    }
+
+    @Test
+    fun deleteFunctionWithLambda() {
+        classLoaderFor(testProject.sourceJar).use { cl ->
+            with(cl.load<Any>(LAMBDA_CLASS)) {
+                newInstance().also {
+                    assertEquals("[$MESSAGE]", getDeclaredMethod("lambdaData", String::class.java).invoke(it, MESSAGE))
+                    assertEquals("($NUMBER)", getDeclaredMethod("lambdaData", Int::class.java).invoke(it, NUMBER))
+                }
+                assertThat(kotlin.declaredFunctions).hasSize(2)
+            }
+        }
+
+        classLoaderFor(testProject.filteredJar).use { cl ->
+            with(cl.load<Any>(LAMBDA_CLASS)) {
+                newInstance().also {
+                    assertFailsWith<NoSuchMethodException> { getDeclaredMethod("lambdaData", String::class.java) }
+                    assertEquals("($NUMBER)", getDeclaredMethod("lambdaData", Int::class.java).invoke(it, NUMBER))
+                }
+                assertThat(kotlin.declaredFunctions).hasSize(1)
+            }
+        }
+    }
+}

--- a/jar-filter/src/test/resources/delete-overloaded-function/build.gradle
+++ b/jar-filter/src/test/resources/delete-overloaded-function/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'net.corda.plugins.jar-filter' apply false
+}
+apply from: 'repositories.gradle'
+
+sourceSets {
+    main {
+        kotlin {
+            srcDir files(
+                '../resources/test/delete-overloaded-function/kotlin',
+                '../resources/test/annotations/kotlin'
+            )
+        }
+    }
+}
+
+dependencies {
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+}
+
+jar {
+    baseName = 'delete-overloaded-function'
+}
+
+import net.corda.gradle.jarfilter.JarFilterTask
+task jarFilter(type: JarFilterTask) {
+    jars jar
+    annotations {
+        forDelete = ["net.corda.gradle.jarfilter.DeleteMe"]
+    }
+}

--- a/jar-filter/src/test/resources/delete-overloaded-function/kotlin/net/corda/gradle/HasOverloadedFunction.kt
+++ b/jar-filter/src/test/resources/delete-overloaded-function/kotlin/net/corda/gradle/HasOverloadedFunction.kt
@@ -1,0 +1,22 @@
+@file:Suppress("unused")
+package net.corda.gradle
+
+import net.corda.gradle.jarfilter.DeleteMe
+
+class HasOverloadedFunction {
+    @DeleteMe
+    @JvmOverloads
+    fun stringData(str: String = "<default-value>") = str
+
+    @JvmOverloads
+    fun stringData(number: Int, str: String = "<default-value>") = "$number: $str"
+}
+
+class HasOverloadWithLambda {
+    @DeleteMe
+    @JvmOverloads
+    fun lambdaData(str: String, action: (String) -> String = { s -> "[$s]" }) = action(str)
+
+    @JvmOverloads
+    fun lambdaData(value: Int, action: (String) -> String = { s -> "($s)" }) = action(value.toString())
+}


### PR DESCRIPTION
Only delete lambda inner classes that correspond to deleted (synthetic) "annotations holder" methods. Default lambda parameters can be deleted by observing when their "enclosing methods" are deleted instead.