### PR TITLE
CORDA-2491 Add network parameter overrides to CordFormation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ### Version 5.0.0
 
+* `cordformation`: Add support for network parameter overrides.
+
 * `cordapp`: Make file order inside the jar reproducible, and discard file timestamps.
 
 * `cordapp`: Compatibility fix for Gradle 5.2 and above.

--- a/cordformation/build.gradle
+++ b/cordformation/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'java-gradle-plugin'
 description 'A small gradle plugin for adding some basic Quasar tasks and configurations to reduce build.gradle bloat.'
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
@@ -57,6 +58,8 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit"
     testImplementation "junit:junit:$junit_version" // TODO: Unify with core
     testImplementation "org.assertj:assertj-core:$assertj_version"
+    testImplementation "net.corda:corda-node-api:5.0-SNAPSHOT"
+    testImplementation "net.corda:corda-serialization:5.0-SNAPSHOT"
     // Docker-compose file generation
     compile "org.yaml:snakeyaml:$snake_yaml_version"
 }

--- a/cordformation/build.gradle
+++ b/cordformation/build.gradle
@@ -3,8 +3,13 @@ apply plugin: 'java-gradle-plugin'
 
 description 'A small gradle plugin for adding some basic Quasar tasks and configurations to reduce build.gradle bloat.'
 
+buildscript {
+    ext {
+        corda_release_version = '4.0'
+    }
+}
+
 repositories {
-    mavenLocal()
     mavenCentral()
 }
 
@@ -58,8 +63,8 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit"
     testImplementation "junit:junit:$junit_version" // TODO: Unify with core
     testImplementation "org.assertj:assertj-core:$assertj_version"
-    testImplementation "net.corda:corda-node-api:5.0-SNAPSHOT"
-    testImplementation "net.corda:corda-serialization:5.0-SNAPSHOT"
+    testImplementation "net.corda:corda-serialization:$corda_release_version"
+    testRuntimeOnly "net.corda:corda-node-api:$corda_release_version"
     // Docker-compose file generation
     compile "org.yaml:snakeyaml:$snake_yaml_version"
 }

--- a/cordformation/build.gradle
+++ b/cordformation/build.gradle
@@ -3,10 +3,8 @@ apply plugin: 'java-gradle-plugin'
 
 description 'A small gradle plugin for adding some basic Quasar tasks and configurations to reduce build.gradle bloat.'
 
