### PR TITLE
CORDA-2713: Update quasar-utils to apply java plugin automatically.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,8 @@
 
 * `cordformation`: Add Jolokia agent to the `cordaRuntime` configuration to prevent the `cordapp` plugin from including it inside the CorDapp.
 
+* `quasar-utils`: Apply the `java` plugin automatically.
+
 ## Version 4
 
 ### Version 4.0.40

--- a/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
@@ -161,7 +161,7 @@ open class Baseform : DefaultTask() {
     }
 
     private fun deleteRootDir() {
-        project.logger.lifecycle("Deleting $directory")
+        logger.lifecycle("Deleting $directory")
         project.delete(directory)
     }
 
@@ -171,7 +171,7 @@ open class Baseform : DefaultTask() {
     protected fun generateExcludedWhitelist() {
         if (excludeWhitelist.isNotEmpty()) {
             val fileName = "exclude_whitelist.txt"
-            logger.debug("Adding $excludeWhitelist to $fileName.")
+            logger.debug("Adding {} to {}.", excludeWhitelist, fileName)
             val rootDir = Paths.get(project.projectDir.toPath().resolve(directory).resolve(fileName).toAbsolutePath().normalize().toString())
             Files.write(rootDir, excludeWhitelist)
         }

--- a/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
@@ -2,6 +2,7 @@ package net.corda.plugins
 
 import org.gradle.api.Project
 import org.gradle.api.Plugin
+import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.JavaExec
 
@@ -15,6 +16,10 @@ class QuasarPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
+        // Apply the Java plugin on the assumption that we're building a JAR.
+        // This will also create the "compile", "compileOnly" and "runtime" configurations.
+        project.pluginManager.apply(JavaPlugin)
+
         Utils.createRuntimeConfiguration("cordaRuntime", project.configurations)
         def quasar = project.configurations.create("quasar")
 
@@ -30,11 +35,11 @@ class QuasarPlugin implements Plugin<Project> {
         // This adds Quasar to the compile classpath WITHOUT any of its transitive dependencies.
         project.dependencies.add("compileOnly", quasar)
 
-        project.tasks.withType(Test).all {
+        project.tasks.withType(Test) {
             jvmArgs "-javaagent:${project.configurations.quasar.singleFile}"
             jvmArgs "-Dco.paralleluniverse.fibers.verifyInstrumentation"
         }
-        project.tasks.withType(JavaExec).all {
+        project.tasks.withType(JavaExec) {
             jvmArgs "-javaagent:${project.configurations.quasar.singleFile}"
             jvmArgs "-Dco.paralleluniverse.fibers.verifyInstrumentation"
         }

--- a/quasar-utils/src/test/groovy/net/corda/plugins/QuasarPluginTest.groovy
+++ b/quasar-utils/src/test/groovy/net/corda/plugins/QuasarPluginTest.groovy
@@ -25,7 +25,6 @@ class QuasarPluginTest {
     void checkDefaultVersionIsUsed() {
         def output = runGradleFor """
 plugins {
-    id 'java'
     id 'net.corda.plugins.quasar-utils' apply false
 }
 
@@ -70,7 +69,6 @@ buildscript {
 }
 
 plugins {
-    id 'java'
     id 'net.corda.plugins.quasar-utils' apply false
 }
 
@@ -105,7 +103,6 @@ configs.collectEntries { [(it.name):it] }.forEach { name, files ->
     void checkForTransitiveDependencies() {
         def output = runGradleFor """
 plugins {
-    id 'java'
     id 'net.corda.plugins.quasar-utils' apply false
 }
 
@@ -139,7 +136,6 @@ configs.collectEntries { [(it.name):it] }.forEach { name, files ->
     void checkJVMArgsAddedForTests() {
         def output = runGradleFor """
 plugins {
-    id 'java'
     id 'net.corda.plugins.quasar-utils' apply false
 }
 
@@ -173,7 +169,7 @@ test {
         buildFile.text = script
         def result = GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
-            .withArguments("--info", "build", "-g", TEST_GRADLE_USER_HOME)
+            .withArguments("--info", "--stacktrace", "build", "-g", TEST_GRADLE_USER_HOME)
             .withPluginClasspath()
             .build()
         println result.output


### PR DESCRIPTION
The `quasar-utils` plugin _requires_ that Gradle's `compile`, `compileOnly` and `runtime` configurations already exist, but these configurations are created by the `java` plugin. So apply the `java` plugin up-front to improve the user experience.