### PR TITLE
Small code-quality tweaks to JarFilter plugin.

### DIFF
--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/JarFilterTask.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/JarFilterTask.kt
@@ -164,6 +164,7 @@ open class JarFilterTask : DefaultTask() {
                         logger.info("No changes after latest pass - exiting.")
                         break
                     } else if (++passes > maxPasses) {
+                        logger.warn("Exceeded maximum number of passes ({}) - aborting!", maxPasses)
                         break
                     }
 

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/Utils.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/Utils.kt
@@ -21,7 +21,9 @@ private val CONSTANT_TIME: FileTime = FileTime.fromMillis(
     GregorianCalendar(1980, FEBRUARY, 1).apply { timeZone = TimeZone.getTimeZone("UTC") }.timeInMillis
 )
 
-internal fun rethrowAsUncheckedException(e: Exception): Nothing
+// Declared as inline to avoid polluting the exception stack trace.
+@Suppress("NOTHING_TO_INLINE")
+internal inline fun rethrowAsUncheckedException(e: Exception): Nothing
     = throw (e as? RuntimeException) ?: GradleException(e.message ?: "", e)
 
 /**


### PR DESCRIPTION
Simple changes for the `JarFilter` plugin:
- Log a warning when we exceed the maximum number of passes allowed through the filter.
- Inline `rethrowAsUncheckedException()` so that it doesn't appear in the exception stack trace.