### PR TITLE
CORDA-2612: Use Network Bootstapper with test runtime classpath.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ### Version 4.0.40
 
+* `cordformation`: `deployNodes` now works from the test runtime classpath.
+
 ### Version 4.0.39
 
 * `api-scanner`: allow to exclude methods from the API report

--- a/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
@@ -220,7 +220,7 @@ open class Baseform : DefaultTask() {
 
     protected fun bootstrapNetwork() {
         loadNetworkBootstrapper().use { cl ->
-            val networkBootstrapperClass: Class<*> = cl.loadClass("net.corda.nodeapi.internal.network.NetworkBootstrapper")
+            val networkBootstrapperClass = cl.loadNetworkBootstrapper()
             val networkBootstrapper = networkBootstrapperClass.newInstance()
             val bootstrapMethod = networkBootstrapperClass.getMethod("bootstrapCordform", Path::class.java, List::class.java).apply { isAccessible = true }
             val allCordapps = nodes.flatMap(Node::getCordappList).map(Node.ResolvedCordapp::jarFile).distinct()
@@ -231,6 +231,14 @@ open class Baseform : DefaultTask() {
             } catch (e: InvocationTargetException) {
                 throw e.cause!!.let { InvalidUserCodeException(it.message ?: "", it) }
             }
+        }
+    }
+
+    private fun ClassLoader.loadNetworkBootstrapper(): Class<*> {
+        return try {
+            loadClass("net.corda.nodeapi.internal.network.NetworkBootstrapper")
+        } catch (e: ClassNotFoundException) {
+            throw InvalidUserCodeException("Cannot find the NetworkBootstrapper class. Please ensure that 'corda-node-api' is available on Gradle's test runtime classpath.", e)
         }
     }
 }

--- a/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
@@ -6,13 +6,14 @@ import net.corda.plugins.SigningOptions.Companion.DEFAULT_KEYSTORE_FILE
 import net.corda.plugins.Utils.Companion.createTempFileFromResource
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
+import org.gradle.api.InvalidUserCodeException
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME
+import org.gradle.api.tasks.SourceSet.TEST_SOURCE_SET_NAME
 import java.io.File
 import java.lang.reflect.InvocationTargetException
 import java.net.URLClassLoader
