### PR TITLE
CORDA-2414 Enforce CorDapp version identifier to be an integer.

### DIFF
--- a/cordapp/src/main/kotlin/net/corda/plugins/CordappData.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/CordappData.kt
@@ -7,7 +7,7 @@ open class CordappData {
     var name: String? = null
     /** relaxed type so users can specify Integer or String identifiers */
     @get:Input
-    var versionId: Any? = null
+    var versionId: Int? = null
     @get:Input
     var vendor: String? = null
     @get:Input

--- a/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
@@ -60,14 +60,14 @@ class CordappPlugin : Plugin<Project> {
                 // Corda 4 attributes support
                 if (!cordapp.contract.isEmpty()) {
                     attributes["Cordapp-Contract-Name"] = cordapp.contract.name ?: "${project.group}.${jarTask.baseName}"
-                    attributes["Cordapp-Contract-Version"] = parseVersion(cordapp.contract.versionId.toString())
+                    attributes["Cordapp-Contract-Version"] = checkCorDappVersionId(cordapp.contract.versionId)
                     attributes["Cordapp-Contract-Vendor"] = cordapp.contract.vendor ?: UNKNOWN
                     attributes["Cordapp-Contract-Licence"] = cordapp.contract.licence ?: UNKNOWN
                     skip = true
                 }
                 if (!cordapp.workflow.isEmpty()) {
                     attributes["Cordapp-Workflow-Name"] = cordapp.workflow.name ?: "${project.group}.${jarTask.baseName}"
-                    attributes["Cordapp-Workflow-Version"] = parseVersion(cordapp.workflow.versionId.toString())
+                    attributes["Cordapp-Workflow-Version"] = checkCorDappVersionId(cordapp.workflow.versionId)
                     attributes["Cordapp-Workflow-Vendor"] = cordapp.workflow.vendor ?: UNKNOWN
                     attributes["Cordapp-Workflow-Licence"] = cordapp.workflow.licence ?: UNKNOWN
                     skip = true
@@ -156,18 +156,13 @@ class CordappPlugin : Plugin<Project> {
         return Pair(targetPlatformVersion, minimumPlatformVersion)
     }
 
-    private fun parseVersion(versionStr: String?): Int {
-        if (versionStr == null)
+    private fun checkCorDappVersionId(versionId: Int?): Int {
+        if (versionId == null)
             throw InvalidUserDataException("Target versionId not specified. Please specify a whole number starting from 1.")
-        return try {
-            val version = Integer.parseInt(versionStr)
-            if (version < 1) {
-                throw InvalidUserDataException("Target versionId must not be smaller than 1.")
-            }
-            version
-        } catch (e: NumberFormatException) {
-            throw InvalidUserDataException("Version identifier must be a whole number starting from 1.")
+        else if (versionId < 1) {
+            throw InvalidUserDataException("Target versionId must not be smaller than 1.")
         }
+        return versionId
     }
 
     private fun Iterable<Dependency>.toUniqueFiles(configuration: Configuration): Set<File> {

--- a/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
@@ -146,21 +146,21 @@ class CordappPlugin : Plugin<Project> {
         // If the minimum platform version is not set, default to 1.
         val minimumPlatformVersion: Int = cordapp.minimumPlatformVersion ?: cordapp.info.minimumPlatformVersion ?: 1
         val targetPlatformVersion = cordapp.targetPlatformVersion ?: cordapp.info.targetPlatformVersion
-                ?: throw InvalidUserDataException("Target versionId was not set and could not be determined from the project's Corda dependency. Please specify the target versionId of your CorDapp.")
+                ?: throw InvalidUserDataException("CorDapp `targetPlatformVersion` was not specified in the `cordapp` metadata section.")
         if (targetPlatformVersion < 1) {
-            throw InvalidUserDataException("Target versionId must not be smaller than 1.")
+            throw InvalidUserDataException("CorDapp `targetPlatformVersion` must not be smaller than 1.")
         }
         if (targetPlatformVersion < minimumPlatformVersion) {
-            throw InvalidUserDataException("Target versionId must not be smaller than min platform versionId.")
+            throw InvalidUserDataException("CorDapp `targetPlatformVersion` must not be smaller than the `minimumPlatformVersion` ($minimumPlatformVersion)")
         }
         return Pair(targetPlatformVersion, minimumPlatformVersion)
     }
 
     private fun checkCorDappVersionId(versionId: Int?): Int {
         if (versionId == null)
-            throw InvalidUserDataException("Target versionId not specified. Please specify a whole number starting from 1.")
+            throw InvalidUserDataException("CorDapp `versionId` was not specified in the associated `contract` or `workflow` metadata section. Please specify a whole number starting from 1.")
         else if (versionId < 1) {
-            throw InvalidUserDataException("Target versionId must not be smaller than 1.")
+            throw InvalidUserDataException("CorDapp `versionId` must not be smaller than 1.")
         }
         return versionId
     }

--- a/cordapp/src/test/resources/net/corda/plugins/CorDappWithContractAndWorflowInfo.gradle
+++ b/cordapp/src/test/resources/net/corda/plugins/CorDappWithContractAndWorflowInfo.gradle
@@ -13,13 +13,13 @@ cordapp {
     targetPlatformVersion target_version_arg.toInteger()
     contract {
         name cordappContractName_info_arg
-        versionId cordappContractVersion_info_arg
+        versionId cordappContractVersion_info_arg.toInteger()
         vendor cordappContractVendor_info_arg
         licence cordappContractLicence_info_arg
     }
     workflow {
         name cordappWorkflowName_info_arg
-        versionId cordappWorkflowVersion_info_arg
+        versionId cordappWorkflowVersion_info_arg.toInteger()
         vendor cordappWorkflowVendor_info_arg
         licence cordappWorkflowLicence_info_arg
     }

--- a/cordapp/src/test/resources/net/corda/plugins/CorDappWithContractInfo.gradle
+++ b/cordapp/src/test/resources/net/corda/plugins/CorDappWithContractInfo.gradle
@@ -13,7 +13,7 @@ cordapp {
     targetPlatformVersion target_version_arg.toInteger()
     contract {
         name cordappContractName_info_arg
-        versionId cordappContractVersion_info_arg
+        versionId cordappContractVersion_info_arg.toInteger()
         vendor cordappContractVendor_info_arg
         licence cordappContractLicence_info_arg
     }

--- a/cordapp/src/test/resources/net/corda/plugins/CorDappWithInfoAll.gradle
+++ b/cordapp/src/test/resources/net/corda/plugins/CorDappWithInfoAll.gradle
@@ -21,13 +21,13 @@ cordapp {
     }
     contract {
         name cordappContractName_info_arg
-        versionId cordappContractVersion_info_arg
+        versionId cordappContractVersion_info_arg.toInteger()
         vendor cordappContractVendor_info_arg
         licence cordappContractLicence_info_arg
     }
     workflow {
         name cordappWorkflowName_info_arg
-        versionId cordappWorkflowVersion_info_arg
+        versionId cordappWorkflowVersion_info_arg.toInteger()
         vendor cordappWorkflowVendor_info_arg
         licence cordappWorkflowLicence_info_arg
     }

--- a/cordapp/src/test/resources/net/corda/plugins/CorDappWithWorkflowInfo.gradle
+++ b/cordapp/src/test/resources/net/corda/plugins/CorDappWithWorkflowInfo.gradle
@@ -13,7 +13,7 @@ cordapp {
     targetPlatformVersion target_version_arg.toInteger()
     workflow {
         name cordappWorkflowName_info_arg
-        versionId cordappWorkflowVersion_info_arg
+        versionId cordappWorkflowVersion_info_arg.toInteger()
         vendor cordappWorkflowVendor_info_arg
         licence cordappWorkflowLicence_info_arg
     }


### PR DESCRIPTION
Corda code processes version identifiers as integers.
Enforce this in the cordapp metadata.