### PR TITLE
Restrict Kotlin API to match the one that Gradle uses.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,12 @@ allprojects {
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
         kotlinOptions {
+            // When writing Gradle plugins in Kotlin, we need to restrict
+            // ourselves to the same Kotlin API that Gradle itself uses.
+            // Gradle 4.10.x uses Kotlin 1.2.
             jvmTarget = "1.8"
+            apiVersion = "1.2"
+            languageVersion = "1.2"
             freeCompilerArgs = ['-Xjvm-default=enable']
         }
     }


### PR DESCRIPTION
Enforce Gradle's API restriction for plugins written in Kotlin. No functional change.