### PR TITLE
CORDA-2699: Backport Jolokia fix to 4.0 branch.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ### Version 4.0.42
 
+* `cordformation`: Add Jolokia agent to the `cordaRuntime` configuration to prevent the `cordapp` plugin from including it inside the CorDapp.
+
 ### Version 4.0.41
 
 * `cordformation`: Unload `SecurityProvider` instances installed by Network Bootstrapper to prevent linkage exceptions later.

--- a/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
@@ -34,9 +34,9 @@ class CordappPlugin : Plugin<Project> {
             throw GradleException("Gradle versionId ${project.gradle.gradleVersion} is below the supported minimum versionId $MIN_GRADLE_VERSION. Please update Gradle or consider using Gradle wrapper if it is provided with the project. More information about CorDapp build system can be found here: https://docs.corda.net/cordapp-build-systems.html")
         }
 
-        Utils.createCompileConfiguration("cordapp", project)
-        Utils.createCompileConfiguration("cordaCompile", project)
-        Utils.createRuntimeConfiguration("cordaRuntime", project)
+        Utils.createCompileConfiguration("cordapp", project.configurations)
+        Utils.createCompileConfiguration("cordaCompile", project.configurations)
+        Utils.createRuntimeConfiguration("cordaRuntime", project.configurations)
 
         cordapp = project.extensions.create("cordapp", CordappExtension::class.java, project.objects)
         configurePomCreation(project)

--- a/cordapp/src/main/kotlin/net/corda/plugins/Utils.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/Utils.kt
@@ -2,6 +2,7 @@ package net.corda.plugins
 
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.plugins.ExtraPropertiesExtension
 import java.nio.file.Files
 import java.nio.file.Path
@@ -18,24 +19,24 @@ fun Project.configuration(name: String): Configuration = configurations.single {
 
 class Utils {
     companion object {
-        fun createCompileConfiguration(name: String, project: Project) {
-            if (project.configurations.none { it.name == name }) {
-                val configuration = project.configurations.create(name) {
+        fun createChildConfiguration(name: String, parent: Configuration, configurations: ConfigurationContainer): Configuration {
+            return configurations.findByName(name) ?: run {
+                val configuration = configurations.create(name) {
                     it.isTransitive = false
                 }
-                project.configurations.single { it.name == "compile" }.extendsFrom(configuration)
+                parent.extendsFrom(configuration)
+                configuration
             }
+        }
+
+        fun createCompileConfiguration(name: String, configurations: ConfigurationContainer): Configuration {
+            return createChildConfiguration(name, configurations.single { it.name == "compile" }, configurations)
         }
 
         // This function is called from the groovy quasar-utils plugin.
         @JvmStatic
-        fun createRuntimeConfiguration(name: String, project: Project) {
-            if (project.configurations.none { it.name == name }) {
-                val configuration = project.configurations.create(name) {
-                    it.isTransitive = false
-                }
-                project.configurations.single { it.name == "runtime" }.extendsFrom(configuration)
-            }
+        fun createRuntimeConfiguration(name: String, configurations: ConfigurationContainer): Configuration {
+            return createChildConfiguration(name, configurations.single { it.name == "runtime" }, configurations)
         }
 
         @JvmStatic

--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
@@ -54,8 +54,11 @@ class Cordformation : Plugin<Project> {
     }
 
     override fun apply(project: Project) {
-        Utils.createCompileConfiguration("cordapp", project)
-        Utils.createRuntimeConfiguration(CORDFORMATION_TYPE, project)
+        project.configurations.apply {
+            Utils.createCompileConfiguration("cordapp", this)
+            val cordaRuntime = Utils.createRuntimeConfiguration("cordaRuntime", this)
+            Utils.createChildConfiguration(CORDFORMATION_TYPE, cordaRuntime, this)
+        }
         // TODO: improve how we re-use existing declared external variables from root gradle.build
         val jolokiaVersion = try { project.rootProject.ext<String>("jolokia_version") } catch (e: Exception) { "1.6.0" }
         val jolokia = project.dependencies.add(CORDFORMATION_TYPE, "org.jolokia:jolokia-jvm:$jolokiaVersion:agent")

--- a/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
@@ -15,7 +15,7 @@ class QuasarPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
-        Utils.createRuntimeConfiguration("cordaRuntime", project)
+        Utils.createRuntimeConfiguration("cordaRuntime", project.configurations)
         def quasar = project.configurations.create("quasar")
 
         def rootProject = project.rootProject


### PR DESCRIPTION
Add Jolokia agent to the `cordaRuntime` configuration to prevent the `cordapp` plugin from including it inside the CorDapp.