-buildscript {
-    ext {
-        corda_release_version = '4.0'
-    }
+ext {
+    corda_release_version = '4.0'
 }
 
 repositories {

--- a/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
@@ -9,6 +9,7 @@ import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.InvalidUserCodeException
 import org.gradle.api.InvalidUserDataException
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
@@ -29,7 +30,7 @@ import java.security.Security
  * See documentation for examples.
  */
 @Suppress("unused")
-open class Baseform : DefaultTask() {
+open class Baseform(objects: ObjectFactory) : DefaultTask() {
 
     private companion object {
         const val nodeJarName = "corda.jar"
@@ -43,7 +44,7 @@ open class Baseform : DefaultTask() {
 
     @get:Optional
     @get:Nested
-    protected val networkParameterOverrides : NetworkParameterOverrides = NetworkParameterOverrides(project)
+    protected val networkParameterOverrides: NetworkParameterOverrides = objects.newInstance(NetworkParameterOverrides::class.java, project)
 
     /**
      * Set the directory to install nodes into.
@@ -78,7 +79,7 @@ open class Baseform : DefaultTask() {
      * Configuration for keystore generation and JAR signing.
      */
     @get:Input
-    val signing: KeyGenAndSigning = project.objects.newInstance(KeyGenAndSigning::class.java)
+    val signing: KeyGenAndSigning = objects.newInstance(KeyGenAndSigning::class.java)
 
     fun signing(action: Action<in KeyGenAndSigning>) {
         action.execute(signing)
@@ -277,7 +278,7 @@ open class Baseform : DefaultTask() {
 
     private fun invokeBootstrap(networkBootstrapperClass: Class<*>, rootDir: Path, allCordapps: List<Path>) {
         try {
-            if (networkParameterOverrides.packageOwnerships.isEmpty()) {
+            if (networkParameterOverrides.packageOwnership.isEmpty()) {
                 val bootstrapMethod = networkBootstrapperClass.getMethod("bootstrapCordform", Path::class.java, List::class.java).apply { isAccessible = true }
                 bootstrapMethod.invoke(networkBootstrapperClass.newInstance(), rootDir, allCordapps)
             } else {

--- a/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
@@ -35,10 +35,10 @@ open class Baseform : DefaultTask() {
         const val nodeJarName = "corda.jar"
     }
 
-    @Input
+    @get:Input
     var directory: Path = project.buildDir.toPath().resolve("nodes")
 
-    @Nested
+    @get:Nested
     protected val nodes = mutableListOf<Node>()
 
     @get:Optional
@@ -70,14 +70,14 @@ open class Baseform : DefaultTask() {
      * support this for a [Closure]. However, these defaults are
      * applied to every node anyway so [Internal] should be fine.
      */
-    @Optional
-    @Internal
+    @get:Optional
+    @get:Internal
     var nodeDefaults: Closure<in Node>? = null
 
     /**
      * Configuration for keystore generation and JAR signing.
      */
-    @Input
+    @get:Input
     val signing: KeyGenAndSigning = project.objects.newInstance(KeyGenAndSigning::class.java)
 
     fun signing(action: Action<in KeyGenAndSigning>) {
@@ -87,7 +87,7 @@ open class Baseform : DefaultTask() {
     /**
      * List of classes to be included in "exclude_whitelist.txt" file for network-bootstrapper.
      */
-    @Input
+    @get:Input
     var excludeWhitelist: List<String> = listOf()
 
     fun excludeWhitelist(map: List<String>) {

--- a/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
@@ -46,6 +46,10 @@ open class Baseform(objects: ObjectFactory) : DefaultTask() {
     @get:Nested
     protected val networkParameterOverrides: NetworkParameterOverrides = objects.newInstance(NetworkParameterOverrides::class.java, project)
 
+    fun networkParameterOverrides(action: Action<in NetworkParameterOverrides>) {
+        action.execute(networkParameterOverrides)
+    }
+
     /**
      * Set the directory to install nodes into.
      *
@@ -119,10 +123,6 @@ open class Baseform(objects: ObjectFactory) : DefaultTask() {
             node.configureFunc()
             nodes += node
         }
-    }
-
-    fun networkParameterOverrides(action: Action<in NetworkParameterOverrides>) {
-        action.execute(networkParameterOverrides)
     }
 
     /**

--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordapp.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordapp.kt
@@ -13,14 +13,14 @@ open class Cordapp private constructor(
     constructor(cordappProject: Project) : this(null, cordappProject)
 
     // The configuration text that will be written
-    @Optional
-    @Input
+    @get:Optional
+    @get:Input
     internal var config: String? = null
 
     /**
      * Determines whether or not CordFormation will deploy this CorDapp into Corda.
      */
-    @Input
+    @get:Input
     var deploy: Boolean = true
 
     /**

--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordapp.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordapp.kt
@@ -4,10 +4,11 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import java.io.File
+import javax.inject.Inject
 
-open class Cordapp private constructor(
-    @get:[Optional Input] val coordinates: String?,
-    @get:[Optional Input] val project: Project?
+open class Cordapp @Inject constructor(
+        @get:[Optional Input] val coordinates: String?,
+        @get:[Optional Input] val project: Project?
 ) {
     constructor(coordinates: String) : this(coordinates, null)
     constructor(cordappProject: Project) : this(null, cordappProject)

--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordform.kt
@@ -1,7 +1,9 @@
 package net.corda.plugins
 
 import org.apache.tools.ant.filters.FixCrLfFilter
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.TaskAction
+import javax.inject.Inject
 
 /**
  * Creates nodes based on the configuration of this task in the gradle configuration DSL.
@@ -9,7 +11,7 @@ import org.gradle.api.tasks.TaskAction
  * See documentation for examples.
  */
 @Suppress("unused")
-open class Cordform : Baseform() {
+open class Cordform @Inject constructor(objects: ObjectFactory) : Baseform(objects) {
     internal companion object {
         const val nodeJarName = "corda.jar"
     }

--- a/cordformation/src/main/kotlin/net/corda/plugins/Dockerform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Dockerform.kt
@@ -1,5 +1,6 @@
 package net.corda.plugins
 
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.TaskAction
 import org.yaml.snakeyaml.DumperOptions
@@ -8,6 +9,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import javax.inject.Inject
 
 /**
  * Creates docker-compose file and image definitions based on the configuration of this task in the gradle configuration DSL.
@@ -15,7 +17,7 @@ import java.nio.file.Paths
  * See documentation for examples.
  */
 @Suppress("unused")
-open class Dockerform : Baseform() {
+open class Dockerform @Inject constructor(objects: ObjectFactory) : Baseform(objects) {
     private companion object {
         const val nodeJarName = "corda.jar"
         private val defaultDirectory: Path = Paths.get("build", "docker")

--- a/cordformation/src/main/kotlin/net/corda/plugins/Dockerform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Dockerform.kt
@@ -3,11 +3,11 @@ package net.corda.plugins
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.TaskAction
 import org.yaml.snakeyaml.DumperOptions
-import java.nio.file.Path
-import java.nio.file.Paths
 import org.yaml.snakeyaml.Yaml
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
 
 /**
  * Creates docker-compose file and image definitions based on the configuration of this task in the gradle configuration DSL.
@@ -31,7 +31,7 @@ open class Dockerform : Baseform() {
 
     private val directoryPath: Path = project.projectDir.toPath().resolve(directory)
 
-    @InputFile
+    @get:InputFile
     val dockerComposePath: Path = directoryPath.resolve("docker-compose.yml")
 
     /**

--- a/cordformation/src/main/kotlin/net/corda/plugins/NetworkParameterOverrides.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/NetworkParameterOverrides.kt
@@ -1,0 +1,29 @@
+package net.corda.plugins
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigObject
+import com.typesafe.config.ConfigValueFactory
+import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.Project
+import org.gradle.api.tasks.Nested
+import javax.inject.Inject
+
+open class NetworkParameterOverrides @Inject constructor(project: Project) {
+
+    @get:Nested
+    val packageOwnerships: NamedDomainObjectContainer<PackageOwnership> = project.container(PackageOwnership::class.java)
+
+    fun packageOwnership(action: Action<NamedDomainObjectContainer<in PackageOwnership>>) {
+        action.execute(packageOwnerships)
+    }
+
+    fun toConfig(): Config {
+        val packageOwnershipsList = mutableListOf<ConfigObject?>()
+        packageOwnerships.forEach { packageOwnershipsList.add(it.toConfigObject()) }
+        val packageOwnershipsConfigObjectList = ConfigValueFactory.fromIterable(packageOwnershipsList)
+
+        return ConfigFactory.empty().withValue("networkParameterOverrides", ConfigValueFactory.fromMap(mapOf("packageOwnership" to packageOwnershipsConfigObjectList)))
+    }
+}

--- a/cordformation/src/main/kotlin/net/corda/plugins/NetworkParameterOverrides.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/NetworkParameterOverrides.kt
@@ -20,7 +20,7 @@ open class NetworkParameterOverrides @Inject constructor(project: Project) {
     }
 
     fun toConfig(): Config {
-        val packageOwnershipsList = mutableListOf<ConfigObject?>()
+        val packageOwnershipsList = mutableListOf<ConfigObject>()
         packageOwnership.forEach { packageOwnershipsList.add(it.toConfigObject()) }
         val packageOwnershipsConfigObjectList = ConfigValueFactory.fromIterable(packageOwnershipsList)
 

--- a/cordformation/src/main/kotlin/net/corda/plugins/NetworkParameterOverrides.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/NetworkParameterOverrides.kt
@@ -13,15 +13,15 @@ import javax.inject.Inject
 open class NetworkParameterOverrides @Inject constructor(project: Project) {
 
     @get:Nested
-    val packageOwnerships: NamedDomainObjectContainer<PackageOwnership> = project.container(PackageOwnership::class.java)
+    val packageOwnership: NamedDomainObjectContainer<PackageOwnership> = project.container(PackageOwnership::class.java)
 
     fun packageOwnership(action: Action<NamedDomainObjectContainer<in PackageOwnership>>) {
-        action.execute(packageOwnerships)
+        action.execute(packageOwnership)
     }
 
     fun toConfig(): Config {
         val packageOwnershipsList = mutableListOf<ConfigObject?>()
-        packageOwnerships.forEach { packageOwnershipsList.add(it.toConfigObject()) }
+        packageOwnership.forEach { packageOwnershipsList.add(it.toConfigObject()) }
         val packageOwnershipsConfigObjectList = ConfigValueFactory.fromIterable(packageOwnershipsList)
 
         return ConfigFactory.empty().withValue("networkParameterOverrides", ConfigValueFactory.fromMap(mapOf("packageOwnership" to packageOwnershipsConfigObjectList)))

--- a/cordformation/src/main/kotlin/net/corda/plugins/NetworkParameterOverrides.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/NetworkParameterOverrides.kt
@@ -15,7 +15,7 @@ open class NetworkParameterOverrides @Inject constructor(project: Project) {
     @get:Nested
     val packageOwnership: NamedDomainObjectContainer<PackageOwnership> = project.container(PackageOwnership::class.java)
 
-    fun packageOwnership(action: Action<NamedDomainObjectContainer<in PackageOwnership>>) {
+    fun packageOwnership(action: Action<in NamedDomainObjectContainer<PackageOwnership>>) {
         action.execute(packageOwnership)
     }
 

--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -8,7 +8,9 @@ import org.apache.commons.io.FilenameUtils.removeExtension
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 import java.io.File
 import java.nio.charset.StandardCharsets
@@ -77,27 +79,27 @@ open class Node @Inject constructor(private val project: Project) {
      *
      * Incorrect configurations will not cause a DSL error.
      */
-    @Optional
-    @Input
+    @get:Optional
+    @get:Input
     var rpcUsers: List<Map<String, Any>> = emptyList()
 
     /**
      * Apply the notary configuration if this node is a notary. The map is the config structure of
      * net.corda.node.services.config.NotaryConfig
      */
-    @Optional
-    @Input
+    @get:Optional
+    @get:Input
     var notary: Map<String, Any> = emptyMap()
 
-    @Optional
-    @Input
+    @get:Optional
+    @get:Input
     var extraConfig: Map<String, Any> = emptyMap()
 
     /**
      * Copy files into the node relative directory './drivers'.
      */
-    @Optional
-    @Input
+    @get:Optional
+    @get:Input
     var drivers: List<String>? = null
 
     /**

--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -47,7 +47,9 @@ open class Node @Inject constructor(private val project: Project) {
         }
 
     private val internalCordapps = mutableListOf<Cordapp>()
-    private val builtCordapp = Cordapp(project)
+    @get:Optional
+    @get:Nested
+    val projectCordapp = project.objects.newInstance(Cordapp::class.java, "", project)
     internal lateinit var nodeDir: File
         @Internal get
         private set
@@ -273,7 +275,7 @@ open class Node @Inject constructor(private val project: Project) {
      * @return The created and inserted [Cordapp]
      */
     fun cordapp(coordinates: String, configureClosure: Closure<in Cordapp>): Cordapp {
-        val cordapp = project.configure(Cordapp(coordinates), configureClosure) as Cordapp
+        val cordapp = project.configure(Cordapp(coordinates, project), configureClosure) as Cordapp
         internalCordapps += cordapp
         return cordapp
     }
@@ -328,6 +330,12 @@ open class Node @Inject constructor(private val project: Project) {
         }
     }
 
+    fun cordapp(configureClosure: Closure<in Cordapp>): Cordapp {
+        val cordapp = project.configure(Cordapp(project), configureClosure) as Cordapp
+        internalCordapps += cordapp
+        return cordapp
+    }
+
     /**
      * Configures the default cordapp automatically added to this node from this project
      *
@@ -335,8 +343,8 @@ open class Node @Inject constructor(private val project: Project) {
      * @return The created and inserted [Cordapp]
      */
     fun projectCordapp(configureClosure: Closure<in Cordapp>): Cordapp {
-        project.configure(builtCordapp, configureClosure) as Cordapp
-        return builtCordapp
+        project.configure(projectCordapp, configureClosure) as Cordapp
+        return projectCordapp
     }
 
     /**
@@ -604,7 +612,7 @@ open class Node @Inject constructor(private val project: Project) {
     @Internal
     internal fun getCordappList(): List<ResolvedCordapp> {
         return internalCordapps.mapNotNull(::resolveCordapp).let {
-            if (builtCordapp.deploy) (it + resolveBuiltCordapp()) else it
+            if (projectCordapp.deploy) (it + resolveBuiltCordapp()) else it
         }
     }
 
@@ -637,7 +645,7 @@ open class Node @Inject constructor(private val project: Project) {
 
     private fun resolveBuiltCordapp(): ResolvedCordapp {
         val projectCordappFile = project.tasks.getByName("jar").outputs.files.singleFile.toPath()
-        return ResolvedCordapp(projectCordappFile, builtCordapp.config)
+        return ResolvedCordapp(projectCordappFile, projectCordapp.config)
     }
 
     private fun getOptionalString(path: String): String? {

--- a/cordformation/src/main/kotlin/net/corda/plugins/PackageOwnership.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/PackageOwnership.kt
@@ -15,7 +15,7 @@ open class PackageOwnership (@get:Input val name: String) {
     @get:Input
     var keystoreAlias: String? = null
 
-    fun toConfigObject(): ConfigObject? {
+    fun toConfigObject(): ConfigObject {
         return ConfigValueFactory.fromMap(mapOf("packageName" to name,
                 "keystore" to keystore,
                 "keystorePassword" to keystorePassword,

--- a/cordformation/src/main/kotlin/net/corda/plugins/PackageOwnership.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/PackageOwnership.kt
@@ -1,0 +1,24 @@
+package net.corda.plugins
+
+import com.typesafe.config.ConfigObject
+import com.typesafe.config.ConfigValueFactory
+import org.gradle.api.tasks.Input
+
+open class PackageOwnership (@get:Input val name: String) {
+
+    @get:Input
+    var keystore: String? = null
+
+    @get:Input
+    var keystorePassword: String? = null
+
+    @get:Input
+    var keystoreAlias: String? = null
+
+    fun toConfigObject(): ConfigObject? {
+        return ConfigValueFactory.fromMap(mapOf("packageName" to name,
+                "keystore" to keystore,
+                "keystorePassword" to keystorePassword,
+                "keystoreAlias" to keystoreAlias))
+    }
+}

--- a/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
@@ -1,14 +1,24 @@
 package net.corda.plugins
 
+import net.corda.core.internal.SignedDataWithCert
+import net.corda.core.internal.ThreadLocalToggleField
+import net.corda.core.node.NetworkParameters
+import net.corda.core.serialization.SerializationDefaults
+import net.corda.core.serialization.SerializedBytes
+import net.corda.core.serialization.deserialize
+import net.corda.core.serialization.internal.SerializationEnvironment
+import net.corda.nodeapi.internal.network.NetworkBootstrapper
+import net.corda.serialization.internal.AMQP_P2P_CONTEXT
+import net.corda.serialization.internal.SerializationFactoryImpl
 import org.apache.commons.io.IOUtils
-import org.assertj.core.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
-import org.gradle.testkit.runner.GradleRunner
-import org.gradle.testkit.runner.TaskOutcome
 
 class CordformTest {
     @Rule
@@ -17,7 +27,8 @@ class CordformTest {
     private lateinit var buildFile: File
 
     private companion object {
-        const val cordaFinanceJarName = "corda-finance-3.0-SNAPSHOT"
+        const val cordaFinanceWorkflowsJarName = "corda-finance-workflows-4.0"
+        const val cordaFinanceContractsJarName = "corda-finance-contracts-4.0"
         const val localCordappJarName = "locally-built-cordapp"
         const val notaryNodeName = "Notary Service"
 
@@ -30,13 +41,50 @@ class CordformTest {
     }
 
     @Test
+    fun `network parameter overrides`() {
+        val runner = getStandardGradleRunnerFor("DeploySingleNodeWithNetworkParameterOverrides.gradle")
+
+        val result = runner.build()
+
+        assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).exists()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).exists()
+        assertThat(getNetworkParameterOverrides(notaryNodeName)).exists()
+
+        ThreadLocalToggleField<SerializationEnvironment>("contextSerializationEnv")
+        net.corda.core.serialization.internal._contextSerializationEnv.set(SerializationEnvironment.with(
+                SerializationFactoryImpl().apply {
+                    registerScheme(NetworkBootstrapper.AMQPParametersSerializationScheme())
+                },
+                AMQP_P2P_CONTEXT)
+        )
+        val serializedBytes = SerializedBytes<SignedDataWithCert<NetworkParameters>>(getNetworkParameterOverrides(notaryNodeName).readBytes())
+        val deserialized = serializedBytes.deserialize(SerializationDefaults.SERIALIZATION_FACTORY).raw.deserialize().packageOwnership
+        assertThat(deserialized.containsKey("com.mypackagename")).isTrue()
+    }
+
+    @Test
+    fun `a node with cordapp dependency - backwards compatibility`() {
+        val runner = getStandardGradleRunnerFor("DeploySingleNodeWithCordappBackwardsCompatibility.gradle")
+
+        val result = runner.build()
+
+        assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).exists()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).exists()
+        assertThat(getNetworkParameterOverrides(notaryNodeName)).exists()
+    }
+
+    @Test
     fun `a node with cordapp dependency`() {
         val runner = getStandardGradleRunnerFor("DeploySingleNodeWithCordapp.gradle")
 
         val result = runner.build()
 
         assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceJarName)).exists()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).exists()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).exists()
+        assertThat(getNetworkParameterOverrides(notaryNodeName)).exists()
     }
 
     @Test
@@ -46,8 +94,10 @@ class CordformTest {
         val result = runner.build()
 
         assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceJarName)).exists()
-        assertThat(getNodeCordappConfig(notaryNodeName, cordaFinanceJarName)).exists()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).exists()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).exists()
+        assertThat(getNodeCordappConfig(notaryNodeName, cordaFinanceWorkflowsJarName)).exists()
+        assertThat(getNodeCordappConfig(notaryNodeName, cordaFinanceContractsJarName)).exists()
     }
 
     @Test
@@ -64,6 +114,7 @@ class CordformTest {
     private fun getStandardGradleRunnerFor(buildFileResourceName: String): GradleRunner {
         createBuildFile(buildFileResourceName)
         return GradleRunner.create()
+                .withDebug(true)
                 .withProjectDir(testProjectDir.root)
                 .withArguments("deployNodes", "-s", "--info", "-g", testGradleUserHome)
                 .withPluginClasspath()
@@ -71,5 +122,6 @@ class CordformTest {
 
     private fun createBuildFile(buildFileResourceName: String) = IOUtils.copy(javaClass.getResourceAsStream(buildFileResourceName), buildFile.outputStream())
     private fun getNodeCordappJar(nodeName: String, cordappJarName: String) = File(testProjectDir.root, "build/nodes/$nodeName/cordapps/$cordappJarName.jar")
-    private fun getNodeCordappConfig(nodeName: String, cordappJarName: String) = File(testProjectDir.root, "build/nodes/$nodeName/cordapps/$cordappJarName.conf")
+    private fun getNodeCordappConfig(nodeName: String, cordappJarName: String) = File(testProjectDir.root, "build/nodes/$nodeName/cordapps/config/$cordappJarName.conf")
+    private fun getNetworkParameterOverrides(nodeName: String) = File(testProjectDir.root, "build/nodes/$nodeName/network-parameters")
 }

--- a/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
@@ -52,9 +52,9 @@ class CordformTest {
         val result = runner.build()
 
         assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).exists()
-        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).exists()
-        assertThat(getNetworkParameterOverrides(notaryNodeName)).exists()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isFile()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isFile()
+        assertThat(getNetworkParameterOverrides(notaryNodeName)).isFile()
 
         ThreadLocalToggleField<SerializationEnvironment>("contextSerializationEnv")
         net.corda.core.serialization.internal._contextSerializationEnv.set(SerializationEnvironment.with(
@@ -75,9 +75,9 @@ class CordformTest {
         val result = runner.build()
 
         assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).exists()
-        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).exists()
-        assertThat(getNetworkParameterOverrides(notaryNodeName)).exists()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isFile()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isFile()
+        assertThat(getNetworkParameterOverrides(notaryNodeName)).isFile()
     }
 
     @Test
@@ -87,9 +87,9 @@ class CordformTest {
         val result = runner.build()
 
         assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).exists()
-        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).exists()
-        assertThat(getNetworkParameterOverrides(notaryNodeName)).exists()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isFile()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isFile()
+        assertThat(getNetworkParameterOverrides(notaryNodeName)).isFile()
     }
 
     @Test
@@ -99,10 +99,10 @@ class CordformTest {
         val result = runner.build()
 
         assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).exists()
-        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).exists()
-        assertThat(getNodeCordappConfig(notaryNodeName, cordaFinanceWorkflowsJarName)).exists()
-        assertThat(getNodeCordappConfig(notaryNodeName, cordaFinanceContractsJarName)).exists()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isFile()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isFile()
+        assertThat(getNodeCordappConfig(notaryNodeName, cordaFinanceWorkflowsJarName)).isFile()
+        assertThat(getNodeCordappConfig(notaryNodeName, cordaFinanceContractsJarName)).isFile()
     }
 
     @Test
@@ -112,8 +112,8 @@ class CordformTest {
         val result = runner.build()
 
         assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        assertThat(getNodeCordappJar(notaryNodeName, localCordappJarName)).exists()
-        assertThat(getNodeCordappConfig(notaryNodeName, localCordappJarName)).exists()
+        assertThat(getNodeCordappJar(notaryNodeName, localCordappJarName)).isFile()
+        assertThat(getNodeCordappConfig(notaryNodeName, localCordappJarName)).isFile()
     }
 
     private fun getStandardGradleRunnerFor(buildFileResourceName: String): GradleRunner {

--- a/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
@@ -18,6 +18,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -43,6 +44,7 @@ class CordformTest {
         buildFile = testProjectDir.newFile("build.gradle")
     }
 
+    @Ignore
     @Test
     fun `network parameter overrides`() {
         val runner = getStandardGradleRunnerFor("DeploySingleNodeWithNetworkParameterOverrides.gradle")

--- a/cordformation/src/test/kotlin/net/corda/plugins/NetworkParameterOverridesTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/NetworkParameterOverridesTest.kt
@@ -1,0 +1,54 @@
+package net.corda.plugins
+
+import com.typesafe.config.*
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class NetworkParameterOverridesTest {
+
+    @Before
+    fun setUp() {
+    }
+
+    @After
+    fun tearDown() {
+    }
+
+    @Test
+    fun toConfig() {
+        val project = ProjectBuilder.builder().build()
+        val networkParameterOverrides = createNetworkParameterOverrides(project)
+
+        val config = networkParameterOverrides.toConfig()!!
+        val renderString = config.root().render(ConfigRenderOptions.concise())
+        val configFromString = ConfigFactory.parseString(renderString)
+        val configObject = configFromString.getObject("networkParameterOverrides")
+        val value = configObject.getValue("packageOwnership") as ConfigList
+        assertThat(value.size).isEqualTo(1)
+
+        val configValue = value[0] as ConfigObject
+        assertThat(configValue.size).isEqualTo(4)
+
+        val expected = ConfigValueFactory.fromMap(mapOf("keystore" to "keystore", "keystoreAlias" to "keystoreAlias", "keystorePassword" to "keystorePassword", "packageName" to "packageName"))
+        assertThat(configValue["keystore"]).isEqualTo(expected["keystore"])
+        assertThat(configValue["keystoreAlias"]).isEqualTo(expected["keystoreAlias"])
+        assertThat(configValue["keystorePassword"]).isEqualTo(expected["keystorePassword"])
+        assertThat(configValue["packageName"]).isEqualTo(expected["packageName"])
+    }
+
+    companion object {
+        fun createNetworkParameterOverrides(project: Project): NetworkParameterOverrides {
+            val networkParameterOverrides = NetworkParameterOverrides(project)
+            val packageOwnership = PackageOwnership("packageName")
+            packageOwnership.keystore = "keystore"
+            packageOwnership.keystoreAlias = "keystoreAlias"
+            packageOwnership.keystorePassword = "keystorePassword"
+            networkParameterOverrides.packageOwnerships.add(packageOwnership)
+            return networkParameterOverrides
+        }
+    }
+}

--- a/cordformation/src/test/kotlin/net/corda/plugins/NetworkParameterOverridesTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/NetworkParameterOverridesTest.kt
@@ -23,7 +23,7 @@ class NetworkParameterOverridesTest {
         val project = ProjectBuilder.builder().build()
         val networkParameterOverrides = createNetworkParameterOverrides(project)
 
-        val config = networkParameterOverrides.toConfig()!!
+        val config = networkParameterOverrides.toConfig()
         val renderString = config.root().render(ConfigRenderOptions.concise())
         val configFromString = ConfigFactory.parseString(renderString)
         val configObject = configFromString.getObject("networkParameterOverrides")

--- a/cordformation/src/test/kotlin/net/corda/plugins/NetworkParameterOverridesTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/NetworkParameterOverridesTest.kt
@@ -4,19 +4,9 @@ import com.typesafe.config.*
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
-import org.junit.After
-import org.junit.Before
 import org.junit.Test
 
 class NetworkParameterOverridesTest {
-
-    @Before
-    fun setUp() {
-    }
-
-    @After
-    fun tearDown() {
-    }
 
     @Test
     fun toConfig() {

--- a/cordformation/src/test/kotlin/net/corda/plugins/NetworkParameterOverridesTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/NetworkParameterOverridesTest.kt
@@ -47,7 +47,7 @@ class NetworkParameterOverridesTest {
             packageOwnership.keystore = "keystore"
             packageOwnership.keystoreAlias = "keystoreAlias"
             packageOwnership.keystorePassword = "keystorePassword"
-            networkParameterOverrides.packageOwnerships.add(packageOwnership)
+            networkParameterOverrides.packageOwnership.add(packageOwnership)
             return networkParameterOverrides
         }
     }

--- a/cordformation/src/test/kotlin/net/corda/plugins/NetworkParameterOverridesTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/NetworkParameterOverridesTest.kt
@@ -33,7 +33,11 @@ class NetworkParameterOverridesTest {
         val configValue = value[0] as ConfigObject
         assertThat(configValue.size).isEqualTo(4)
 
-        val expected = ConfigValueFactory.fromMap(mapOf("keystore" to "keystore", "keystoreAlias" to "keystoreAlias", "keystorePassword" to "keystorePassword", "packageName" to "packageName"))
+        val expected = ConfigValueFactory.fromMap(
+                mapOf("keystore" to "keystore",
+                "keystoreAlias" to "keystoreAlias",
+                "keystorePassword" to "keystorePassword",
+                "packageName" to "packageName"))
         assertThat(configValue["keystore"]).isEqualTo(expected["keystore"])
         assertThat(configValue["keystoreAlias"]).isEqualTo(expected["keystoreAlias"])
         assertThat(configValue["keystorePassword"]).isEqualTo(expected["keystorePassword"])

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordapp.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordapp.gradle
@@ -12,7 +12,6 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-dev' }
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordapp.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordapp.gradle
@@ -1,8 +1,7 @@
 buildscript {
     ext {
         corda_group = 'net.corda'
-        corda_release_version = '5.0-SNAPSHOT' // TODO: Set to 5.0 when Corda 5 is released
-        finance_release_version = '4.0'
+        corda_release_version = '4.0'
         jolokia_version = '1.6.0'
     }
 }
@@ -23,8 +22,8 @@ repositories {
 dependencies {
     runtime "$corda_group:corda:$corda_release_version"
     runtime "$corda_group:corda-node-api:$corda_release_version"
-    cordapp "$corda_group:corda-finance-contracts:$finance_release_version"
-    cordapp "$corda_group:corda-finance-workflows:$finance_release_version"
+    cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
+    cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform) {
@@ -39,7 +38,7 @@ task deployNodes(type: net.corda.plugins.Cordform) {
         rpcSettings {
             adminAddress "localhost:10004"
         }
-        cordapps = ["$corda_group:corda-finance-contracts:$finance_release_version",
-                    "$corda_group:corda-finance-workflows:$finance_release_version"]
+        cordapps = ["$corda_group:corda-finance-contracts:$corda_release_version",
+                    "$corda_group:corda-finance-workflows:$corda_release_version"]
     }
 }

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordapp.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordapp.gradle
@@ -1,7 +1,8 @@
 buildscript {
     ext {
         corda_group = 'net.corda'
-        corda_release_version = '3.0-SNAPSHOT' // TODO: Set to 3.0.0 when Corda 3 is released
+        corda_release_version = '5.0-SNAPSHOT' // TODO: Set to 5.0 when Corda 5 is released
+        finance_release_version = '4.0'
         jolokia_version = '1.6.0'
     }
 }
@@ -12,6 +13,7 @@ plugins {
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-dev' }
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }
@@ -21,15 +23,23 @@ repositories {
 dependencies {
     runtime "$corda_group:corda:$corda_release_version"
     runtime "$corda_group:corda-node-api:$corda_release_version"
-    cordapp "$corda_group:corda-finance:$corda_release_version"
+    cordapp "$corda_group:corda-finance-contracts:$finance_release_version"
+    cordapp "$corda_group:corda-finance-workflows:$finance_release_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform) {
     node {
+        projectCordapp {
+            deploy false
+        }
         name 'O=Notary Service,L=Zurich,C=CH'
         notary = [validating : true]
         p2pPort 10002
         rpcPort 10003
-        cordapps = ["$corda_group:corda-finance:$corda_release_version"]
+        rpcSettings {
+            adminAddress "localhost:10004"
+        }
+        cordapps = ["$corda_group:corda-finance-contracts:$finance_release_version",
+                    "$corda_group:corda-finance-workflows:$finance_release_version"]
     }
 }

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappBackwardsCompatibility.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappBackwardsCompatibility.gradle
@@ -12,7 +12,6 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-dev' }
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappBackwardsCompatibility.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappBackwardsCompatibility.gradle
@@ -1,8 +1,7 @@
 buildscript {
     ext {
         corda_group = 'net.corda'
-        corda_release_version = '5.0-SNAPSHOT' // TODO: Set to 5.0 when Corda 5 is released
-        finance_release_version = '4.0'
+        corda_release_version = '4.0'
         jolokia_version = '1.6.0'
     }
 }
@@ -23,8 +22,8 @@ repositories {
 dependencies {
     runtime "$corda_group:corda:$corda_release_version"
     runtime "$corda_group:corda-node-api:$corda_release_version"
-    cordapp "$corda_group:corda-finance-contracts:$finance_release_version"
-    cordapp "$corda_group:corda-finance-workflows:$finance_release_version"
+    cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
+    cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform) {
@@ -39,11 +38,7 @@ task deployNodes(type: net.corda.plugins.Cordform) {
         rpcSettings {
             adminAddress "localhost:10004"
         }
-        cordapp "$corda_group:corda-finance-contracts:$finance_release_version", {
-            config "a=b"
-        }
-        cordapp "$corda_group:corda-finance-workflows:$finance_release_version", {
-            config "a=b"
-        }
+        cordapps = ["$corda_group:corda-finance-contracts:$corda_release_version",
+                    "$corda_group:corda-finance-workflows:$corda_release_version"]
     }
 }

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappConfig.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappConfig.gradle
@@ -12,7 +12,6 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-dev' }
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappConfig.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappConfig.gradle
@@ -1,8 +1,7 @@
 buildscript {
     ext {
         corda_group = 'net.corda'
-        corda_release_version = '5.0-SNAPSHOT' // TODO: Set to 5.0 when Corda 5 is released
-        finance_release_version = '4.0'
+        corda_release_version = '4.0'
         jolokia_version = '1.6.0'
     }
 }
@@ -23,8 +22,8 @@ repositories {
 dependencies {
     runtime "$corda_group:corda:$corda_release_version"
     runtime "$corda_group:corda-node-api:$corda_release_version"
-    cordapp "$corda_group:corda-finance-contracts:$finance_release_version"
-    cordapp "$corda_group:corda-finance-workflows:$finance_release_version"
+    cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
+    cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform) {
@@ -39,10 +38,10 @@ task deployNodes(type: net.corda.plugins.Cordform) {
         rpcSettings {
             adminAddress "localhost:10004"
         }
-        cordapp "$corda_group:corda-finance-contracts:$finance_release_version", {
+        cordapp "$corda_group:corda-finance-contracts:$corda_release_version", {
             config "a=b"
         }
-        cordapp "$corda_group:corda-finance-workflows:$finance_release_version", {
+        cordapp "$corda_group:corda-finance-workflows:$corda_release_version", {
             config "a=b"
         }
     }

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
@@ -12,7 +12,6 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-dev' }
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
@@ -1,7 +1,8 @@
 buildscript {
     ext {
         corda_group = 'net.corda'
-        corda_release_version = '3.0-SNAPSHOT' // TODO: Set to 3.0.0 when Corda 3 is released
+        corda_release_version = '5.0-SNAPSHOT' // TODO: Set to 5.0 when Corda 5 is released
+        finance_release_version = '4.0'
         jolokia_version = '1.6.0'
     }
 }
@@ -12,6 +13,7 @@ plugins {
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-dev' }
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }
@@ -21,7 +23,8 @@ repositories {
 dependencies {
     runtime "$corda_group:corda:$corda_release_version"
     runtime "$corda_group:corda-node-api:$corda_release_version"
-    cordapp "$corda_group:corda-finance:$corda_release_version"
+    cordapp "$corda_group:corda-finance-contracts:$finance_release_version"
+    cordapp "$corda_group:corda-finance-workflows:$finance_release_version"
 }
 
 jar {
@@ -34,6 +37,9 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: [jar]) {
         notary = [validating : true]
         p2pPort 10002
         rpcPort 10003
+        rpcSettings {
+            adminAddress "localhost:10004"
+        }
         cordapp {
             config "a=b"
         }

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
@@ -1,8 +1,7 @@
 buildscript {
     ext {
         corda_group = 'net.corda'
-        corda_release_version = '5.0-SNAPSHOT' // TODO: Set to 5.0 when Corda 5 is released
-        finance_release_version = '4.0'
+        corda_release_version = '4.0'
         jolokia_version = '1.6.0'
     }
 }
@@ -23,8 +22,6 @@ repositories {
 dependencies {
     runtime "$corda_group:corda:$corda_release_version"
     runtime "$corda_group:corda-node-api:$corda_release_version"
-    cordapp "$corda_group:corda-finance-contracts:$finance_release_version"
-    cordapp "$corda_group:corda-finance-workflows:$finance_release_version"
 }
 
 jar {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
@@ -37,7 +37,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: [jar]) {
         rpcSettings {
             adminAddress "localhost:10004"
         }
-        cordapp {
+        projectCordapp {
             config "a=b"
         }
     }

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithNetworkParameterOverrides.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithNetworkParameterOverrides.gradle
@@ -28,6 +28,15 @@ dependencies {
 }
 
 task deployNodes(type: net.corda.plugins.Cordform) {
+    networkParameterOverrides {
+        packageOwnership {
+            "com.mypackagename" {
+                keystore = "_teststore"
+                keystorePassword = "MyStorePassword"
+                keystoreAlias = "MyKeyAlias"
+            }
+        }
+    }
     node {
         projectCordapp {
             deploy false
@@ -39,11 +48,7 @@ task deployNodes(type: net.corda.plugins.Cordform) {
         rpcSettings {
             adminAddress "localhost:10004"
         }
-        cordapp "$corda_group:corda-finance-contracts:$finance_release_version", {
-            config "a=b"
-        }
-        cordapp "$corda_group:corda-finance-workflows:$finance_release_version", {
-            config "a=b"
-        }
+        cordapps = ["$corda_group:corda-finance-contracts:$finance_release_version",
+                    "$corda_group:corda-finance-workflows:$finance_release_version"]
     }
 }


### PR DESCRIPTION
[CORDA-2491](https://r3-cev.atlassian.net/browse/CORDA-2491)
- Added `NetworkParameterOverrides` and `PackageOwnership` support. These are optional fields.
- The old entrypoint will still be used when no `networkParameterOverrides` is set.
- Updated `CordformTest`, which was still targeting Corda 3. Given the circular dependencies between `Cordformation` and Corda, these tests are only relying on released artifacts when testing for backwards compatibility or deploying the finance application. The tests have been updated so it is easier to run manually, targeting locally installed `SNAPSHOT` versions of the dependencies.
- Annotated existing members to make a better usage of incremental builds.

Example:
```
task deployNodes(type: net.corda.plugins.Cordform) {
networkParameterOverrides {
        packageOwnership {
            "com.mypackagename" {
                keystore = "_teststore"
                keystorePassword = "MyStorePassword"
                keystoreAlias = "MyKeyAlias"
            }
        }
    }
[...]
}
```

Related with: corda/corda#5075, corda/corda#5081