### PR TITLE
Update changelog and publish 4.0.38

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        gradle_plugins_version = '4.0.38-SNAPSHOT'
+        gradle_plugins_version = '4.0.38'
         bouncycastle_version = '1.57'
         typesafe_config_version = '1.3.1'
         jsr305_version = '3.0.2'

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,14 @@
 
 ## Version 4
 
+### Version 4.0.39
+
 ### Version 4.0.38
+
+* `cordformation`: deployNodes does not attempt to sign any JARs unless explicitly configured to do so using `signing.enabled = true`
+* `cordapp`: enforce CorDapp `workflow` and `contract` version identifier metadata to be an integer.
+* `cordapp`: relax cordapp metadata checking (warn on missing metadata rather than failing-fast).
+   This allows multi-module structured CorDapps to only define metadata for flows and/or contracts modules.
 
 ### Version 4.0.37
 


### PR DESCRIPTION
Includes following changes:

- cordformation: deployNodes does not attempt to sign any JARs unless explicitly configured to do so using signing.enabled = true
- cordapp: enforce CorDapp workflow and contract version identifier metadata to be an integer.
- cordapp: relax cordapp metadata checking (warn on missing metadata rather than failing-fast).
This allows multi-module structured CorDapps to only define metadata for flows and/or contracts modules.