### PR TITLE
CORDA-2474: Remove Kotlin library from published POMs for Kotlin plugins.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,11 +39,11 @@ allprojects {
     version gradle_plugins_version
     group 'net.corda.plugins'
 
-    tasks.withType(JavaCompile).all {
+    tasks.withType(JavaCompile) {
         options.encoding = 'UTF-8'
     }
 
-    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
         kotlinOptions {
             // When writing Gradle plugins in Kotlin, we need to restrict
             // ourselves to the same Kotlin API that Gradle itself uses.

--- a/cordapp/build.gradle
+++ b/cordapp/build.gradle
@@ -32,8 +32,12 @@ pluginBundle {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    testCompile "commons-io:commons-io:$commons_io_version"
-    testCompile "junit:junit:$junit_version" // TODO: Unify with core
-    testCompile "org.assertj:assertj-core:$assertj_version"
+    // Gradle plugins written in Kotlin will always use Gradle's
+    // own provided Kotlin libraries at runtime. So ensure that
+    // we don't add Kotlin as a dependency in our published POM.
+    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    testImplementation "org.jetbrains.kotlin:kotlin-test-junit"
+    testImplementation "commons-io:commons-io:$commons_io_version"
+    testImplementation "junit:junit:$junit_version" // TODO: Unify with core
+    testImplementation "org.assertj:assertj-core:$assertj_version"
 }

--- a/cordformation/build.gradle
+++ b/cordformation/build.gradle
@@ -9,7 +9,6 @@ repositories {
 
 configurations {
     noderunner
-    compile.extendsFrom noderunner
 }
 
 sourceSets {
@@ -46,14 +45,18 @@ pluginBundle {
 
 dependencies {
     compile project(":cordapp")
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    // Gradle plugins written in Kotlin will always use Gradle's
+    // own provided Kotlin libraries at runtime. So ensure that
+    // we don't add Kotlin as a dependency in our published POM.
+    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     compile "commons-io:commons-io:$commons_io_version"
     compile "com.typesafe:config:$typesafe_config_version"
 
     noderunner "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    testCompile "junit:junit:$junit_version" // TODO: Unify with core
-    testCompile "org.assertj:assertj-core:$assertj_version"
+    testImplementation "org.jetbrains.kotlin:kotlin-test-junit"
+    testImplementation "junit:junit:$junit_version" // TODO: Unify with core
+    testImplementation "org.assertj:assertj-core:$assertj_version"
     // Docker-compose file generation
     compile "org.yaml:snakeyaml:$snake_yaml_version"
 }

--- a/jar-filter/build.gradle
+++ b/jar-filter/build.gradle
@@ -44,8 +44,13 @@ configurations {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    implementation "org.jetbrains.kotlinx:kotlinx-metadata-jvm:$kotlin_metadata_version"
+    // Gradle plugins written in Kotlin will always use Gradle's
+    // own provided Kotlin libraries at runtime. So ensure that
+    // we don't add Kotlin as a dependency in our published POM.
+    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm:$kotlin_metadata_version") {
+        exclude group: 'org.jetbrains.kotlin'
+    }
     implementation "org.ow2.asm:asm:$asm_version"
 
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit"


### PR DESCRIPTION
Gradle plugins written in Kotlin will use Gradle's own provided Kotlin libraries and so should not be published with dependencies on different ones.