### PR TITLE
Update cordapp plugin to modify GenerateMavenPom tasks once the task-graph is ready.

### DIFF
--- a/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
@@ -120,8 +120,7 @@ class CordappPlugin : Plugin<Project> {
                 project.logger.info("Modifying task: ${task.name} in project ${project.path} to exclude all dependencies from pom")
                 val pom = task.pom
                 if (pom is MavenPomInternal) {
-                    val filteredPom = FilteredPom(pom)
-                    task.pom = filteredPom
+                    task.pom = FilteredPom(pom)
                 }
             }
         }

--- a/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
@@ -2,10 +2,7 @@ package net.corda.plugins
 
 import net.corda.plugins.SignJar.Companion.sign
 import net.corda.plugins.Utils.Companion.compareVersions
-import org.gradle.api.GradleException
-import org.gradle.api.InvalidUserDataException
-import org.gradle.api.Plugin
-import org.gradle.api.Project
+import org.gradle.api.*
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.java.archives.Attributes
@@ -118,15 +115,13 @@ class CordappPlugin : Plugin<Project> {
     }
 
     private fun configurePomCreation(project: Project) {
-        project.gradle.taskGraph.beforeTask { task ->
-            if (task.project == project && task.name.startsWith("generatePomFile")) {
-                task.doFirst { aboutToExecute ->
-                    project.logger.info("Modifying task: ${task.name} in project ${project.path} to exclude all dependencies from pom")
-                    val pom = (aboutToExecute as GenerateMavenPom).pom
-                    if (pom is MavenPomInternal) {
-                        val filteredPom = FilteredPom(pom)
-                        aboutToExecute.pom = filteredPom
-                    }
+        project.tasks.withType(GenerateMavenPom::class.java) { task ->
+            task.doFirst { _ ->
+                project.logger.info("Modifying task: ${task.name} in project ${project.path} to exclude all dependencies from pom")
+                val pom = task.pom
+                if (pom is MavenPomInternal) {
+                    val filteredPom = FilteredPom(pom)
+                    task.pom = filteredPom
                 }
             }
         }

--- a/cordapp/src/main/kotlin/net/corda/plugins/DelegatedPom.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/DelegatedPom.kt
@@ -1,143 +1,27 @@
-package net.corda.plugins;
+package net.corda.plugins
 
-import org.gradle.api.Action
-import org.gradle.api.XmlProvider
-import org.gradle.api.provider.Property
 import org.gradle.api.publish.maven.*
 import org.gradle.api.publish.maven.internal.dependencies.MavenDependencyInternal
-import org.gradle.api.publish.maven.internal.publication.MavenPomDistributionManagementInternal
 import org.gradle.api.publish.maven.internal.publication.MavenPomInternal
-import org.gradle.api.publish.maven.internal.publisher.MavenProjectIdentity
 
-open class DelegatedPom(
-    private val pom: MavenPomInternal
-) {
-    
-     fun withXml(action: Action<in XmlProvider>?) {
-        pom.withXml(action)
-    }
-     fun getContributors(): MutableList<MavenPomContributor>? {
-        return pom.contributors
-    }
-     fun issueManagement(action: Action<in MavenPomIssueManagement>?) {
-        pom.issueManagement(action)
-    }
-
-     fun getName(): Property<String>? {
-        return pom.name
-    }
-
-     fun getCiManagement(): MavenPomCiManagement? {
-        return pom.ciManagement
-    }
-
-     fun licenses(action: Action<in MavenPomLicenseSpec>?) {
-        pom.licenses(action)
-    }
-
-     fun distributionManagement(action: Action<in MavenPomDistributionManagement>?) {
-        pom.distributionManagement(action)
-    }
-
-     fun getOrganization(): MavenPomOrganization? {
-        return pom.organization
-    }
-
-     fun getPackaging(): String? {
-        return pom.packaging
-    }
-
-     fun getDescription(): Property<String>? {
-        return pom.description
-    }
-
-     fun getInceptionYear(): Property<String>? {
-        return pom.inceptionYear
-    }
-
-     fun ciManagement(action: Action<in MavenPomCiManagement>?) {
-        pom.ciManagement(action)
-    }
-
-     fun getUrl(): Property<String>? {
-        return pom.url
-    }
-
-     fun developers(action: Action<in MavenPomDeveloperSpec>?) {
-        pom.developers(action)
-    }
-
-     fun getXmlAction(): Action<XmlProvider>? {
-        return pom.xmlAction
-    }
-
-     fun getIssueManagement(): MavenPomIssueManagement? {
-        return pom.issueManagement
-    }
-
-     fun getMailingLists(): MutableList<MavenPomMailingList>? {
-        return pom.mailingLists
-    }
-
-     fun getRuntimeDependencyManagement(): MutableSet<MavenDependency>? {
+open class DelegatedPom(pom: MavenPomInternal): MavenPomInternal by pom {
+    override fun getRuntimeDependencyManagement(): MutableSet<MavenDependency> {
         //for now, just return empty set, but in future if we do allow cordapps to have dependencies outside of corda
         //something along the lines of:
         // val depsToExclude: Set<Pair<String, String>> = projectDepCalculator(project)
         // return pom.runtimeDependencyManagement.filterNot { toExcludableDependency(it) in depsToExclude}.toHashSet()
-        return HashSet()
+        return hashSetOf()
     }
 
-     fun getRuntimeDependencies(): MutableSet<MavenDependencyInternal>? {
-        return HashSet()
+    override fun getRuntimeDependencies(): MutableSet<MavenDependencyInternal> {
+        return hashSetOf()
     }
 
-     fun getApiDependencyManagement(): MutableSet<MavenDependency>? {
-        return HashSet()
+    override fun getApiDependencyManagement(): MutableSet<MavenDependency> {
+        return hashSetOf()
     }
 
-     fun getApiDependencies(): MutableSet<MavenDependencyInternal>? {
-        return HashSet()
+    override fun getApiDependencies(): MutableSet<MavenDependencyInternal> {
+        return hashSetOf()
     }
-
-     fun getDevelopers(): MutableList<MavenPomDeveloper>? {
-        return pom.developers
-    }
-
-     fun getProjectIdentity(): MavenProjectIdentity? {
-        return pom.projectIdentity
-    }
-
-     fun mailingLists(action: Action<in MavenPomMailingListSpec>?) {
-        pom.mailingLists(action)
-    }
-
-     fun organization(action: Action<in MavenPomOrganization>?) {
-        pom.organization(action)
-    }
-
-     fun getLicenses(): MutableList<MavenPomLicense>? {
-        return pom.licenses
-    }
-
-     fun getDistributionManagement(): MavenPomDistributionManagementInternal? {
-        return pom.distributionManagement
-    }
-
-     fun scm(action: Action<in MavenPomScm>?) {
-        pom.scm(action)
-    }
-
-     fun setPackaging(packaging: String?) {
-        pom.packaging = packaging
-    }
-
-     fun contributors(action: Action<in MavenPomContributorSpec>?) {
-        pom.contributors(action)
-    }
-
-     fun getScm(): MavenPomScm? {
-        return pom.scm
-    }
-
-
 }

--- a/cordapp/src/main/kotlin/net/corda/plugins/Utils.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/Utils.kt
@@ -15,7 +15,6 @@ import kotlin.math.max
 @Suppress("UNCHECKED_CAST")
 fun <T : Any> Project.ext(name: String): T = (extensions.findByName("ext") as ExtraPropertiesExtension).get(name) as T
 fun Project.configuration(name: String): Configuration = configurations.single { it.name == name }
-fun Project.configurationsWithPrefix(prefix: String): List<Configuration> = configurations.filter { it.name.startsWith(prefix) }
 
 class Utils {
     companion object {


### PR DESCRIPTION
We need to be _sure_ that Gradle has finished creating the entire project's dynamic tasks before we can reasonably expect to find any `GenerateMavenPom` tasks. Gradle provides the
```kotlin
withType(Class<S> type, Action<? super S> configureAction)
```
API for _precisely_ this purpose. (And I really should have remembered this before now  :man_facepalming:).