### PR TITLE
Ensure that Gradle plugin tests have their own settings.gradle file.

### DIFF
--- a/cordapp/src/test/kotlin/net/corda/plugins/CordappTest.kt
+++ b/cordapp/src/test/kotlin/net/corda/plugins/CordappTest.kt
@@ -26,6 +26,7 @@ class CordappTest {
     @Before
     fun setup() {
         buildFile = testProjectDir.newFile("build.gradle")
+        installResource(testProjectDir, "settings.gradle")
         installResource(testProjectDir, "repositories.gradle")
     }
 

--- a/cordapp/src/test/resources/settings.gradle
+++ b/cordapp/src/test/resources/settings.gradle
@@ -1,0 +1,6 @@
+// Common settings for all Gradle test projects.
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+    }
+}

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterConfigurationTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterConfigurationTest.kt
@@ -27,7 +27,7 @@ class JarFilterConfigurationTest {
 
     @Before
     fun setup() {
-        testProjectDir.installResource("gradle.properties")
+        testProjectDir.installResources("gradle.properties", "settings.gradle")
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterTimestampTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterTimestampTest.kt
@@ -41,7 +41,7 @@ class JarFilterTimestampTest {
         private fun createTestProject() = TestRule { base, _ ->
             object : Statement() {
                 override fun evaluate() {
-                    testProjectDir.installResource("gradle.properties")
+                    testProjectDir.installResources("gradle.properties", "settings.gradle")
                     testProjectDir.newFile("build.gradle").writeText("""
                         |plugins {
                         |    id 'net.corda.plugins.jar-filter'

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConfigurationTests.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConfigurationTests.kt
@@ -20,7 +20,7 @@ class MetaFixConfigurationTests {
 
     @Before
     fun setup() {
-        testProjectDir.installResource("gradle.properties")
+        testProjectDir.installResources("gradle.properties", "settings.gradle")
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixTimestampTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixTimestampTest.kt
@@ -42,7 +42,7 @@ class MetaFixTimestampTest {
         private fun createTestProject() = TestRule { base, _ ->
             object : Statement() {
                 override fun evaluate() {
-                    testProjectDir.installResource("gradle.properties")
+                    testProjectDir.installResources("gradle.properties", "settings.gradle")
                     testProjectDir.newFile("build.gradle").writeText("""
                         |plugins {
                         |    id 'net.corda.plugins.jar-filter'

--- a/quasar-utils/src/test/groovy/net/corda/plugins/QuasarPluginTest.groovy
+++ b/quasar-utils/src/test/groovy/net/corda/plugins/QuasarPluginTest.groovy
@@ -1,6 +1,7 @@
 package net.corda.plugins
 
 import org.gradle.testkit.runner.GradleRunner
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -14,6 +15,11 @@ class QuasarPluginTest {
 
     @Rule
     public final TemporaryFolder testProjectDir = new TemporaryFolder()
+
+    @Before
+    void setup() {
+        Utilities.installResource(testProjectDir, "settings.gradle")
+    }
 
     @Test
     void checkDefaultVersionIsUsed() {

--- a/quasar-utils/src/test/groovy/net/corda/plugins/Utilities.groovy
+++ b/quasar-utils/src/test/groovy/net/corda/plugins/Utilities.groovy
@@ -1,0 +1,30 @@
+package net.corda.plugins
+
+import org.junit.rules.TemporaryFolder
+import java.nio.file.Files
+import java.nio.file.Path
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING
+
+class Utilities {
+    static long installResource(TemporaryFolder folder, String resourceName) {
+        File buildFile = folder.newFile(resourceName.substring(1 + resourceName.lastIndexOf('/')))
+        return copyResourceTo(resourceName, buildFile)
+    }
+
+    static long copyResourceTo(String resourceName, Path target) {
+        InputStream input = Utilities.class.classLoader.getResourceAsStream(resourceName)
+        if (input == null) {
+            throw new FileNotFoundException(resourceName)
+        }
+        try {
+            return Files.copy(input, target, REPLACE_EXISTING)
+        } finally {
+            input.close()
+        }
+    }
+
+    static long copyResourceTo(String resourceName, File  target) {
+        return copyResourceTo(resourceName, target.toPath())
+    }
+}

--- a/quasar-utils/src/test/resources/settings.gradle
+++ b/quasar-utils/src/test/resources/settings.gradle
@@ -1,0 +1,6 @@
+// Common settings for all Gradle test projects.
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+    }
+}


### PR DESCRIPTION
Ensure that our Gradle test projects all have their own `settings.gradle` files.
Gradle 5.x will insist on this, so lay the groundwork now.