### PR TITLE
Few signing options defaults to system properties first, then to hardcoded defaults (improvements for CORDA-1915).

### DIFF
--- a/cordapp/src/main/kotlin/net/corda/plugins/SignJar.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/SignJar.kt
@@ -12,7 +12,6 @@ import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
 
 open class SignJar : DefaultTask() {
-
     companion object {
         fun sign(project: Project, signing: Signing, file: File, enabled: Boolean = signing.enabled) {
             if (!enabled) {
@@ -23,11 +22,11 @@ open class SignJar : DefaultTask() {
             if (signing.options.hasDefaultOptions()) {
                 project.logger.info("CorDapp JAR signing with the default Corda development key, suitable for Corda running in development mode only.")
                 val keyStorePath = Utils.createTempFileFromResource(SigningOptions.DEFAULT_KEYSTORE, SigningOptions.DEFAULT_KEYSTORE_FILE, SigningOptions.DEFAULT_KEYSTORE_EXTENSION)
-                options["keystore"] = keyStorePath.toString()
+                options[SigningOptions.Key.KEYSTORE] = keyStorePath.toString()
             }
 
             val path = file.toPath()
-            options["jar"] = path.toString()
+            options[SigningOptions.Key.JAR] = path.toString()
 
             try {
                 project.ant.invokeMethod("signjar", options)
@@ -40,7 +39,7 @@ open class SignJar : DefaultTask() {
                         else "Run with --info or --debug option and search for 'ant:signjar' in log output. ", e)
             } finally {
                 if (signing.options.hasDefaultOptions()) {
-                    Paths.get(options["keystore"]).toFile().delete()
+                    Paths.get(options[SigningOptions.Key.KEYSTORE]).toFile().delete()
                 }
             }
         }

--- a/cordapp/src/main/kotlin/net/corda/plugins/Signing.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/Signing.kt
@@ -10,14 +10,14 @@ import javax.inject.Inject
 open class Signing @Inject constructor(objectFactory: ObjectFactory) {
 
     @get:Input
-    var enabled: Boolean = true
+    var enabled: Boolean = System.getProperty("signingEnabled", "true").toBoolean()
 
     fun enabled(value: Boolean) {
         enabled = value
     }
 
-    fun enabled(value: String?) {
-        enabled = value?.toBoolean() ?: true
+    fun enabled(value: String) {
+        enabled = value.toBoolean()
     }
 
     @get:Nested

--- a/cordapp/src/main/kotlin/net/corda/plugins/Signing.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/Signing.kt
@@ -1,16 +1,16 @@
 package net.corda.plugins
 
+import net.corda.plugins.SigningOptions.Companion.SYSTEM_PROPERTY_PREFIX
 import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
 import javax.inject.Inject
 
-/** JAR sign and control option. */
 open class Signing @Inject constructor(objectFactory: ObjectFactory) {
 
     @get:Input
-    var enabled: Boolean = System.getProperty("signingEnabled", "true").toBoolean()
+    var enabled: Boolean = System.getProperty(SYSTEM_PROPERTY_PREFIX + "enabled", "true").toBoolean()
 
     fun enabled(value: Boolean) {
         enabled = value

--- a/cordapp/src/main/kotlin/net/corda/plugins/SigningOptions.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/SigningOptions.kt
@@ -2,11 +2,10 @@ package net.corda.plugins
 
 import org.gradle.api.tasks.Input
 
-/** JAR sign options. */
-//Option used for ANT task "signjar"
+/** Options for ANT task "signjar". */
 open class SigningOptions {
     companion object {
-        // Defaults to resource/certificates/cordadevcakeys.jks keyStore with Corda development key
+        // Defaults to resource/certificates/cordadevcakeys.jks keystore with Corda development key
         private const val DEFAULT_ALIAS = "cordaintermediateca"
         private const val DEFAULT_STOREPASS = "cordacadevpass"
         private const val DEFAULT_STORETYPE = "JKS"
@@ -14,181 +13,148 @@ open class SigningOptions {
         const val DEFAULT_KEYSTORE = "certificates/cordadevcakeys.jks"
         const val DEFAULT_KEYSTORE_FILE = "cordadevcakeys"
         const val DEFAULT_KEYSTORE_EXTENSION = "jks"
+        const val SYSTEM_PROPERTY_PREFIX = "signing."
+    }
+
+    /** Option keys for ANT task. */
+    class Key {
+        companion object {
+            val JAR = "jar"
+            val ALIAS = "alias"
+            val STOREPASS = "storepass"
+            val KEYSTORE = "keystore"
+            val STORETYPE = "storetype"
+            val KEYPASS = "keypass"
+            val SIGFILE = "sigfile"
+            val SIGNEDJAR = "signedjar"
+            val VERBOSE = "verbose"
+            val STRICT = "strict"
+            val INTERNALSF = "internalsf"
+            val SECTIONSONLY = "sectionsonly"
+            val LAZY = "lazy"
+            val MAXMEMORY = "maxmemory"
+            val PRESERVELASTMODIFIED = "preservelastmodified"
+            val TSACERT = "tsaurl"
+            val TSAURL = "tsacert"
+            val TSAPROXYHOST = "tsaproxyhost"
+            val TSAPROXYPORT = "tsaproxyport"
+            val EXECUTABLE = "executable"
+            val FORCE = "force"
+            val SIGALG = "sigalg"
+            val DIGESTALG = "digestalg"
+            val TSADIGESTALG = "tsadigestalg"
+        }
     }
 
     @get:Input
-    var alias = System.getProperty("signingAlias", DEFAULT_ALIAS)
-
-    fun alias(value: String) {
-        alias = value
-    }
+    var alias = System.getProperty(SYSTEM_PROPERTY_PREFIX + Key.ALIAS, DEFAULT_ALIAS)
 
     @get:Input
-    var storepass = System.getProperty("signingStorepass", DEFAULT_STOREPASS)
-
-    fun storepass(value: String) {
-        storepass = value
-    }
+    var storepass = System.getProperty(SYSTEM_PROPERTY_PREFIX + Key.STOREPASS, DEFAULT_STOREPASS)
 
     @get:Input
-    var keystore = System.getProperty("signingKeystore", DEFAULT_KEYSTORE)
-
-    fun keystore(value: String) {
-        keystore = value
-    }
+    var keystore = System.getProperty(SYSTEM_PROPERTY_PREFIX + Key.KEYSTORE, DEFAULT_KEYSTORE)
 
     @get:Input
-    var storetype = System.getProperty("signingStoretype", DEFAULT_STORETYPE)
-
-    fun storetype(value: String) {
-        storetype = value
-    }
+    var storetype = System.getProperty(SYSTEM_PROPERTY_PREFIX + Key.STORETYPE, DEFAULT_STORETYPE)
 
     @get:Input
-    var keypass = System.getProperty("signingKeypass", DEFAULT_KEYPASS)
-
-    fun keypass(value: String) {
-        keypass = value
-    }
+    var keypass = System.getProperty(SYSTEM_PROPERTY_PREFIX + Key.KEYPASS, DEFAULT_KEYPASS)
 
     @get:Input
     var sigfile = ""
 
-    fun sigfile(value: String) {
-        sigfile = value
-    }
-
     @get:Input
     var signedjar = ""
-
-    fun signedjar(value: String) {
-        signedjar = value
-    }
 
     @get:Input
     var verbose = ""
 
-    fun verbose(value: String) {
-        verbose = value
+    fun verbose(value: Boolean) {
+        verbose = value.toString()
     }
 
     @get:Input
     var strict = ""
 
-    fun strict(value: String) {
-        strict = value
+    fun strict(value: Boolean) {
+        strict = value.toString()
     }
 
     @get:Input
     var internalsf = ""
 
-    fun internalsf(value: String) {
-        internalsf = value
+    fun internalsf(value: Boolean) {
+        internalsf = value.toString()
     }
 
     @get:Input
     var sectionsonly = ""
 
-    fun sectionsonly(value: String) {
-        sectionsonly = value
+    fun sectionsonly(value: Boolean) {
+        sectionsonly = value.toString()
     }
 
     @get:Input
     var lazy = ""
 
-    fun lazy(value: String) {
-        lazy = value
+    fun lazy(value: Boolean) {
+        lazy = value.toString()
     }
 
     @get:Input
     var maxmemory = ""
 
-    fun maxmemory(value: String) {
-        maxmemory = value
-    }
-
     @get:Input
     var preservelastmodified = ""
 
-    fun preservelastmodified(value: String) {
-        preservelastmodified = value
+    fun preservelastmodified(value: Boolean) {
+        preservelastmodified = value.toString()
     }
 
     @get:Input
     var tsaurl = ""
 
-    fun tsaurl(value: String) {
-        tsaurl = value
-    }
-
     @get:Input
     var tsacert = ""
-
-    fun tsacert(value: String) {
-        tsacert = value
-    }
 
     @get:Input
     var tsaproxyhost = ""
 
-    fun tsaproxyhost(value: String) {
-        tsaproxyhost = value
-    }
-
     @get:Input
     var tsaproxyport = ""
-
-    fun tsaproxyport(value: String) {
-        tsaproxyport = value
-    }
 
     @get:Input
     var executable = ""
 
-    fun executable(value: String) {
-        executable = value
-    }
-
     @get:Input
     var force = ""
 
-    fun force(value: String) {
-        force = value
+    fun force(value: Boolean) {
+        force = value.toString()
     }
 
     @get:Input
     var sigalg = ""
 
-    fun sigalg(value: String) {
-        sigalg = value
-    }
-
     @get:Input
     var digestalg = ""
 
-    fun digestalg(value: String) {
-        digestalg = value
-    }
-
     @get:Input
     var tsadigestalg = ""
-
-    fun tsadigestalg(value: String) {
-        tsadigestalg = value
-    }
 
     /**
      * Returns options as map.
      */
     fun toSignJarOptionsMap(): MutableMap<String, String> =
-            mapOf("alias" to alias, "storepass" to storepass, "keystore" to keystore,
-                    "storetype" to storetype, "keypass" to keypass, "sigfile" to sigfile,
-                    "signedjar" to signedjar, "verbose" to verbose, "strict" to strict,
-                    "internalsf" to internalsf, "sectionsonly" to sectionsonly, "lazy" to lazy,
-                    "maxmemory" to maxmemory, "preservelastmodified" to preservelastmodified,
-                    "tsaurl" to tsacert, "tsacert" to tsaurl, "tsaproxyhost" to tsaproxyhost,
-                    "tsaproxyport" to tsaproxyport, "executable" to executable, "force" to force,
-                    "sigalg" to sigalg, "digestalg" to digestalg, "tsadigestalg" to tsadigestalg)
+            mapOf(Key.ALIAS to alias, Key.STOREPASS to storepass, Key.KEYSTORE to keystore,
+                    Key.STORETYPE to storetype, Key.KEYPASS to keypass, Key.SIGFILE to sigfile,
+                    Key.SIGNEDJAR to signedjar, Key.VERBOSE to verbose, Key.STRICT to strict,
+                    Key.INTERNALSF to internalsf, Key.SECTIONSONLY to sectionsonly, Key.LAZY to lazy,
+                    Key.MAXMEMORY to maxmemory, Key.PRESERVELASTMODIFIED to preservelastmodified,
+                    Key.TSAURL to tsacert, Key.TSACERT to tsaurl, Key.TSAPROXYHOST to tsaproxyhost,
+                    Key.TSAPROXYPORT to tsaproxyport, Key.EXECUTABLE to executable, Key.FORCE to force,
+                    Key.SIGALG to sigalg, Key.DIGESTALG to digestalg, Key.TSADIGESTALG to tsadigestalg)
                     .filter { it.value.isNotBlank() }.toMutableMap()
 
     fun hasDefaultOptions() = keystore == DEFAULT_KEYSTORE

--- a/cordapp/src/main/kotlin/net/corda/plugins/SigningOptions.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/SigningOptions.kt
@@ -1,6 +1,8 @@
 package net.corda.plugins
 
+import org.gradle.api.tasks.Console
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 
 /** Options for ANT task "signjar". */
 open class SigningOptions {
@@ -19,30 +21,30 @@ open class SigningOptions {
     /** Option keys for ANT task. */
     class Key {
         companion object {
-            val JAR = "jar"
-            val ALIAS = "alias"
-            val STOREPASS = "storepass"
-            val KEYSTORE = "keystore"
-            val STORETYPE = "storetype"
-            val KEYPASS = "keypass"
-            val SIGFILE = "sigfile"
-            val SIGNEDJAR = "signedjar"
-            val VERBOSE = "verbose"
-            val STRICT = "strict"
-            val INTERNALSF = "internalsf"
-            val SECTIONSONLY = "sectionsonly"
-            val LAZY = "lazy"
-            val MAXMEMORY = "maxmemory"
-            val PRESERVELASTMODIFIED = "preservelastmodified"
-            val TSACERT = "tsaurl"
-            val TSAURL = "tsacert"
-            val TSAPROXYHOST = "tsaproxyhost"
-            val TSAPROXYPORT = "tsaproxyport"
-            val EXECUTABLE = "executable"
-            val FORCE = "force"
-            val SIGALG = "sigalg"
-            val DIGESTALG = "digestalg"
-            val TSADIGESTALG = "tsadigestalg"
+            const val JAR = "jar"
+            const val ALIAS = "alias"
+            const val STOREPASS = "storepass"
+            const val KEYSTORE = "keystore"
+            const val STORETYPE = "storetype"
+            const val KEYPASS = "keypass"
+            const val SIGFILE = "sigfile"
+            const val SIGNEDJAR = "signedjar"
+            const val VERBOSE = "verbose"
+            const val STRICT = "strict"
+            const val INTERNALSF = "internalsf"
+            const val SECTIONSONLY = "sectionsonly"
+            const val LAZY = "lazy"
+            const val MAXMEMORY = "maxmemory"
+            const val PRESERVELASTMODIFIED = "preservelastmodified"
+            const val TSACERT = "tsaurl"
+            const val TSAURL = "tsacert"
+            const val TSAPROXYHOST = "tsaproxyhost"
+            const val TSAPROXYPORT = "tsaproxyport"
+            const val EXECUTABLE = "executable"
+            const val FORCE = "force"
+            const val SIGALG = "sigalg"
+            const val DIGESTALG = "digestalg"
+            const val TSADIGESTALG = "tsadigestalg"
         }
     }
 
@@ -67,7 +69,7 @@ open class SigningOptions {
     @get:Input
     var signedjar = ""
 
-    @get:Input
+    @get:Console
     var verbose = ""
 
     fun verbose(value: Boolean) {
@@ -102,7 +104,7 @@ open class SigningOptions {
         lazy = value.toString()
     }
 
-    @get:Input
+    @get:Internal
     var maxmemory = ""
 
     @get:Input

--- a/cordapp/src/main/kotlin/net/corda/plugins/SigningOptions.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/SigningOptions.kt
@@ -16,193 +16,180 @@ open class SigningOptions {
         const val DEFAULT_KEYSTORE_EXTENSION = "jks"
     }
 
-    // Methods accept null value, this allows to use e.g. 'alias System.getProperty('key')' in Gradle configuration file,
-    // instead of requiring 'alias System.getProperty('key','')'
     @get:Input
-    var alias = ""
+    var alias = System.getProperty("signingAlias", DEFAULT_ALIAS)
 
-    fun alias(value: String?) {
-        alias = value ?: ""
+    fun alias(value: String) {
+        alias = value
     }
 
     @get:Input
-    var storepass = ""
+    var storepass = System.getProperty("signingStorepass", DEFAULT_STOREPASS)
 
-    fun storepass(value: String?) {
-        storepass = value ?: ""
+    fun storepass(value: String) {
+        storepass = value
     }
 
     @get:Input
-    var keystore = ""
+    var keystore = System.getProperty("signingKeystore", DEFAULT_KEYSTORE)
 
-    fun keystore(value: String?) {
-        keystore = value ?: ""
+    fun keystore(value: String) {
+        keystore = value
     }
 
     @get:Input
-    var storetype = ""
+    var storetype = System.getProperty("signingStoretype", DEFAULT_STORETYPE)
 
-    fun storetype(value: String?) {
-        storetype = value ?: ""
+    fun storetype(value: String) {
+        storetype = value
     }
 
     @get:Input
-    var keypass = ""
+    var keypass = System.getProperty("signingKeypass", DEFAULT_KEYPASS)
 
-    fun keypass(value: String?) {
-        keypass = value ?: ""
+    fun keypass(value: String) {
+        keypass = value
     }
 
     @get:Input
     var sigfile = ""
 
-    fun sigfile(value: String?) {
-        sigfile = value ?: ""
+    fun sigfile(value: String) {
+        sigfile = value
     }
 
     @get:Input
     var signedjar = ""
 
-    fun signedjar(value: String?) {
-        signedjar = value ?: ""
+    fun signedjar(value: String) {
+        signedjar = value
     }
 
     @get:Input
     var verbose = ""
 
-    fun verbose(value: String?) {
-        verbose = value ?: ""
+    fun verbose(value: String) {
+        verbose = value
     }
 
     @get:Input
     var strict = ""
 
-    fun strict(value: String?) {
-        strict = value ?: ""
+    fun strict(value: String) {
+        strict = value
     }
 
     @get:Input
     var internalsf = ""
 
-    fun internalsf(value: String?) {
-        internalsf = value ?: ""
+    fun internalsf(value: String) {
+        internalsf = value
     }
 
     @get:Input
     var sectionsonly = ""
 
-    fun sectionsonly(value: String?) {
-        sectionsonly = value ?: ""
+    fun sectionsonly(value: String) {
+        sectionsonly = value
     }
 
     @get:Input
     var lazy = ""
 
-    fun lazy(value: String?) {
-        lazy = value ?: ""
+    fun lazy(value: String) {
+        lazy = value
     }
 
     @get:Input
     var maxmemory = ""
 
-    fun maxmemory(value: String?) {
-        maxmemory = value ?: ""
+    fun maxmemory(value: String) {
+        maxmemory = value
     }
 
     @get:Input
     var preservelastmodified = ""
 
-    fun preservelastmodified(value: String?) {
-        preservelastmodified = value ?: ""
+    fun preservelastmodified(value: String) {
+        preservelastmodified = value
     }
 
     @get:Input
     var tsaurl = ""
 
-    fun tsaurl(value: String?) {
-        tsaurl = value ?: ""
+    fun tsaurl(value: String) {
+        tsaurl = value
     }
 
     @get:Input
     var tsacert = ""
 
-    fun tsacert(value: String?) {
-        tsacert = value ?: ""
+    fun tsacert(value: String) {
+        tsacert = value
     }
 
     @get:Input
     var tsaproxyhost = ""
 
-    fun tsaproxyhost(value: String?) {
-        tsaproxyhost = value ?: ""
+    fun tsaproxyhost(value: String) {
+        tsaproxyhost = value
     }
 
     @get:Input
     var tsaproxyport = ""
 
-    fun tsaproxyport(value: String?) {
-        tsaproxyport = value ?: ""
+    fun tsaproxyport(value: String) {
+        tsaproxyport = value
     }
 
     @get:Input
     var executable = ""
 
-    fun executable(value: String?) {
-        executable = value ?: ""
+    fun executable(value: String) {
+        executable = value
     }
 
     @get:Input
     var force = ""
 
-    fun force(value: String?) {
-        force = value ?: ""
+    fun force(value: String) {
+        force = value
     }
 
     @get:Input
     var sigalg = ""
 
-    fun sigalg(value: String?) {
-        sigalg = value ?: ""
+    fun sigalg(value: String) {
+        sigalg = value
     }
 
     @get:Input
     var digestalg = ""
 
-    fun digestalg(value: String?) {
-        digestalg = value ?: ""
+    fun digestalg(value: String) {
+        digestalg = value
     }
 
     @get:Input
     var tsadigestalg = ""
 
-    fun tsadigestalg(value: String?) {
-        tsadigestalg = value ?: ""
+    fun tsadigestalg(value: String) {
+        tsadigestalg = value
     }
 
     /**
-     * Returns options as map, if [keystore] was not provided then adds default values to missing
-     * [alias], [storepass], [keypass], [storetype] so default keystore can be accessed.
+     * Returns options as map.
      */
-    fun toSignJarOptionsMap(): MutableMap<String, String> {
-        // If default options are used then still add any provided options by user to allow experiment with default keyStore
-        val options = if (hasDefaultOptions()) mutableMapOf("alias" to DEFAULT_ALIAS,
-                "storepass" to DEFAULT_STOREPASS,
-                "keypass" to DEFAULT_KEYPASS,
-                "storetype" to DEFAULT_STORETYPE)
-        else mutableMapOf()
+    fun toSignJarOptionsMap(): MutableMap<String, String> =
+            mapOf("alias" to alias, "storepass" to storepass, "keystore" to keystore,
+                    "storetype" to storetype, "keypass" to keypass, "sigfile" to sigfile,
+                    "signedjar" to signedjar, "verbose" to verbose, "strict" to strict,
+                    "internalsf" to internalsf, "sectionsonly" to sectionsonly, "lazy" to lazy,
+                    "maxmemory" to maxmemory, "preservelastmodified" to preservelastmodified,
+                    "tsaurl" to tsacert, "tsacert" to tsaurl, "tsaproxyhost" to tsaproxyhost,
+                    "tsaproxyport" to tsaproxyport, "executable" to executable, "force" to force,
+                    "sigalg" to sigalg, "digestalg" to digestalg, "tsadigestalg" to tsadigestalg)
+                    .filter { it.value.isNotBlank() }.toMutableMap()
 
-        options += mapOf("alias" to alias, "storepass" to storepass, "keystore" to keystore,
-                "storetype" to storetype, "keypass" to keypass, "sigfile" to sigfile,
-                "signedjar" to signedjar, "verbose" to verbose, "strict" to strict,
-                "internalsf" to internalsf, "sectionsonly" to sectionsonly, "lazy" to lazy,
-                "maxmemory" to maxmemory, "preservelastmodified" to preservelastmodified,
-                "tsaurl" to tsacert, "tsacert" to tsaurl, "tsaproxyhost" to tsaproxyhost,
-                "tsaproxyport" to tsaproxyport, "executable" to executable, "force" to force,
-                "sigalg" to sigalg, "digestalg" to digestalg, "tsadigestalg" to tsadigestalg)
-                .filter { it.value.isNotBlank() }
-
-        return options
-    }
-
-    fun hasDefaultOptions() = keystore.isBlank()
+    fun hasDefaultOptions() = keystore == DEFAULT_KEYSTORE
 }

--- a/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
@@ -70,7 +70,7 @@ open class Baseform : DefaultTask() {
      * Configuration for keystore generation and JAR signing.
      */
     @Input
-    var signing: KeyGenAndSigning = project.objects.newInstance(KeyGenAndSigning::class.java)
+    val signing: KeyGenAndSigning = project.objects.newInstance(KeyGenAndSigning::class.java)
 
     fun signing(action: Action<in KeyGenAndSigning>) {
         action.execute(signing)

--- a/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
@@ -4,6 +4,7 @@ import groovy.lang.Closure
 import net.corda.plugins.SigningOptions.Companion.DEFAULT_KEYSTORE_EXTENSION
 import net.corda.plugins.SigningOptions.Companion.DEFAULT_KEYSTORE_FILE
 import net.corda.plugins.Utils.Companion.createTempFileFromResource
+import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.Input
@@ -66,14 +67,13 @@ open class Baseform : DefaultTask() {
     var nodeDefaults: Closure<in Node>? = null
 
     /**
-     * Options for sign Cordapp JARs and generate keyStore for it,
-     * by default all Cordapps are signed with default keyStore options.
+     * Configuration for keystore generation and JAR signing.
      */
     @Input
-    var signing: KeyGenAndSigning = KeyGenAndSigning()
+    var signing: KeyGenAndSigning = project.objects.newInstance(KeyGenAndSigning::class.java)
 
-    fun signing(configureClosure: Closure<in KeyGenAndSigning>) {
-        signing = project.configure(KeyGenAndSigning(), configureClosure) as KeyGenAndSigning
+    fun signing(action: Action<in KeyGenAndSigning>) {
+        action.execute(signing)
     }
 
     /**
@@ -187,8 +187,8 @@ open class Baseform : DefaultTask() {
 
         if (signing.generateKeystore && !signing.options.hasDefaultOptions()) {
             val genKeyTaskOptions = signing.options.toGenKeyOptionsMap()
-            if (Files.exists(Paths.get(genKeyTaskOptions["keystore"]))) {
-                logger.warn("Skipping keystore generation to sign Cordapps, the keystore already exists at '${genKeyTaskOptions["keystore"]}'.")
+            if (Files.exists(Paths.get(genKeyTaskOptions[SigningOptions.Key.KEYSTORE]))) {
+                logger.warn("Skipping keystore generation to sign Cordapps, the keystore already exists at '${genKeyTaskOptions[SigningOptions.Key.KEYSTORE]}'.")
             } else {
                 logger.info("Generating keystore to sign Cordapps with options: ${genKeyTaskOptions.map { "${it.key}=${it.value}" }.joinToString()}.")
                 project.ant.invokeMethod("genkey", genKeyTaskOptions)
@@ -198,13 +198,13 @@ open class Baseform : DefaultTask() {
         val signJarOptions = signing.options.toSignJarOptionsMap()
         if (signing.options.hasDefaultOptions()) {
             val keyStorePath = createTempFileFromResource(SigningOptions.DEFAULT_KEYSTORE, DEFAULT_KEYSTORE_FILE, DEFAULT_KEYSTORE_EXTENSION)
-            signJarOptions["keystore"] = keyStorePath.toString()
+            signJarOptions[SigningOptions.Key.KEYSTORE] = keyStorePath.toString()
         }
 
-        val jarsToSign = mutableListOf(project.tasks.getByName("jar").outputs.files.singleFile.toPath()) +
+        val jarsToSign = mutableListOf(project.tasks.getByName(SigningOptions.Key.JAR).outputs.files.singleFile.toPath()) +
                 if (signing.all) nodes.flatMap(Node::getCordappList).map { it.jarFile }.distinct() else emptyList()
         jarsToSign.forEach {
-            signJarOptions["jar"] = it.toString()
+            signJarOptions[SigningOptions.Key.JAR] = it.toString()
             project.ant.invokeMethod("signjar", signJarOptions)
         }
     }

--- a/cordformation/src/main/kotlin/net/corda/plugins/KeyGenAndSigning.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/KeyGenAndSigning.kt
@@ -1,30 +1,49 @@
 package net.corda.plugins
 
-import groovy.lang.Closure
+import org.gradle.api.Action
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.Input
-import org.gradle.util.ConfigureUtil
+import org.gradle.api.tasks.Nested
+import javax.inject.Inject
 
-/** JAR sign, keystore generation and overall signing control options. */
-open class KeyGenAndSigning {
+open class KeyGenAndSigning @Inject constructor(objectFactory: ObjectFactory) {
     @get:Input
     var enabled: Boolean = true
-        private set
-    fun enabled(value: Boolean) { enabled = value }
 
-    @get:Input
-    var options: KeyGenAndSigningOptions = KeyGenAndSigningOptions()
-        private set
-    fun options(configureClosure: Closure<in KeyGenAndSigningOptions>) {
-        options = ConfigureUtil.configure(configureClosure, options) as KeyGenAndSigningOptions
+    fun enabled(value: Boolean) {
+        enabled = value
+    }
+
+    fun enabled(value: String) {
+        enabled = value.toBoolean()
     }
 
     @get:Input
     var all: Boolean = true
-        private set
-    fun all(value: Boolean) { all = value }
+
+    fun all(value: Boolean) {
+        all = value
+    }
+
+    fun all(value: String) {
+        all = value.toBoolean()
+    }
 
     @get:Input
     var generateKeystore: Boolean = false
-        private set
-    fun generateKeystore(value: Boolean) { generateKeystore = value }
+
+    fun generateKeystore(value: Boolean) {
+        generateKeystore = value
+    }
+
+    fun generateKeystore(value: String) {
+        generateKeystore = value.toBoolean()
+    }
+
+    @get:Nested
+    var options: KeyGenAndSigningOptions = objectFactory.newInstance(KeyGenAndSigningOptions::class.java)
+
+    fun options(action: Action<in KeyGenAndSigningOptions>) {
+        action.execute(options)
+    }
 }

--- a/cordformation/src/main/kotlin/net/corda/plugins/KeyGenAndSigning.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/KeyGenAndSigning.kt
@@ -41,7 +41,7 @@ open class KeyGenAndSigning @Inject constructor(objectFactory: ObjectFactory) {
     }
 
     @get:Nested
-    var options: KeyGenAndSigningOptions = objectFactory.newInstance(KeyGenAndSigningOptions::class.java)
+    val options: KeyGenAndSigningOptions = objectFactory.newInstance(KeyGenAndSigningOptions::class.java)
 
     fun options(action: Action<in KeyGenAndSigningOptions>) {
         action.execute(options)

--- a/cordformation/src/main/kotlin/net/corda/plugins/KeyGenAndSigningOptions.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/KeyGenAndSigningOptions.kt
@@ -2,28 +2,34 @@ package net.corda.plugins
 
 import org.gradle.api.tasks.Input
 
-/** JAR sign and keystore generation options, with default values set for minimal required set. */
-//Option used for ANT tasks "genkey" and "signjar"
-class KeyGenAndSigningOptions : SigningOptions() {
+/** Options for ANT tasks "genkey" and "signjar". */
+open class KeyGenAndSigningOptions : SigningOptions() {
+    /** Additional option keys for ANT task. */
+    class Key {
+        companion object {
+            val KEYALG = "keyalg"
+            val DNAME = "dname"
+            val VALIDITY = "validity"
+            val KEYSIZE = "keysize"
+        }
+    }
 
     @get:Input
     var keyalg = "RSA"
-    fun keyalg(value: String) { keyalg = value }
 
     @get:Input
     var dname = ""
-    fun dname(value: String) { dname = value }
 
     @get:Input
     var validity = ""
-    fun validity(value: String) { validity = value }
 
     @get:Input
     var keysize = ""
-    fun keysize(value: String) { keysize = value }
 
-    fun toGenKeyOptionsMap() = mapOf("alias" to alias, "storepass" to storepass, "keystore" to keystore,
-            "storetype" to storetype, "keypass" to keypass, "sigalg" to sigalg, "keyalg" to keyalg,
-            "verbose" to verbose, "dname" to dname, "validity" to validity, "keysize" to keysize)
-            .filter { it.value.isNotBlank() }.toMutableMap()
+    fun toGenKeyOptionsMap(): MutableMap<String, String> =
+            mapOf(SigningOptions.Key.ALIAS to alias, SigningOptions.Key.STOREPASS to storepass,
+                    SigningOptions.Key.KEYSTORE to keystore, SigningOptions.Key.STORETYPE to storetype,
+                    SigningOptions.Key.KEYPASS to keypass, SigningOptions.Key.SIGALG to sigalg, SigningOptions.Key.VERBOSE to verbose,
+                    Key.KEYALG to keyalg, Key.DNAME to dname, Key.VALIDITY to validity, Key.KEYSIZE to keysize)
+                    .filter { it.value.isNotBlank() }.toMutableMap()
 }

--- a/cordformation/src/main/kotlin/net/corda/plugins/KeyGenAndSigningOptions.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/KeyGenAndSigningOptions.kt
@@ -7,10 +7,10 @@ open class KeyGenAndSigningOptions : SigningOptions() {
     /** Additional option keys for ANT task. */
     class Key {
         companion object {
-            val KEYALG = "keyalg"
-            val DNAME = "dname"
-            val VALIDITY = "validity"
-            val KEYSIZE = "keysize"
+            const val KEYALG = "keyalg"
+            const val DNAME = "dname"
+            const val VALIDITY = "validity"
+            const val KEYSIZE = "keysize"
         }
     }
 


### PR DESCRIPTION
Functional change: 
for few main `signing.options` the plugin tries to get a value from the relevant system property if the option is not set in the configuration entry, the system property name is 'signing.' + option name.
Refactorings:
String refactored to constants as some of them are used multiple times.
Removing redundant methods named as relevant property, for simple types both conventions works out-of-box (`key "value"` and `key="value"`).
Added methods with Boolean parameter for options which are true|false to enable (`key value` and not only `key "value"`).
Replace one 'instance' of Groovy `Closure` with Gradle `Action`.