### PR TITLE
CORDA-2897: Update JarFilter to use Gradle Property and Provider classes.

### DIFF
--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/FilterAnnotations.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/FilterAnnotations.kt
@@ -1,17 +1,36 @@
 package net.corda.gradle.jarfilter
 
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import javax.inject.Inject
 
-open class FilterAnnotations {
+open class FilterAnnotations @Inject constructor(objects: ObjectFactory) {
     @get:Input
-    var forDelete: Set<String> = emptySet()
-
-    @get:Input
-    var forStub: Set<String> = emptySet()
-
-    @get:Input
-    var forRemove: Set<String> = emptySet()
+    val forDelete: SetProperty<String> = objects.setProperty(String::class.java)
 
     @get:Input
-    var forSanitise: Set<String> = emptySet()
+    val forStub: SetProperty<String> = objects.setProperty(String::class.java)
+
+    @get:Input
+    val forRemove: SetProperty<String> = objects.setProperty(String::class.java)
+
+    @get:Input
+    val forSanitise: SetProperty<String> = objects.setProperty(String::class.java)
+
+    @get:Internal
+    val values get() = Values(
+        forDelete.get(),
+        forStub.get(),
+        forRemove.get(),
+        forSanitise.get()
+    )
+
+    class Values(
+        val forDelete: Set<String>,
+        val forStub: Set<String>,
+        val forRemove: Set<String>,
+        val forSanitise: Set<String>
+    )
 }

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/Utils.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/Utils.kt
@@ -1,7 +1,7 @@
 @file:JvmName("Utils")
 package net.corda.gradle.jarfilter
 
-import org.gradle.api.GradleException
+import org.gradle.api.InvalidUserCodeException
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.ClassWriter
@@ -23,8 +23,8 @@ private val CONSTANT_TIME: FileTime = FileTime.fromMillis(
 
 // Declared as inline to avoid polluting the exception stack trace.
 @Suppress("NOTHING_TO_INLINE")
-internal inline fun rethrowAsUncheckedException(e: Exception): Nothing
-    = throw (e as? RuntimeException) ?: GradleException(e.message ?: "", e)
+internal inline fun Exception.asUncheckedException(): RuntimeException
+    = (this as? RuntimeException) ?: InvalidUserCodeException(message ?: "", this)
 
 /**
  * Recreates a [ZipEntry] object. The entry's byte contents

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterConfigurationTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterConfigurationTest.kt
@@ -10,6 +10,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import kotlin.test.fail
 
 class JarFilterConfigurationTest {
     private companion object {
@@ -267,6 +268,6 @@ class JarFilterConfigurationTest {
     }
 
     private fun BuildResult.forTask(name: String): BuildTask {
-        return task(":$name") ?: throw AssertionError("No outcome for $name task")
+        return task(":$name") ?: fail("No outcome for $name task")
     }
 }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterConfigurationTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterConfigurationTest.kt
@@ -68,7 +68,7 @@ class JarFilterConfigurationTest {
         println(output)
 
         assertThat(output).containsSubsequence(
-            "Caused by: org.gradle.api.GradleException:",
+            "Caused by: org.gradle.api.InvalidUserCodeException:",
             "Caused by: java.io.FileNotFoundException:"
         )
 

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterProject.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterProject.kt
@@ -10,6 +10,7 @@ import org.junit.runner.Description
 import org.junit.runners.model.Statement
 import java.io.FileNotFoundException
 import java.nio.file.Path
+import kotlin.test.fail
 
 class JarFilterProject(private val projectDir: TemporaryFolder, private val name: String) : TestRule {
     private var _sourceJar: Path? = null
@@ -39,8 +40,7 @@ class JarFilterProject(private val projectDir: TemporaryFolder, private val name
                 _output = result.output
                 println(output)
 
-                val jarFilter = result.task(":jarFilter")
-                    ?: throw AssertionError("No outcome for jarFilter task")
+                val jarFilter = result.task(":jarFilter") ?: fail("No outcome for jarFilter task")
                 assertEquals(SUCCESS, jarFilter.outcome)
 
                 _sourceJar = projectDir.pathOf("build", "libs", "$name.jar")

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterTimestampTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterTimestampTest.kt
@@ -16,6 +16,7 @@ import java.util.*
 import java.util.Calendar.FEBRUARY
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
+import kotlin.test.fail
 
 class JarFilterTimestampTest {
     companion object {
@@ -61,8 +62,7 @@ class JarFilterTimestampTest {
                     output = result.output
                     println(output)
 
-                    val jarFilter = result.task(":jarFilter")
-                        ?: throw AssertionError("No outcome for jarFilter task")
+                    val jarFilter = result.task(":jarFilter") ?: fail("No outcome for jarFilter task")
                     assertEquals(SUCCESS, jarFilter.outcome)
 
                     filteredJar = testProjectDir.pathOf("build", "filtered-libs", "timestamps-filtered.jar")

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConfigurationTests.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConfigurationTests.kt
@@ -57,7 +57,7 @@ class MetaFixConfigurationTests {
         println(output)
 
         assertThat(output).containsSubsequence(
-            "Caused by: org.gradle.api.GradleException:",
+            "Caused by: org.gradle.api.InvalidUserCodeException:",
             "Caused by: java.io.FileNotFoundException:"
         )
 

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConfigurationTests.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConfigurationTests.kt
@@ -10,6 +10,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import kotlin.test.fail
 
 class MetaFixConfigurationTests {
     @Rule
@@ -74,6 +75,6 @@ class MetaFixConfigurationTests {
     }
 
     private fun BuildResult.forTask(name: String): BuildTask {
-        return task(":$name") ?: throw AssertionError("No outcome for $name task")
+        return task(":$name") ?: fail("No outcome for $name task")
     }
 }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConstructorDefaultParameterTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConstructorDefaultParameterTest.kt
@@ -11,6 +11,7 @@ import org.junit.Assert.*
 import org.junit.BeforeClass
 import org.junit.Test
 import kotlin.reflect.full.primaryConstructor
+import kotlin.test.fail
 
 class MetaFixConstructorDefaultParameterTest {
     companion object {
@@ -42,7 +43,7 @@ class MetaFixConstructorDefaultParameterTest {
         }
 
         val sourcePrimary = sourceClass.kotlin.primaryConstructor
-                ?: throw AssertionError("source primary constructor missing")
+                ?: fail("source primary constructor missing")
         sourcePrimary.call(BIG_NUMBER, NUMBER, MESSAGE).apply {
             assertThat(longData()).isEqualTo(BIG_NUMBER)
             assertThat(intData()).isEqualTo(NUMBER)
@@ -50,7 +51,7 @@ class MetaFixConstructorDefaultParameterTest {
         }
 
         val sourceSecondary = sourceClass.kotlin.constructors.firstOrNull { it != sourcePrimary }
-                ?: throw AssertionError("source secondary constructor missing")
+                ?: fail("source secondary constructor missing")
         sourceSecondary.call('X', MESSAGE).apply {
             assertThat(stringData()).isEqualTo("X$MESSAGE")
         }
@@ -70,14 +71,14 @@ class MetaFixConstructorDefaultParameterTest {
     @Test
     fun `test fixed primary constructor has mandatory parameters`() {
         val fixedPrimary = fixedClass.kotlin.primaryConstructor
-                ?: throw AssertionError("fixed primary constructor missing")
+                ?: fail("fixed primary constructor missing")
         assertTrue("All fixed parameters should be mandatory", fixedPrimary.hasAllMandatoryParameters)
     }
 
     @Test
     fun `test fixed secondary constructor still has optional parameters`() {
         val fixedSecondary = (fixedClass.kotlin.constructors - fixedClass.kotlin.primaryConstructor).firstOrNull()
-                ?: throw AssertionError("fixed secondary constructor missing")
+                ?: fail("fixed secondary constructor missing")
         assertTrue("Some fixed parameters should be optional", fixedSecondary.hasAnyOptionalParameters)
     }
 

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFunctionDefaultParameterTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFunctionDefaultParameterTest.kt
@@ -11,6 +11,7 @@ import org.junit.BeforeClass
 import org.junit.Test
 import kotlin.reflect.KFunction
 import kotlin.reflect.full.declaredFunctions
+import kotlin.test.fail
 
 class MetaFixFunctionDefaultParameterTest {
     companion object {
@@ -82,7 +83,7 @@ class MetaFixFunctionDefaultParameterTest {
     }
 
     private fun <T> Iterable<KFunction<T>>.findOrFail(name: String): KFunction<T> {
-        return find { it.name == name } ?: throw AssertionError("$name missing")
+        return find { it.name == name } ?: fail("$name missing")
     }
 }
 

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixProject.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixProject.kt
@@ -10,6 +10,7 @@ import org.junit.runner.Description
 import org.junit.runners.model.Statement
 import java.io.FileNotFoundException
 import java.nio.file.Path
+import kotlin.test.fail
 
 @Suppress("UNUSED")
 class MetaFixProject(private val projectDir: TemporaryFolder, private val name: String) : TestRule {
@@ -40,8 +41,7 @@ class MetaFixProject(private val projectDir: TemporaryFolder, private val name: 
                 _output = result.output
                 println(output)
 
-                val metafix = result.task(":metafix")
-                    ?: throw AssertionError("No outcome for metafix task")
+                val metafix = result.task(":metafix") ?: fail("No outcome for metafix task")
                 assertEquals(SUCCESS, metafix.outcome)
 
                 _sourceJar = projectDir.pathOf("build", "libs", "$name.jar")

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixTimestampTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixTimestampTest.kt
@@ -17,6 +17,7 @@ import java.util.Calendar.FEBRUARY
 import java.util.zip.ZipEntry
 import java.util.zip.ZipEntry.*
 import java.util.zip.ZipFile
+import kotlin.test.fail
 
 class MetaFixTimestampTest {
     companion object {
@@ -62,8 +63,7 @@ class MetaFixTimestampTest {
                     output = result.output
                     println(output)
 
-                    val metafix = result.task(":metafix")
-                        ?: throw AssertionError("No outcome for metafix task")
+                    val metafix = result.task(":metafix") ?: fail("No outcome for metafix task")
                     assertEquals(SUCCESS, metafix.outcome)
 
                     metafixedJar = testProjectDir.pathOf("build", "metafixer-libs", "timestamps-metafixed.jar")

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/SanitiseDeleteConstructorTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/SanitiseDeleteConstructorTest.kt
@@ -15,6 +15,7 @@ import org.junit.rules.TestRule
 import kotlin.jvm.kotlin
 import kotlin.reflect.full.primaryConstructor
 import kotlin.test.assertFailsWith
+import kotlin.test.fail
 
 class SanitiseDeleteConstructorTest {
     companion object {
@@ -55,10 +56,10 @@ class SanitiseDeleteConstructorTest {
                     assertThat("<init>(J) not found", this, hasItem(longConstructor))
                     assertEquals(initialCount, this.size)
                 }
-                val primary = kotlin.primaryConstructor ?: throw AssertionError("primary constructor missing")
+                val primary = kotlin.primaryConstructor ?: fail("primary constructor missing")
                 assertThat(primary.call(BIG_NUMBER).longData()).isEqualTo(BIG_NUMBER)
 
-                val noArg = kotlin.noArgConstructor ?: throw AssertionError("no-arg constructor missing")
+                val noArg = kotlin.noArgConstructor ?: fail("no-arg constructor missing")
                 assertThat(noArg.callBy(emptyMap()).longData()).isEqualTo(0)
                 assertThat(newInstance().longData()).isEqualTo(0)
             }
@@ -73,7 +74,7 @@ class SanitiseDeleteConstructorTest {
                     assertThat("<init>(J) not found", this, hasItem(longConstructor))
                     assertEquals(1, this.size)
                 }
-                val primary = kotlin.primaryConstructor ?: throw AssertionError("primary constructor missing")
+                val primary = kotlin.primaryConstructor ?: fail("primary constructor missing")
                 assertThat(primary.call(BIG_NUMBER).longData()).isEqualTo(BIG_NUMBER)
 
                 assertNull("no-arg constructor exists", kotlin.noArgConstructor)
@@ -106,10 +107,10 @@ class SanitiseDeleteConstructorTest {
                     assertThat("<init>(I) not found", this, hasItem(intConstructor))
                     assertEquals(initialCount, this.size)
                 }
-                val primary = kotlin.primaryConstructor ?: throw AssertionError("primary constructor missing")
+                val primary = kotlin.primaryConstructor ?: fail("primary constructor missing")
                 assertThat(primary.call(NUMBER).intData()).isEqualTo(NUMBER)
 
-                val noArg = kotlin.noArgConstructor ?: throw AssertionError("no-arg constructor missing")
+                val noArg = kotlin.noArgConstructor ?: fail("no-arg constructor missing")
                 assertThat(noArg.callBy(emptyMap()).intData()).isEqualTo(0)
                 assertThat(newInstance().intData()).isEqualTo(0)
             }
@@ -124,7 +125,7 @@ class SanitiseDeleteConstructorTest {
                     assertThat("<init>(I) not found", this, hasItem(intConstructor))
                     assertEquals(1, this.size)
                 }
-                val primary = kotlin.primaryConstructor ?: throw AssertionError("primary constructor missing")
+                val primary = kotlin.primaryConstructor ?: fail("primary constructor missing")
                 assertThat(primary.call(NUMBER).intData()).isEqualTo(NUMBER)
 
                 assertNull("no-arg constructor exists", kotlin.noArgConstructor)
@@ -157,10 +158,10 @@ class SanitiseDeleteConstructorTest {
                     assertThat("<init>(String) not found", this, hasItem(stringConstructor))
                     assertEquals(initialCount, this.size)
                 }
-                val primary = kotlin.primaryConstructor ?: throw AssertionError("primary constructor missing")
+                val primary = kotlin.primaryConstructor ?: fail("primary constructor missing")
                 assertThat(primary.call(MESSAGE).stringData()).isEqualTo(MESSAGE)
 
-                val noArg = kotlin.noArgConstructor ?: throw AssertionError("no-arg constructor missing")
+                val noArg = kotlin.noArgConstructor ?: fail("no-arg constructor missing")
                 assertThat(noArg.callBy(emptyMap()).stringData()).isEqualTo(DEFAULT_MESSAGE)
                 assertThat(newInstance().stringData()).isEqualTo(DEFAULT_MESSAGE)
             }
@@ -175,7 +176,7 @@ class SanitiseDeleteConstructorTest {
                     assertThat("<init>(String) not found", this, hasItem(stringConstructor))
                     assertEquals(1, this.size)
                 }
-                val primary = kotlin.primaryConstructor ?: throw AssertionError("primary constructor missing")
+                val primary = kotlin.primaryConstructor ?: fail("primary constructor missing")
                 assertThat(primary.call(MESSAGE).stringData()).isEqualTo(MESSAGE)
 
                 assertNull("no-arg constructor exists", kotlin.noArgConstructor)
@@ -195,7 +196,7 @@ class SanitiseDeleteConstructorTest {
                     assertEquals(1, this.size)
                 }
 
-                val primary = kotlin.primaryConstructor ?: throw AssertionError("primary constructor missing")
+                val primary = kotlin.primaryConstructor ?: fail("primary constructor missing")
                 primary.call(NUMBER, MESSAGE).also { complex ->
                     assertThat((complex as HasString).stringData()).isEqualTo(MESSAGE)
                     assertThat((complex as HasInt).intData()).isEqualTo(NUMBER)
@@ -219,7 +220,7 @@ class SanitiseDeleteConstructorTest {
                     assertEquals(1, this.size)
                 }
 
-                val primary = kotlin.primaryConstructor ?: throw AssertionError("primary constructor missing")
+                val primary = kotlin.primaryConstructor ?: fail("primary constructor missing")
                 primary.call(NUMBER, MESSAGE).also { complex ->
                     assertThat((complex as HasString).stringData()).isEqualTo(MESSAGE)
                     assertThat((complex as HasInt).intData()).isEqualTo(NUMBER)

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/SanitiseStubConstructorTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/SanitiseStubConstructorTest.kt
@@ -16,6 +16,7 @@ import java.lang.reflect.InvocationTargetException
 import kotlin.jvm.kotlin
 import kotlin.reflect.full.primaryConstructor
 import kotlin.test.assertFailsWith
+import kotlin.test.fail
 
 class SanitiseStubConstructorTest {
     companion object {
@@ -56,10 +57,10 @@ class SanitiseStubConstructorTest {
                     assertThat("<init>(J) not found", this, hasItem(longConstructor))
                     assertEquals(constructorCount, this.size)
                 }
-                val primary = kotlin.primaryConstructor ?: throw AssertionError("primary constructor missing")
+                val primary = kotlin.primaryConstructor ?: fail("primary constructor missing")
                 assertThat(primary.call(BIG_NUMBER).longData()).isEqualTo(BIG_NUMBER)
 
-                val noArg = kotlin.noArgConstructor ?: throw AssertionError("no-arg constructor missing")
+                val noArg = kotlin.noArgConstructor ?: fail("no-arg constructor missing")
                 assertThat(noArg.callBy(emptyMap()).longData()).isEqualTo(0)
                 assertThat(newInstance().longData()).isEqualTo(0)
             }
@@ -74,10 +75,10 @@ class SanitiseStubConstructorTest {
                     assertThat("<init>(J) not found", this, hasItem(longConstructor))
                     assertEquals(constructorCount, this.size)
                 }
-                val primary = kotlin.primaryConstructor ?: throw AssertionError("primary constructor missing")
+                val primary = kotlin.primaryConstructor ?: fail("primary constructor missing")
                 assertThat(primary.call(BIG_NUMBER).longData()).isEqualTo(BIG_NUMBER)
 
-                val noArg = kotlin.noArgConstructor ?: throw AssertionError("no-arg constructor missing")
+                val noArg = kotlin.noArgConstructor ?: fail("no-arg constructor missing")
                 assertThat(assertFailsWith<InvocationTargetException> { noArg.callBy(emptyMap()) }.targetException)
                     .isInstanceOf(UnsupportedOperationException::class.java)
                     .hasMessage("Method has been deleted")
@@ -111,10 +112,10 @@ class SanitiseStubConstructorTest {
                     assertThat("<init>(I) not found", this, hasItem(intConstructor))
                     assertEquals(constructorCount, this.size)
                 }
-                val primary = kotlin.primaryConstructor ?: throw AssertionError("primary constructor missing")
+                val primary = kotlin.primaryConstructor ?: fail("primary constructor missing")
                 assertThat(primary.call(NUMBER).intData()).isEqualTo(NUMBER)
 
-                val noArg = kotlin.noArgConstructor ?: throw AssertionError("no-arg constructor missing")
+                val noArg = kotlin.noArgConstructor ?: fail("no-arg constructor missing")
                 assertThat(noArg.callBy(emptyMap()).intData()).isEqualTo(0)
                 assertThat(newInstance().intData()).isEqualTo(0)
             }
@@ -129,10 +130,10 @@ class SanitiseStubConstructorTest {
                     assertThat("<init>(I) not found", this, hasItem(intConstructor))
                     assertEquals(constructorCount, this.size)
                 }
-                val primary = kotlin.primaryConstructor ?: throw AssertionError("primary constructor missing")
+                val primary = kotlin.primaryConstructor ?: fail("primary constructor missing")
                 assertThat(primary.call(NUMBER).intData()).isEqualTo(NUMBER)
 
-                val noArg = kotlin.noArgConstructor ?: throw AssertionError("no-arg constructor missing")
+                val noArg = kotlin.noArgConstructor ?: fail("no-arg constructor missing")
                 assertThat(assertFailsWith<InvocationTargetException> { noArg.callBy(emptyMap()) }.targetException)
                     .isInstanceOf(UnsupportedOperationException::class.java)
                     .hasMessage("Method has been deleted")
@@ -166,10 +167,10 @@ class SanitiseStubConstructorTest {
                     assertThat("<init>(String) not found", this, hasItem(stringConstructor))
                     assertEquals(constructorCount, this.size)
                 }
-                val primary = kotlin.primaryConstructor ?: throw AssertionError("primary constructor missing")
+                val primary = kotlin.primaryConstructor ?: fail("primary constructor missing")
                 assertThat(primary.call(MESSAGE).stringData()).isEqualTo(MESSAGE)
 
-                val noArg = kotlin.noArgConstructor ?: throw AssertionError("no-arg constructor missing")
+                val noArg = kotlin.noArgConstructor ?: fail("no-arg constructor missing")
                 assertThat(noArg.callBy(emptyMap()).stringData()).isEqualTo(DEFAULT_MESSAGE)
                 assertThat(newInstance().stringData()).isEqualTo(DEFAULT_MESSAGE)
             }
@@ -184,10 +185,10 @@ class SanitiseStubConstructorTest {
                     assertThat("<init>(String) not found", this, hasItem(stringConstructor))
                     assertEquals(constructorCount, this.size)
                 }
-                val primary = kotlin.primaryConstructor ?: throw AssertionError("primary constructor missing")
+                val primary = kotlin.primaryConstructor ?: fail("primary constructor missing")
                 assertThat(primary.call(MESSAGE).stringData()).isEqualTo(MESSAGE)
 
-                val noArg = kotlin.noArgConstructor ?: throw AssertionError("no-arg constructor missing")
+                val noArg = kotlin.noArgConstructor ?: fail("no-arg constructor missing")
                 assertThat(assertFailsWith<InvocationTargetException> { noArg.callBy(emptyMap()) }.targetException)
                     .isInstanceOf(UnsupportedOperationException::class.java)
                     .hasMessage("Method has been deleted")
@@ -208,7 +209,7 @@ class SanitiseStubConstructorTest {
                     assertEquals(1, this.size)
                 }
 
-                val primary = kotlin.primaryConstructor ?: throw AssertionError("primary constructor missing")
+                val primary = kotlin.primaryConstructor ?: fail("primary constructor missing")
                 primary.call(NUMBER, MESSAGE).also { complex ->
                     assertThat((complex as HasString).stringData()).isEqualTo(MESSAGE)
                     assertThat((complex as HasInt).intData()).isEqualTo(NUMBER)
@@ -232,7 +233,7 @@ class SanitiseStubConstructorTest {
                     assertEquals(1, this.size)
                 }
 
-                val primary = kotlin.primaryConstructor ?: throw AssertionError("primary constructor missing")
+                val primary = kotlin.primaryConstructor ?: fail("primary constructor missing")
                 primary.call(NUMBER, MESSAGE).also { complex ->
                     assertThat((complex as HasString).stringData()).isEqualTo(MESSAGE)
                     assertThat((complex as HasInt).intData()).isEqualTo(NUMBER)

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/UtilsTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/UtilsTest.kt
@@ -1,7 +1,7 @@
 package net.corda.gradle.jarfilter
 
 import org.assertj.core.api.Assertions.assertThat
-import org.gradle.api.GradleException
+import org.gradle.api.InvalidUserCodeException
 import org.gradle.api.InvalidUserDataException
 import org.junit.Test
 import java.io.IOException
@@ -10,7 +10,7 @@ import kotlin.test.assertFailsWith
 class UtilsTest {
     @Test
     fun testRethrowingCheckedException() {
-        val ex = assertFailsWith<GradleException> { rethrowAsUncheckedException(IOException(MESSAGE)) }
+        val ex = assertFailsWith<InvalidUserCodeException> { throw IOException(MESSAGE).asUncheckedException() }
         assertThat(ex)
             .hasMessage(MESSAGE)
             .hasCauseExactlyInstanceOf(IOException::class.java)
@@ -18,7 +18,7 @@ class UtilsTest {
 
     @Test
     fun testRethrowingCheckExceptionWithoutMessage() {
-        val ex = assertFailsWith<GradleException> { rethrowAsUncheckedException(IOException()) }
+        val ex = assertFailsWith<InvalidUserCodeException> { throw IOException().asUncheckedException() }
         assertThat(ex)
             .hasMessage("")
             .hasCauseExactlyInstanceOf(IOException::class.java)
@@ -26,7 +26,7 @@ class UtilsTest {
 
     @Test
     fun testRethrowingUncheckedException() {
-        val ex = assertFailsWith<IllegalArgumentException> { rethrowAsUncheckedException(IllegalArgumentException(MESSAGE)) }
+        val ex = assertFailsWith<IllegalArgumentException> { throw IllegalArgumentException(MESSAGE).asUncheckedException() }
         assertThat(ex)
             .hasMessage(MESSAGE)
             .hasNoCause()
@@ -34,7 +34,7 @@ class UtilsTest {
 
     @Test
     fun testRethrowingGradleException() {
-        val ex = assertFailsWith<InvalidUserDataException> { rethrowAsUncheckedException(InvalidUserDataException(MESSAGE)) }
+        val ex = assertFailsWith<InvalidUserDataException> { throw InvalidUserDataException(MESSAGE).asUncheckedException() }
         assertThat(ex)
             .hasMessage(MESSAGE)
             .hasNoCause()


### PR DESCRIPTION
JarFilter "gets away" with using POJOs for configuring its tasks at the moment, but Gradle 4.x onwards provides `Property` and `Provider` classes to do this properly. Update JarFilter accordingly.