### PR TITLE
 CORDA-2902: Remove file timestamps from contents of CorDapps.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ### Version 4.0.43
 
+* `cordapp`: Make file order inside the jar reproducible, and discard file timestamps.
+
 * `cordapp`: Compatibility fix for Gradle 5.2 and above.
 
 * `api-scanner`: Compatibility fix for Gradle 5.x.


### PR DESCRIPTION
Configure the CorDapp's jar task to remove the file timestamps from the jar's contents, and also to make the file order inside the jar reproducible. This make's Corda's CanonicalizerPlugin script obsolete.