### PR TITLE
Some license and notice files have extensions

### DIFF
--- a/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
@@ -63,16 +63,16 @@ class CordappPlugin : Plugin<Project> {
         }
 
         task.doLast {
-            jarTask.from(getDirectNonCordaDependencies(project).map {
-                project.logger.info("CorDapp dependency: ${it.name}")
-                project.zipTree(it)
+            jarTask.from(getDirectNonCordaDependencies(project).map {file ->
+                project.logger.info("CorDapp dependency: ${file.name}")
+                project.zipTree(file)
             }).apply {
                 exclude("META-INF/*.SF")
                 exclude("META-INF/*.DSA")
                 exclude("META-INF/*.RSA")
                 exclude("META-INF/*.MF")
-                exclude("META-INF/LICENSE")
-                exclude("META-INF/NOTICE")
+                exclude("META-INF/LICENSE*")
+                exclude("META-INF/NOTICE*")
                 exclude("META-INF/INDEX.LIST")
             }
         }


### PR DESCRIPTION
Some LICENSE files have extensions (such as .txt and .md), these should be excluded in the same way that LICENSE was excluded. Similarly for NOTICE, the file extension should not be considered when determining whether or not to include it in the JAR.

Note that I'm seeing a build failure when attempting to build it locally, but I'm seeing this error on `master` as well:
```
Included projects: [root project 'junit4380683632756613633']

> Configure project :
Evaluating root project 'junit4380683632756613633' using build file 'C:\Users\egeek\Development\r3\corda-gradle-plugins\cordformation\build\junit4380683632756613633\build.gradle'.
Compiling build file 'C:\Users\egeek\Development\r3\corda-gradle-plugins\cordformation\build\junit4380683632756613633\build.gradle' using SubsetScriptTransformer.
Compiling build file 'C:\Users\egeek\Development\r3\corda-gradle-plugins\cordformation\build\junit4380683632756613633\build.gradle' using BuildScriptTransformer.

FAILURE: Build failed with an exception.

* Where:
Build file 'C:\Users\egeek\Development\r3\corda-gradle-plugins\cordformation\build\junit4380683632756613633\build.gradle' line: 37

* What went wrong:
A problem occurred evaluating root project 'junit4380683632756613633'.
> Could not find method cordapp() for arguments [build_5gms8ekgk0b4aw9vc62v59kb8$_run_closure4$_closure8$_closure9@4d59efdf] on object of type net.corda.plugins.Node.

* Try:
Run with --debug option to get more log output. Run with --scan to get full insights.

* Exception is:
org.gradle.api.GradleScriptException: A problem occurred evaluating root project 'junit4380683632756613633'.
	at org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java:92)
	at org.gradle.configuration.DefaultScriptPluginFactory$ScriptPluginImpl$2.run(DefaultScriptPluginFactory.java:206)
	at org.gradle.configuration.ProjectScriptTarget.addConfiguration(ProjectScriptTarget.java:77)
	at org.gradle.configuration.DefaultScriptPluginFactory$ScriptPluginImpl.apply(DefaultScriptPluginFactory.java:211)
...
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:46)
	at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:55)
Caused by: org.gradle.internal.metaobject.AbstractDynamicObject$CustomMessageMissingMethodException: Could not find method cordapp() for arguments [build_5gms8ekgk0b4aw9vc62v59kb8$_run_closure4$_closure8$_closure9@4d59efdf] on object of type net.corda.plugins.Node.
	at org.gradle.internal.metaobject.AbstractDynamicObject.methodMissingException(AbstractDynamicObject.java:179)
	at org.gradle.internal.metaobject.ConfigureDelegate.invokeMethod(ConfigureDelegate.java:87)
...
```
It seems it's trying to use Corda 3 and a method is missing?