### PR TITLE
CORDA-2915: Configure the CorDapp Jar task to create a stable SHA256 hash.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ### Version 5.0.0
 
+* `cordapp`: Explicitly configure all of the CorDapp's `jar` task properties to ensure the CorDapp has a stable SHA256 hash.
+
 * `cordformation`: Add support for network parameter overrides.
 
 * `cordapp`: Make file order inside the jar reproducible, and discard file timestamps.


### PR DESCRIPTION
Removing file timestamps from the jar's contents is not enough. We also need to specify file and directory permission bits explicitly, and then set every other option which may alter the jar output.