@@ -29,11 +30,10 @@ import java.nio.file.Paths
 open class Baseform : DefaultTask() {
     private companion object {
         const val nodeJarName = "corda.jar"
-        private val defaultDirectory: Path = Paths.get("build", "nodes")
     }
 
     @Input
-    var directory = defaultDirectory
+    var directory: Path = project.buildDir.toPath().resolve("nodes")
 
     @Nested
     protected val nodes = mutableListOf<Node>()
@@ -122,13 +122,13 @@ open class Baseform : DefaultTask() {
     private fun getNodeByName(name: String): Node? = nodes.firstOrNull { it.name == name }
 
     /**
-     * The NetworkBootstrapper needn't be compiled until just before our build method, so we load it manually via sourceSets.main.runtimeClasspath.
+     * The NetworkBootstrapper needn't be compiled until just before our build method, so we load it manually via sourceSets.test.runtimeClasspath.
      */
-    private fun loadNetworkBootstrapperClass(): Class<*> {
+    private fun loadNetworkBootstrapper(): URLClassLoader {
         val plugin = project.convention.getPlugin(JavaPluginConvention::class.java)
-        val classpath = plugin.sourceSets.getByName(MAIN_SOURCE_SET_NAME).runtimeClasspath
+        val classpath = plugin.sourceSets.getByName(TEST_SOURCE_SET_NAME).runtimeClasspath
         val urls = classpath.files.map { it.toURI().toURL() }.toTypedArray()
-        return URLClassLoader(urls).loadClass("net.corda.nodeapi.internal.network.NetworkBootstrapper")
+        return URLClassLoader(urls)
     }
 
     /**
@@ -158,7 +158,7 @@ open class Baseform : DefaultTask() {
     }
 
     private fun deleteRootDir() {
-        project.logger.info("Deleting $directory")
+        project.logger.lifecycle("Deleting $directory")
         project.delete(directory)
     }
 
@@ -167,7 +167,7 @@ open class Baseform : DefaultTask() {
      */
     protected fun generateExcludedWhitelist() {
         if (excludeWhitelist.isNotEmpty()) {
-            var fileName = "exclude_whitelist.txt"
+            val fileName = "exclude_whitelist.txt"
             logger.debug("Adding $excludeWhitelist to $fileName.")
             val rootDir = Paths.get(project.projectDir.toPath().resolve(directory).resolve(fileName).toAbsolutePath().normalize().toString())
             Files.write(rootDir, excludeWhitelist)
@@ -191,7 +191,7 @@ open class Baseform : DefaultTask() {
             if (Files.exists(Paths.get(genKeyTaskOptions[SigningOptions.Key.KEYSTORE]))) {
                 logger.warn("Skipping keystore generation to sign Cordapps, the keystore already exists at '${genKeyTaskOptions[SigningOptions.Key.KEYSTORE]}'.")
             } else {
-                logger.info("Generating keystore to sign Cordapps with options: ${genKeyTaskOptions.map { "${it.key}=${it.value}" }.joinToString()}.")
+                logger.lifecycle("Generating keystore to sign Cordapps with options: ${genKeyTaskOptions.map { "${it.key}=${it.value}" }.joinToString()}.")
                 project.ant.invokeMethod("genkey", genKeyTaskOptions)
             }
         }
@@ -203,7 +203,7 @@ open class Baseform : DefaultTask() {
         }
 
         val jarsToSign = mutableListOf(project.tasks.getByName(SigningOptions.Key.JAR).outputs.files.singleFile.toPath()) +
-                if (signing.all) nodes.flatMap(Node::getCordappList).map { it.jarFile }.distinct() else emptyList()
+                if (signing.all) nodes.flatMap(Node::getCordappList).map(Node.ResolvedCordapp::jarFile).distinct() else emptyList()
         jarsToSign.forEach {
             signJarOptions[SigningOptions.Key.JAR] = it.toString()
             try{
@@ -219,16 +219,18 @@ open class Baseform : DefaultTask() {
     }
 
     protected fun bootstrapNetwork() {
-        val networkBootstrapperClass = loadNetworkBootstrapperClass()
-        val networkBootstrapper = networkBootstrapperClass.newInstance()
-        val bootstrapMethod = networkBootstrapperClass.getMethod("bootstrapCordform", Path::class.java, List::class.java).apply { isAccessible = true }
-        val allCordapps = nodes.flatMap(Node::getCordappList).map { it.jarFile }.distinct()
-        val rootDir = project.projectDir.toPath().resolve(directory).toAbsolutePath().normalize()
-        try {
-            // Call NetworkBootstrapper.bootstrap
-            bootstrapMethod.invoke(networkBootstrapper, rootDir, allCordapps)
-        } catch (e: InvocationTargetException) {
-            throw e.cause!!
+        loadNetworkBootstrapper().use { cl ->
+            val networkBootstrapperClass: Class<*> = cl.loadClass("net.corda.nodeapi.internal.network.NetworkBootstrapper")
+            val networkBootstrapper = networkBootstrapperClass.newInstance()
+            val bootstrapMethod = networkBootstrapperClass.getMethod("bootstrapCordform", Path::class.java, List::class.java).apply { isAccessible = true }
+            val allCordapps = nodes.flatMap(Node::getCordappList).map(Node.ResolvedCordapp::jarFile).distinct()
+            val rootDir = project.projectDir.toPath().resolve(directory).toAbsolutePath().normalize()
+            try {
+                // Call NetworkBootstrapper.bootstrap
+                bootstrapMethod.invoke(networkBootstrapper, rootDir, allCordapps)
+            } catch (e: InvocationTargetException) {
+                throw e.cause!!.let { InvalidUserCodeException(it.message ?: "", it) }
+            }
         }
     }
 }

--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordform.kt
@@ -57,7 +57,7 @@ open class Cordform : Baseform() {
      */
     @TaskAction
     fun build() {
-        project.logger.info("Running Cordform task")
+        project.logger.lifecycle("Running Cordform task")
         initializeConfiguration()
         nodes.forEach(Node::installConfig)
         installCordaJar()

--- a/cordformation/src/main/kotlin/net/corda/plugins/Dockerform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Dockerform.kt
@@ -39,7 +39,7 @@ open class Dockerform : Baseform() {
      */
     @TaskAction
     fun build() {
-        project.logger.info("Running Cordform task")
+        project.logger.lifecycle("Running Cordform task")
         initializeConfiguration()
         nodes.forEach(Node::installDockerConfig)
         installCordaJar()

--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -373,7 +373,7 @@ open class Node @Inject constructor(private val project: Project) {
 
     internal fun installCordapps() {
         val cordappsDir = nodeDir.toPath().resolve("cordapps")
-        val nodeCordapps = getCordappList().map { it.jarFile }.distinct()
+        val nodeCordapps = getCordappList().map(Node.ResolvedCordapp::jarFile).distinct()
         nodeCordapps.map { nodeCordapp ->
             project.copy {
                 it.apply {
@@ -393,7 +393,7 @@ open class Node @Inject constructor(private val project: Project) {
         // with loading our custom X509EdDSAEngine.
         val organizationName = name!!.trim().split(",").firstOrNull { it.startsWith("O=") }?.substringAfter("=")
         val dirName = organizationName ?: name
-        containerName = dirName!!.replace("\\s+".toRegex(), "-").toLowerCase()
+        containerName = dirName!!.replace("\\s++".toRegex(), "-").toLowerCase()
         this.rootDir = rootDir.toFile()
         nodeDir = File(this.rootDir, dirName.replace("\\s", ""))
         Files.createDirectories(nodeDir.toPath())
@@ -431,10 +431,10 @@ open class Node @Inject constructor(private val project: Project) {
     private fun installWebserverJar() {
         // If no webserver JAR is provided, the default development webserver is used.
         val webJar = if (webserverJar == null) {
-            project.logger.info("Using default development webserver.")
+            project.logger.lifecycle("Using default development webserver.")
             Cordformation.verifyAndGetRuntimeJar(project, "corda-webserver")
         } else {
-            project.logger.info("Using custom webserver: $webserverJar.")
+            project.logger.lifecycle("Using custom webserver: $webserverJar.")
             File(webserverJar)
         }
 
@@ -469,7 +469,7 @@ open class Node @Inject constructor(private val project: Project) {
 
     internal fun installDrivers() {
         drivers?.let {
-            project.logger.info("Copy $it to './drivers' directory")
+            project.logger.lifecycle("Copy $it to './drivers' directory")
             it.forEach { path -> copyToDriversDir(File(path)) }
         }
     }


### PR DESCRIPTION
The CordFormation plugin currently uses the `main` runtime classpath for the Network Bootstrapper. While the Bootstrapper will _probably_ have been included via either the `cordaCompile` or `cordaRuntime` configurations, there is still no way for us to include any other jars such as a SLF4J logging back-end. So switch to using the `test` runtime classpath here, and ensure that we close the classloader afterwards.