### PR TITLE
CORDA-2903: Publish special POM tag to support Gradle plugins block.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,6 +133,31 @@ configure(publishProjects) { subproject ->
                     subproject.mavenPom.call(pom)
                 }
             }
+
+            // Create a "special" artifact in the Maven repository so that
+            // Gradle's plugins {} block can find our plugins:
+            //
+            // This artifact would normally be created by setting:
+            //
+            //     gradlePlugin {
+            //         automatedPublishing = true
+            //     }
+            //
+            // except that this would also discard all of our POM customisations.
+            create(subproject.name + "-plugin", MavenPublication) {
+                groupId subproject.group + '.' + subproject.name
+                artifactId subproject.group + '.' + subproject.name + '.gradle.plugin'
+
+                pom {
+                    packaging 'pom'
+                    withXml {
+                        def dependency = asNode().appendNode('dependencies').appendNode('dependency')
+                        dependency.appendNode('groupId', subproject.group)
+                        dependency.appendNode('artifactId', subproject.name)
+                        dependency.appendNode('version', subproject.version)
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Create the special POM artifact so that we can publish our Gradle plugins to a Maven repository and import them using the `plugins{}` block.