### PR TITLE
CORDA-2096 Cordapp JAR sealing is optional

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ### Version 4.0.35
 
+* `cordapp`: New `sealing` entry allows to opt-out generation of sealed CorDapp JAR.
+
 ### Version 4.0.34
 
 * `cordapp`: New `SignJar` task allows to sign arbitrary JAR files by reusing `signing` configuration of the `Cordapp` plugin

--- a/cordapp/src/main/kotlin/net/corda/plugins/CordappExtension.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/CordappExtension.kt
@@ -14,10 +14,17 @@ open class CordappExtension @Inject constructor(objectFactory: ObjectFactory)  {
     val info: Info = objectFactory.newInstance(Info::class.java)
 
     /**
-     * Optional parameters for ANT signJar tasks to sign Cordapps
+     * Optional parameters for ANT signJar tasks to sign Cordapps.
      */
     @get:Nested
     val signing: Signing = objectFactory.newInstance(Signing::class.java)
+
+    /**
+     * Optional marker to seal all packages in the JAR.
+     */
+    @get:Nested
+    val sealing: Sealing = objectFactory.newInstance(Sealing::class.java)
+
 
     fun info(action: Action<in Info>) {
         action.execute(info)
@@ -25,5 +32,9 @@ open class CordappExtension @Inject constructor(objectFactory: ObjectFactory)  {
 
     fun signing(action: Action<in Signing>) {
         action.execute(signing)
+    }
+
+    fun sealing(action: Action<in Sealing>) {
+        action.execute(sealing)
     }
 }

--- a/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
@@ -60,7 +60,7 @@ class CordappPlugin : Plugin<Project> {
             if (attributes["Implementation-Vendor"] == UNKNOWN) {
                 project.logger.warn("CordApp's vendor is \"$UNKNOWN\". Please specify it in \"cordapp.info.vendor\".")
             }
-            if (cordapp.signing.enabled) {
+            if (cordapp.sealing.enabled) {
                 attributes["Sealed"] = "true"
             }
         }.doLast {

--- a/cordapp/src/main/kotlin/net/corda/plugins/Sealing.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/Sealing.kt
@@ -1,0 +1,17 @@
+package net.corda.plugins
+
+import org.gradle.api.tasks.Input
+
+open class Sealing {
+
+    @get:Input
+    var enabled: Boolean = System.getProperty( "sealing.enabled", "true").toBoolean()
+
+    fun enabled(value: Boolean) {
+        enabled = value
+    }
+
+    fun enabled(value: String) {
+        enabled = value.toBoolean()
+    }
+}


### PR DESCRIPTION
CORDA-2096 introduced obligatory JAR sealing when Jar is signed, create separate DSL entry `sealing` to allow disable sealing. Sealing is enabled by default.
```
cordapp {
  signing {
    //... 
  } 
   sealing {
      enabled true
   }
   //...
}