### PR TITLE
CORDA-2889: Fix scanApi task configuration for Gradle 5.x.

### DIFF
--- a/api-scanner/src/main/java/net/corda/plugins/ApiScanner.java
+++ b/api-scanner/src/main/java/net/corda/plugins/ApiScanner.java
@@ -3,8 +3,8 @@ package net.corda.plugins;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ConfigurationContainer;
-import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.jvm.tasks.Jar;
 
@@ -27,13 +27,10 @@ public class ApiScanner implements Plugin<Project> {
         // Register the scanning task lazily, so that it will be configured after the project has been evaluated.
         project.getLogger().info("Adding scanApi task to {}", project.getName());
         TaskProvider<ScanApi> scanProvider = project.getTasks().register("scanApi", ScanApi.class, scanTask -> {
-            ConfigurableFileCollection jarSources = project.files();
-
-            project.getTasks().withType(Jar.class, jarTask -> {
-                if (jarTask.getClassifier().isEmpty() && jarTask.isEnabled()) {
-                    jarSources.from(jarTask);
-                }
-            });
+            TaskCollection<Jar> jarTasks = project.getTasks()
+                .withType(Jar.class)
+                .matching(jarTask -> jarTask.getClassifier().isEmpty() && jarTask.isEnabled());
+            FileCollection jarSources = project.files(jarTasks);
 
             scanTask.setClasspath(compilationClasspath(project.getConfigurations()));
             // Automatically creates a dependency on jar tasks.

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ### Version 5.0.0
 
+* `api-scanner`: Compatibility fix for Gradle 5.x.
+
 * `cordformation`: Unload `SecurityProvider` instances installed by Network Bootstrapper to prevent linkage exceptions later.
 
 * `cordformation`: Revert `deployNodes` back to using the runtime classpath again. Anything needed solely by `deployNodes` can be added to Gradle's `runtimeOnly` configuration instead.


### PR DESCRIPTION
The API Scanner's `scanApi` task is failing in Gradle 5.x with this exception:
```
Caused by: org.gradle.api.internal.AbstractMutationGuard$IllegalMutationException: DefaultTaskContainer#withType(Class, Action) on task set cannot be executed in the current context.
	at org.gradle.api.internal.AbstractMutationGuard.createIllegalStateException(AbstractMutationGuard.java:39)
        ...
```
Modify this task to work in _both_ Gradle 4.x _and_ Gradle 5.x.