### PR TITLE
CORDA-2676: Unregister all SecurityProvider instances installed by Network Bootstrapper.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@
 
 ### Version 5.0.0
 
+* `cordformation`: Unload `SecurityProvider` instances installed by Network Bootstrapper to prevent linkage exceptions later.
+
+* `cordformation`: Revert `deployNodes` back to using the runtime classpath again. Anything needed solely by `deployNodes` can be added to Gradle's `runtimeOnly` configuration instead.
+
 * `cordformation`: Add Jolokia agent to the `cordaRuntime` configuration to prevent the `cordapp` plugin from including it inside the CorDapp.
 
 ## Version 4

--- a/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
@@ -13,13 +13,14 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.SourceSet.TEST_SOURCE_SET_NAME
+import org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME
 import java.io.File
 import java.lang.reflect.InvocationTargetException
 import java.net.URLClassLoader
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.security.Security
 
 /**
  * Creates nodes based on the configuration of this task in the gradle configuration DSL.
@@ -122,13 +123,15 @@ open class Baseform : DefaultTask() {
     private fun getNodeByName(name: String): Node? = nodes.firstOrNull { it.name == name }
 
     /**
-     * The NetworkBootstrapper needn't be compiled until just before our build method, so we load it manually via sourceSets.test.runtimeClasspath.
+     * The NetworkBootstrapper needn't be compiled until just before our build method,
+     * so we load it manually via sourceSets.main.runtimeClasspath.
      */
-    private fun loadNetworkBootstrapper(): URLClassLoader {
+    private fun createNetworkBootstrapperLoader(): URLClassLoader {
         val plugin = project.convention.getPlugin(JavaPluginConvention::class.java)
-        val classpath = plugin.sourceSets.getByName(TEST_SOURCE_SET_NAME).runtimeClasspath
+        val classpath = plugin.sourceSets.getByName(MAIN_SOURCE_SET_NAME).runtimeClasspath
         val urls = classpath.files.map { it.toURI().toURL() }.toTypedArray()
-        return URLClassLoader(urls)
+        // This classloader should be self-contained. Don't assign Gradle's classloader as its parent.
+        return URLClassLoader(urls, null)
     }
 
     /**
@@ -219,7 +222,7 @@ open class Baseform : DefaultTask() {
     }
 
     protected fun bootstrapNetwork() {
-        loadNetworkBootstrapper().use { cl ->
+        createNetworkBootstrapperLoader().use { cl ->
             val networkBootstrapperClass = cl.loadNetworkBootstrapper()
             val networkBootstrapper = networkBootstrapperClass.newInstance()
             val bootstrapMethod = networkBootstrapperClass.getMethod("bootstrapCordform", Path::class.java, List::class.java).apply { isAccessible = true }
@@ -230,6 +233,30 @@ open class Baseform : DefaultTask() {
                 bootstrapMethod.invoke(networkBootstrapper, rootDir, allCordapps)
             } catch (e: InvocationTargetException) {
                 throw e.cause!!.let { InvalidUserCodeException(it.message ?: "", it) }
+            } finally {
+                /*
+                 * Ensure we remove any [SecurityProvider] instances that the
+                 * Network Bootstrapper may have registered. Otherwise the JVM
+                 * will be unable to delete this [ClassLoader] from memory.
+                 */
+                Security.getProviders().forEach { provider ->
+                    if (provider::class.java.classLoader == cl) {
+                        Security.removeProvider(provider.name)
+                    }
+                }
+
+                /*
+                 * Shutdown the most likely SFL4J implementations that
+                 * Network Bootstrapper could be using.
+                 */
+                cl.shutdownLog4J2()
+                cl.shutdownLog4J()
+                cl.shutdownLogback()
+
+                /*
+                 * Make sure JCL isn't holding onto anything either.
+                 */
+                cl.shutdownCommonsLogging()
             }
         }
     }
@@ -238,7 +265,29 @@ open class Baseform : DefaultTask() {
         return try {
             loadClass("net.corda.nodeapi.internal.network.NetworkBootstrapper")
         } catch (e: ClassNotFoundException) {
-            throw InvalidUserCodeException("Cannot find the NetworkBootstrapper class. Please ensure that 'corda-node-api' is available on Gradle's test runtime classpath.", e)
+            throw InvalidUserCodeException("Cannot find the NetworkBootstrapper class. Please ensure that 'corda-node-api' is available on Gradle's runtime classpath, "
+                    + "e.g. by adding it to Gradle's 'runtimeOnly' configuration.", e)
         }
+    }
+
+    private fun ClassLoader.shutdownCommonsLogging() = execute("org.apache.commons.logging.LogFactory", "releaseAll") { c, m -> invoke(c, m, null) }
+    private fun ClassLoader.shutdownLog4J() = execute("org.apache.log4j.LogManager", "shutdown") { c, m -> invoke(c, m, null) }
+    private fun ClassLoader.shutdownLog4J2() = execute("org.apache.logging.log4j.LogManager", "shutdown") { c, m -> invoke(c, m, null) }
+    private fun ClassLoader.shutdownLogback() = execute("ch.qos.logback.classic.LoggerContext", "stop") { c, m ->
+        val iLogger = invoke("org.slf4j.LoggerFactory", "getILoggerFactory", null)
+        invoke(c, m, iLogger)
+    }
+
+    private fun ClassLoader.execute(className: String, methodName: String, body: (String, String) -> Unit) {
+        try {
+            body(className, methodName)
+            logger.info("Executed {}.{}() successfully", className, methodName)
+        } catch (e: Exception) {
+            logger.debug("Failed to execute {}.{}(): {} ({})", className, methodName, e::class.java.name, e.message)
+        }
+    }
+
+    private fun ClassLoader.invoke(className: String, methodName: String, obj: Any?): Any? {
+        return loadClass(className).getDeclaredMethod(methodName).invoke(obj)
     }
 }


### PR DESCRIPTION
Remove any `SecurityProvider` instances installed by the Network Bootstrapper because the JVM cannot discard their classes until all references to them are destroyed. We also want to ensure that the Network Bootstrapper links consistently to everything inside the single `ClassLoader` provided by `cordformation`, and not to any `ClassLoader` from a previous `deployNodes` invocation.

Also revert the `deployNodes` task back to using the runtime classpath because none of the extra jars on the test runtime classpath is needed by the Bootstrapper. Any extra SLF4J backend can be added to the Gradle's `runtimeOnly` configuration.