### PR TITLE
CORDA-2897: Simplify JarFilter's usage of directoryProperty().

### DIFF
--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/JarFilterTask.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/JarFilterTask.kt
@@ -66,9 +66,7 @@ open class JarFilterTask @Inject constructor(objects: ObjectFactory, layouts: Pr
     }
 
     @get:Internal
-    val outputDir: DirectoryProperty = layouts.directoryProperty().apply {
-        set(layouts.buildDirectory.dir("filtered-libs"))
-    }
+    val outputDir: DirectoryProperty = layouts.directoryProperty(layouts.buildDirectory.dir("filtered-libs"))
 
     fun outputDir(dir: File) {
         outputDir.set(dir)

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTask.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTask.kt
@@ -36,9 +36,7 @@ open class MetaFixerTask @Inject constructor(objects: ObjectFactory, layouts: Pr
     fun jars(inputs: Any?) = setJars(inputs)
 
     @get:Internal
-    val outputDir: DirectoryProperty = layouts.directoryProperty().apply {
-        set(layouts.buildDirectory.dir("metafixer-libs"))
-    }
+    val outputDir: DirectoryProperty = layouts.directoryProperty(layouts.buildDirectory.dir("metafixer-libs"))
 
     fun outputDir(dir: File) {
         outputDir.set(dir)


### PR DESCRIPTION
Use directoryProperty() that is initialised by a Provider - no need for a lambda.