### PR TITLE
CORDA-2907: Add test cases for CorDapp semi-fat jar Gradle configurations. (#193)

### DIFF
--- a/cordapp/src/test/kotlin/net/corda/plugins/CordappGradleConfigurationsTest.kt
+++ b/cordapp/src/test/kotlin/net/corda/plugins/CordappGradleConfigurationsTest.kt
@@ -1,0 +1,113 @@
+package net.corda.plugins
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.assertEquals
+import org.junit.BeforeClass
+import org.junit.ClassRule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.rules.TemporaryFolder
+import org.junit.rules.TestRule
+import java.util.stream.Collectors.toList
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+
+class CordappGradleConfigurationsTest {
+    companion object {
+        private val testProjectDir = TemporaryFolder()
+        private val testProject = GradleProject(testProjectDir)
+            .withBuildScript("""
+            |plugins {
+            |    id 'net.corda.plugins.cordapp'
+            |}
+            |
+            |apply from: 'repositories.gradle'
+            |
+            |version = '1.0-SNAPSHOT'
+            |group = 'com.example'
+            |
+            |dependencies {
+            |    compile "org.slf4j:slf4j-api:1.7.26"
+            |    runtime "org.slf4j:slf4j-simple:1.7.26"
+            |    cordaCompile "com.google.guava:guava:20.0"
+            |    cordaRuntime "javax.servlet:javax.servlet-api:3.1.0"
+            |    runtimeOnly "javax.validation:validation-api:1.1.0.Final"
+            |}
+            |
+            |jar {
+            |    archiveName = 'configurations.jar'
+            |}
+            |
+            |cordapp {
+            |    info {
+            |        name = 'Testing'
+            |        targetPlatformVersion = 5
+            |    }
+            |}
+        """.trimMargin())
+
+        @ClassRule
+        @JvmField
+        val rules: TestRule = RuleChain
+            .outerRule(testProjectDir)
+            .around(testProject)
+
+        private lateinit var poms: List<ZipEntry>
+
+        @BeforeClass
+        @JvmStatic
+        fun checkSetup() {
+            val cordapp = testProject.pathOf("build", "libs", "configurations.jar")
+            assertThat(cordapp).isRegularFile()
+
+            poms = ZipFile(cordapp.toFile()).stream()
+                .filter { entry -> entry.name.endsWith("/pom.xml") }
+                .collect(toList())
+        }
+    }
+
+    @Test
+    fun testCorrectNumberOfIncludes() {
+        assertEquals(2, poms.size)
+    }
+
+    @Test
+    fun testCompileIncluded() {
+        assertThat(testProject.output)
+            .contains("CorDapp dependency: slf4j-api-1.7.26.jar")
+        assertThat(poms)
+            .anyMatch { it.name == "META-INF/maven/org.slf4j/slf4j-api/pom.xml" }
+    }
+
+    @Test
+    fun testRuntimeIncluded() {
+        assertThat(testProject.output)
+            .contains("CorDapp dependency: slf4j-simple-1.7.26.jar")
+        assertThat(poms)
+            .anyMatch { it.name == "META-INF/maven/org.slf4j/slf4j-simple/pom.xml" }
+    }
+
+    @Test
+    fun testRuntimeOnlyExcluded() {
+        assertThat(testProject.output)
+            .doesNotContain("CorDapp dependency: validation-api-1.1.0.Final.jar")
+        assertThat(poms)
+            .noneMatch { it.name == "META-INF/maven/javax.validation/validation-api/pom.xml" }
+    }
+
+    @Test
+    fun testCordaRuntimeExcluded() {
+        assertThat(testProject.output)
+            .doesNotContain("CorDapp dependency: javax.servlet-api-3.1.0.jar")
+        assertThat(poms)
+            .noneMatch { it.name == "META-INF/maven/javax.servlet/javax.servlet-api/pom.xml" }
+    }
+
+    @Test
+    fun testCordaCompileExcluded() {
+        assertThat(testProject.output)
+            .doesNotContain("CorDapp dependency: guava-20.0.jar")
+        assertThat(poms)
+            .noneMatch { it.name == "META-INF/maven/com.google.guava/guava/pom.xml" }
+    }
+}

--- a/cordapp/src/test/kotlin/net/corda/plugins/GradleProject.kt
+++ b/cordapp/src/test/kotlin/net/corda/plugins/GradleProject.kt
@@ -1,0 +1,65 @@
+package net.corda.plugins
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome.*
+import org.junit.Assert.assertEquals
+import org.junit.rules.TemporaryFolder
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.test.fail
+
+class GradleProject(private val projectDir: TemporaryFolder) : TestRule {
+    private companion object {
+        private val testGradleUserHome = systemProperty("test.gradle.user.home")
+    }
+
+    private var buildScript: String = ""
+    private var taskName: String = "jar"
+
+    fun withTaskName(taskName: String): GradleProject {
+        this.taskName = taskName
+        return this
+    }
+
+    fun withBuildScript(buildScript: String): GradleProject {
+        this.buildScript = buildScript
+        return this
+    }
+
+    var output: String = ""
+        private set
+
+    fun pathOf(vararg elements: String): Path = Paths.get(projectDir.root.absolutePath, *elements)
+
+    override fun apply(statement: Statement, description: Description): Statement {
+        return object : Statement() {
+            override fun evaluate() {
+                installResource(projectDir, "repositories.gradle")
+                installResource(projectDir, "settings.gradle")
+                installResource(projectDir, "gradle.properties")
+                projectDir.newFile("build.gradle").writeText(buildScript)
+
+                val result = GradleRunner.create()
+                    .withProjectDir(projectDir.root)
+                    .withArguments(getGradleArgsForTasks(taskName))
+                    .withPluginClasspath()
+                    .withDebug(true)
+                    .build()
+                output = result.output
+                println(output)
+
+                val taskResult = result.task(":$taskName") ?: fail("No outcome for $taskName task")
+                assertEquals(SUCCESS, taskResult.outcome)
+
+                statement.evaluate()
+            }
+        }
+    }
+
+    private fun getGradleArgsForTasks(vararg taskNames: String): List<String> {
+        return arrayListOf(*taskNames, "--info", "--stacktrace", "-g", testGradleUserHome)
+    }
+}

--- a/cordapp/src/test/resources/gradle.properties
+++ b/cordapp/src/test/resources/gradle.properties
@@ -1,0 +1,1 @@
+# Placeholder for common Gradle properties.

--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
@@ -3,6 +3,7 @@ package net.corda.plugins
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ModuleDependency
+import org.gradle.api.plugins.JavaPlugin
 import java.io.File
 
 /**
@@ -54,6 +55,10 @@ class Cordformation : Plugin<Project> {
     }
 
     override fun apply(project: Project) {
+        // Apply the Java plugin on the assumption that we're building a JAR.
+        // This will also create the "compile", "compileOnly" and "runtime" configurations.
+        project.pluginManager.apply(JavaPlugin::class.java)
+
         project.configurations.apply {
             Utils.createCompileConfiguration("cordapp", this)
             val cordaRuntime = Utils.createRuntimeConfiguration("cordaRuntime", this)

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordapp.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordapp.gradle
@@ -7,7 +7,6 @@ buildscript {
 }
 
 plugins {
-    id 'java'
     id 'net.corda.plugins.cordformation'
 }
 

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappBackwardsCompatibility.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappBackwardsCompatibility.gradle
@@ -7,7 +7,6 @@ buildscript {
 }
 
 plugins {
-    id 'java'
     id 'net.corda.plugins.cordformation'
 }
 

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappConfig.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappConfig.gradle
@@ -7,7 +7,6 @@ buildscript {
 }
 
 plugins {
-    id 'java'
     id 'net.corda.plugins.cordformation'
 }
 

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
@@ -7,7 +7,6 @@ buildscript {
 }
 
 plugins {
-    id 'java'
     id 'net.corda.plugins.cordformation'
 }
 

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithNetworkParameterOverrides.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithNetworkParameterOverrides.gradle
@@ -8,7 +8,6 @@ buildscript {
 }
 
 plugins {
-    id 'java'
     id 'net.corda.plugins.cordformation'
 }
 


### PR DESCRIPTION
* Add test cases for CorDapp semi-fat jar Gradle configurations.
* Remove explicit `java` plugin from Cordformation test cases, as it's no longer required.