### PR TITLE
CORDA-2917: Preliminary migration to JUnit 5.

### DIFF
--- a/api-scanner/build.gradle
+++ b/api-scanner/build.gradle
@@ -37,15 +37,17 @@ configurations {
 }
 
 dependencies {
-    compile "io.github.lukehutch:fast-classpath-scanner:2.18.2"
-    testCompile project(':api-scanner:annotations')
-    testCompile "org.assertj:assertj-core:$assertj_version"
-    testCompile "junit:junit:$junit_version"
+    implementation "io.github.lukehutch:fast-classpath-scanner:2.18.2"
+    testImplementation project(':api-scanner:annotations')
+    testImplementation "org.assertj:assertj-core:$assertj_version"
+    testImplementation "junit:junit:$junit_version"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher:$junit_platform_version"
 
     // This dependency is only to prevent IntelliJ from choking
     // on the Kotlin classes in the test/resources directory.
-    testCompile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    testCompile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     jacocoRuntime "org.jacoco:org.jacoco.agent:${jacoco.toolVersion}:runtime"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,9 @@ buildscript {
         artifactory_plugin_version = '4.7.3'
         snake_yaml_version = '1.19'
         commons_io_version = '2.6'
-        assertj_version = '3.9.1'
+        assertj_version = '3.12.1'
+        junit_jupiter_version = '5.4.2'
+        junit_platform_version = '1.4.2'
         junit_version = '4.12'
         asm_version = '6.2.1'
     }
@@ -56,6 +58,8 @@ allprojects {
     }
 
     tasks.withType(Test) {
+        useJUnitPlatform()
+
         // Prevent the project from creating temporary files outside of the build directory.
         systemProperty 'java.io.tmpdir', buildDir.absolutePath
 

--- a/cordapp/build.gradle
+++ b/cordapp/build.gradle
@@ -36,8 +36,10 @@ dependencies {
     // own provided Kotlin libraries at runtime. So ensure that
     // we don't add Kotlin as a dependency in our published POM.
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    testImplementation "org.jetbrains.kotlin:kotlin-test-junit"
     testImplementation "commons-io:commons-io:$commons_io_version"
-    testImplementation "junit:junit:$junit_version" // TODO: Unify with core
+    testImplementation "org.jetbrains.kotlin:kotlin-test"
+    testImplementation("org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junit_jupiter_version")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junit_platform_version")
     testImplementation "org.assertj:assertj-core:$assertj_version"
 }

--- a/cordapp/src/test/kotlin/net/corda/plugins/CordappGradleConfigurationsTest.kt
+++ b/cordapp/src/test/kotlin/net/corda/plugins/CordappGradleConfigurationsTest.kt
@@ -1,62 +1,56 @@
 package net.corda.plugins
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Assert.assertEquals
-import org.junit.BeforeClass
-import org.junit.ClassRule
-import org.junit.Test
-import org.junit.rules.RuleChain
-import org.junit.rules.TemporaryFolder
-import org.junit.rules.TestRule
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestReporter
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
 import java.util.stream.Collectors.toList
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 
 class CordappGradleConfigurationsTest {
     companion object {
-        private val testProjectDir = TemporaryFolder()
-        private val testProject = GradleProject(testProjectDir)
-            .withBuildScript("""
-            |plugins {
-            |    id 'net.corda.plugins.cordapp'
-            |}
-            |
-            |apply from: 'repositories.gradle'
-            |
-            |version = '1.0-SNAPSHOT'
-            |group = 'com.example'
-            |
-            |dependencies {
-            |    compile "org.slf4j:slf4j-api:1.7.26"
-            |    runtime "org.slf4j:slf4j-simple:1.7.26"
-            |    cordaCompile "com.google.guava:guava:20.0"
-            |    cordaRuntime "javax.servlet:javax.servlet-api:3.1.0"
-            |    runtimeOnly "javax.validation:validation-api:1.1.0.Final"
-            |}
-            |
-            |jar {
-            |    archiveName = 'configurations.jar'
-            |}
-            |
-            |cordapp {
-            |    info {
-            |        name = 'Testing'
-            |        targetPlatformVersion = 5
-            |    }
-            |}
-        """.trimMargin())
-
-        @ClassRule
-        @JvmField
-        val rules: TestRule = RuleChain
-            .outerRule(testProjectDir)
-            .around(testProject)
-
+        private lateinit var testProject: GradleProject
         private lateinit var poms: List<ZipEntry>
 
-        @BeforeClass
+        @BeforeAll
         @JvmStatic
-        fun checkSetup() {
+        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+            testProject = GradleProject(testProjectDir, reporter)
+                .withBuildScript("""
+                    |plugins {
+                    |    id 'net.corda.plugins.cordapp'
+                    |}
+                    |
+                    |apply from: 'repositories.gradle'
+                    |
+                    |version = '1.0-SNAPSHOT'
+                    |group = 'com.example'
+                    |
+                    |dependencies {
+                    |    compile "org.slf4j:slf4j-api:1.7.26"
+                    |    runtime "org.slf4j:slf4j-simple:1.7.26"
+                    |    cordaCompile "com.google.guava:guava:20.0"
+                    |    cordaRuntime "javax.servlet:javax.servlet-api:3.1.0"
+                    |    runtimeOnly "javax.validation:validation-api:1.1.0.Final"
+                    |}
+                    |
+                    |jar {
+                    |    archiveName = 'configurations.jar'
+                    |}
+                    |
+                    |cordapp {
+                    |    info {
+                    |        name = 'Testing'
+                    |        targetPlatformVersion = 5
+                    |    }
+                    |}
+                """.trimMargin())
+                .build()
+
             val cordapp = testProject.pathOf("build", "libs", "configurations.jar")
             assertThat(cordapp).isRegularFile()
 

--- a/cordapp/src/test/kotlin/net/corda/plugins/CordappTest.kt
+++ b/cordapp/src/test/kotlin/net/corda/plugins/CordappTest.kt
@@ -4,28 +4,27 @@ import org.apache.commons.io.IOUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.TemporaryFolder
-import java.io.File
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.jar.JarInputStream
 
 class CordappTest {
-    @Rule
-    @JvmField
-    val testProjectDir = TemporaryFolder()
-    private lateinit var buildFile: File
+    @TempDir
+    lateinit var testProjectDir: Path
+    private lateinit var buildFile: Path
 
     private companion object {
         const val cordappJarName = "test-cordapp"
 
-        private val testGradleUserHome = System.getProperty("test.gradle.user.home", ".")
+        private val testGradleUserHome = systemProperty("test.gradle.user.home")
     }
 
-    @Before
+    @BeforeEach
     fun setup() {
-        buildFile = testProjectDir.newFile("build.gradle")
+        buildFile = testProjectDir.resolve("build.gradle")
         installResource(testProjectDir, "settings.gradle")
         installResource(testProjectDir, "repositories.gradle")
     }
@@ -52,9 +51,9 @@ class CordappTest {
         assertThat(result.task(":jar")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
         val jarFile = getCordappJar(cordappJarName)
-        assertThat(jarFile).exists()
+        assertThat(jarFile).isRegularFile()
 
-        JarInputStream(jarFile.inputStream()).use { jar ->
+        JarInputStream(jarFile.toFile().inputStream()).use { jar ->
             val attributes = jar.manifest.mainAttributes
 
             assertThat(attributes.getValue("Name")).isEqualTo(expectedName)
@@ -88,9 +87,9 @@ class CordappTest {
         assertThat(result.task(":jar")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
         val jarFile = getCordappJar(cordappJarName)
-        assertThat(jarFile).exists()
+        assertThat(jarFile).isRegularFile()
 
-        JarInputStream(jarFile.inputStream()).use { jar ->
+        JarInputStream(jarFile.toFile().inputStream()).use { jar ->
             val attributes = jar.manifest.mainAttributes
 
             assertThat(attributes.getValue("Cordapp-Contract-Name")).isEqualTo(expectedContractCordappName)
@@ -124,9 +123,9 @@ class CordappTest {
         assertThat(result.task(":jar")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
         val jarFile = getCordappJar(cordappJarName)
-        assertThat(jarFile).exists()
+        assertThat(jarFile).isRegularFile()
 
-        JarInputStream(jarFile.inputStream()).use { jar ->
+        JarInputStream(jarFile.toFile().inputStream()).use { jar ->
             val attributes = jar.manifest.mainAttributes
 
             assertThat(attributes.getValue("Cordapp-Workflow-Name")).isEqualTo(expectedWorkflowCordappName)
@@ -168,9 +167,9 @@ class CordappTest {
         assertThat(result.task(":jar")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
         val jarFile = getCordappJar(cordappJarName)
-        assertThat(jarFile).exists()
+        assertThat(jarFile).isRegularFile()
 
-        JarInputStream(jarFile.inputStream()).use { jar ->
+        JarInputStream(jarFile.toFile().inputStream()).use { jar ->
             val attributes = jar.manifest.mainAttributes
 
             assertThat(attributes.getValue("Cordapp-Contract-Name")).isEqualTo(expectedContractCordappName)
@@ -217,9 +216,9 @@ class CordappTest {
         assertThat(result.task(":jar")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
         val jarFile = getCordappJar(cordappJarName)
-        assertThat(jarFile).exists()
+        assertThat(jarFile).isRegularFile()
 
-        JarInputStream(jarFile.inputStream()).use { jar ->
+        JarInputStream(jarFile.toFile().inputStream()).use { jar ->
             val attributes = jar.manifest.mainAttributes
 
             assertThat(attributes.getValue("Cordapp-Contract-Name")).isEqualTo(expectedContractCordappName)
@@ -257,11 +256,11 @@ class CordappTest {
     private fun jarTaskRunner(buildFileResourceName: String, extraArgs: List<String> = emptyList()): GradleRunner {
         createBuildFile(buildFileResourceName)
         return GradleRunner.create()
-                .withProjectDir(testProjectDir.root)
+                .withProjectDir(testProjectDir.toFile())
                 .withArguments(listOf("jar", "-s", "--info", "-g", testGradleUserHome) + extraArgs)
                 .withPluginClasspath()
     }
 
-    private fun createBuildFile(buildFileResourceName: String) = IOUtils.copy(javaClass.getResourceAsStream(buildFileResourceName), buildFile.outputStream())
-    private fun getCordappJar(cordappJarName: String) = File(testProjectDir.root, "build/libs/$cordappJarName.jar")
+    private fun createBuildFile(buildFileResourceName: String) = IOUtils.copy(javaClass.getResourceAsStream(buildFileResourceName), buildFile.toFile().outputStream())
+    private fun getCordappJar(cordappJarName: String): Path = Paths.get(testProjectDir.toFile().absolutePath, "build", "libs", "$cordappJarName.jar")
 }

--- a/cordapp/src/test/kotlin/net/corda/plugins/GradleProject.kt
+++ b/cordapp/src/test/kotlin/net/corda/plugins/GradleProject.kt
@@ -2,16 +2,13 @@ package net.corda.plugins
 
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome.*
-import org.junit.Assert.assertEquals
-import org.junit.rules.TemporaryFolder
-import org.junit.rules.TestRule
-import org.junit.runner.Description
-import org.junit.runners.model.Statement
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.TestReporter
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.test.fail
 
-class GradleProject(private val projectDir: TemporaryFolder) : TestRule {
+class GradleProject(private val projectDir: Path, private val reporter: TestReporter) {
     private companion object {
         private val testGradleUserHome = systemProperty("test.gradle.user.home")
     }
@@ -32,31 +29,26 @@ class GradleProject(private val projectDir: TemporaryFolder) : TestRule {
     var output: String = ""
         private set
 
-    fun pathOf(vararg elements: String): Path = Paths.get(projectDir.root.absolutePath, *elements)
+    fun pathOf(vararg elements: String): Path = Paths.get(projectDir.toFile().absolutePath, *elements)
 
-    override fun apply(statement: Statement, description: Description): Statement {
-        return object : Statement() {
-            override fun evaluate() {
-                installResource(projectDir, "repositories.gradle")
-                installResource(projectDir, "settings.gradle")
-                installResource(projectDir, "gradle.properties")
-                projectDir.newFile("build.gradle").writeText(buildScript)
+    fun build(): GradleProject {
+        installResource(projectDir, "repositories.gradle")
+        installResource(projectDir, "settings.gradle")
+        installResource(projectDir, "gradle.properties")
+        projectDir.resolve("build.gradle").toFile().writeText(buildScript)
 
-                val result = GradleRunner.create()
-                    .withProjectDir(projectDir.root)
-                    .withArguments(getGradleArgsForTasks(taskName))
-                    .withPluginClasspath()
-                    .withDebug(true)
-                    .build()
-                output = result.output
-                println(output)
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir.toFile())
+            .withArguments(getGradleArgsForTasks(taskName))
+            .withPluginClasspath()
+            .withDebug(true)
+            .build()
+        output = result.output
+        reporter.publishEntry("stdout", output)
 
-                val taskResult = result.task(":$taskName") ?: fail("No outcome for $taskName task")
-                assertEquals(SUCCESS, taskResult.outcome)
-
-                statement.evaluate()
-            }
-        }
+        val taskResult = result.task(":$taskName") ?: fail("No outcome for $taskName task")
+        assertEquals(SUCCESS, taskResult.outcome)
+        return this
     }
 
     private fun getGradleArgsForTasks(vararg taskNames: String): List<String> {

--- a/cordapp/src/test/kotlin/net/corda/plugins/PomFilterTest.kt
+++ b/cordapp/src/test/kotlin/net/corda/plugins/PomFilterTest.kt
@@ -1,73 +1,71 @@
 package net.corda.plugins
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Assert.*
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.RuleChain
-import org.junit.rules.TemporaryFolder
-import org.junit.rules.TestRule
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestReporter
+import org.junit.jupiter.api.io.TempDir
 import org.w3c.dom.Document
 import java.nio.file.Path
 import javax.xml.parsers.DocumentBuilderFactory
 
 class PomFilterTest {
-    private val testProjectDir = TemporaryFolder()
-    private val testProject = GradleProject(testProjectDir)
-        .withTaskName("generatePomFileForCordappPublishPublication")
-        .withBuildScript("""
-            |plugins {
-            |    id 'net.corda.plugins.cordapp'
-            |    id 'maven-publish'
-            |}
-            |
-            |apply from: 'repositories.gradle'
-            |
-            |version = '1.0-SNAPSHOT'
-            |group = 'com.example'
-            |
-            |dependencies {
-            |    compile "org.slf4j:jcl-over-slf4j:1.7.26"
-            |    implementation "org.slf4j:slf4j-api:1.7.26"
-            |    runtimeOnly "org.slf4j:slf4j-simple:1.7.26"
-            |    cordaCompile "com.google.guava:guava:20.0"
-            |    cordaRuntime "javax.servlet:javax.servlet-api:3.1.0"
-            |}
-            |
-            |cordapp {
-            |    info {
-            |        name = 'Testing'
-            |        targetPlatformVersion = 5
-            |    }
-            |}
-            |
-            |publishing {
-            |    publications {
-            |        cordappPublish(MavenPublication) {
-            |            from components.java
-            |
-            |            groupId project.group
-            |            artifactId 'cordapp-test'
-            |
-            |            pom {
-            |                licenses {
-            |                    license {
-            |                        name = 'Apache-2.0'
-            |                        url = 'https://www.apache.org/licenses/LICENSE-2.0'
-            |                        distribution = 'repo'
-            |                    }
-            |                }
-            |            }
-            |        }
-            |    }
-            |}
-        """.trimMargin())
+    private lateinit var testProject: GradleProject
 
-    @Rule
-    @JvmField
-    val rules: TestRule = RuleChain
-        .outerRule(testProjectDir)
-        .around(testProject)
+    @BeforeEach
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTaskName("generatePomFileForCordappPublishPublication")
+            .withBuildScript("""
+                |plugins {
+                |    id 'net.corda.plugins.cordapp'
+                |    id 'maven-publish'
+                |}
+                |
+                |apply from: 'repositories.gradle'
+                |
+                |version = '1.0-SNAPSHOT'
+                |group = 'com.example'
+                |
+                |dependencies {
+                |    compile "org.slf4j:jcl-over-slf4j:1.7.26"
+                |    implementation "org.slf4j:slf4j-api:1.7.26"
+                |    runtimeOnly "org.slf4j:slf4j-simple:1.7.26"
+                |    cordaCompile "com.google.guava:guava:20.0"
+                |    cordaRuntime "javax.servlet:javax.servlet-api:3.1.0"
+                |}
+                |
+                |cordapp {
+                |    info {
+                |        name = 'Testing'
+                |        targetPlatformVersion = 5
+                |    }
+                |}
+                |
+                |publishing {
+                |    publications {
+                |        cordappPublish(MavenPublication) {
+                |            from components.java
+                |
+                |            groupId project.group
+                |            artifactId 'cordapp-test'
+                |
+                |            pom {
+                |                licenses {
+                |                    license {
+                |                        name = 'Apache-2.0'
+                |                        url = 'https://www.apache.org/licenses/LICENSE-2.0'
+                |                        distribution = 'repo'
+                |                    }
+                |                }
+                |            }
+                |        }
+                |    }
+                |}
+            """.trimMargin())
+            .build()
+    }
 
     @Test
     fun testFilteredPom() {
@@ -75,10 +73,10 @@ class PomFilterTest {
         assertThat(pomFile).isRegularFile()
 
         val pom = pomFile.readXml()
-        assertEquals("Should contain <project/> tag", 1, pom.getElementsByTagName("project").length)
-        assertEquals("Should contain <licenses/> tag", 1, pom.getElementsByTagName("licenses").length)
-        assertEquals("Should not contain <dependencies/> tag", 0, pom.getElementsByTagName("dependencies").length)
-        assertEquals("Should not contain <dependency/> tags", 0, pom.getElementsByTagName("dependency").length)
+        assertEquals(1, pom.getElementsByTagName("project").length, "Should contain <project/> tag")
+        assertEquals(1, pom.getElementsByTagName("licenses").length, "Should contain <licenses/> tag")
+        assertEquals(0, pom.getElementsByTagName("dependencies").length, "Should not contain <dependencies/> tag")
+        assertEquals(0, pom.getElementsByTagName("dependency").length, "Should not contain <dependency/> tags")
     }
 
     private fun Path.readXml(): Document {

--- a/cordapp/src/test/kotlin/net/corda/plugins/Utilities.kt
+++ b/cordapp/src/test/kotlin/net/corda/plugins/Utilities.kt
@@ -1,7 +1,5 @@
 package net.corda.plugins
 
-import org.junit.rules.TemporaryFolder
-import java.io.File
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
@@ -12,19 +10,14 @@ import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 private val classLoader: ClassLoader = object {}.javaClass.classLoader
 
 @Throws(IOException::class)
-fun installResource(folder: TemporaryFolder, resourceName: String): Long {
-    val buildFile = folder.newFile(resourceName.substring(1 + resourceName.lastIndexOf('/')))
+fun installResource(folder: Path, resourceName: String): Long {
+    val buildFile = folder.resolve(resourceName.substring(1 + resourceName.lastIndexOf('/')))
     return copyResourceTo(resourceName, buildFile)
 }
 
 @Throws(IOException::class)
 fun copyResourceTo(resourceName: String, target: Path): Long {
     classLoader.getResourceAsStream(resourceName).use { input -> return Files.copy(input, target, REPLACE_EXISTING) }
-}
-
-@Throws(IOException::class)
-fun copyResourceTo(resourceName: String, target: File): Long {
-    return copyResourceTo(resourceName, target.toPath())
 }
 
 fun systemProperty(name: String): String = System.getProperty(name) ?: fail("System property '$name' not set.")

--- a/cordapp/src/test/kotlin/net/corda/plugins/VersionComparatorTest.kt
+++ b/cordapp/src/test/kotlin/net/corda/plugins/VersionComparatorTest.kt
@@ -1,7 +1,7 @@
 package net.corda.plugins
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class VersionComparatorTest {
     @Test

--- a/cordformation/build.gradle
+++ b/cordformation/build.gradle
@@ -48,23 +48,25 @@ pluginBundle {
 }
 
 dependencies {
-    compile project(":cordapp")
+    implementation project(":cordapp")
     // Gradle plugins written in Kotlin will always use Gradle's
     // own provided Kotlin libraries at runtime. So ensure that
     // we don't add Kotlin as a dependency in our published POM.
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    compile "commons-io:commons-io:$commons_io_version"
-    compile "com.typesafe:config:$typesafe_config_version"
+    implementation "commons-io:commons-io:$commons_io_version"
+    implementation "com.typesafe:config:$typesafe_config_version"
 
     noderunner "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    testImplementation "org.jetbrains.kotlin:kotlin-test-junit"
-    testImplementation "junit:junit:$junit_version" // TODO: Unify with core
+    testImplementation "org.jetbrains.kotlin:kotlin-test"
+    testImplementation("org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junit_jupiter_version")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junit_platform_version")
     testImplementation "org.assertj:assertj-core:$assertj_version"
     testImplementation "net.corda:corda-serialization:$corda_release_version"
     testRuntimeOnly "net.corda:corda-node-api:$corda_release_version"
     // Docker-compose file generation
-    compile "org.yaml:snakeyaml:$snake_yaml_version"
+    implementation "org.yaml:snakeyaml:$snake_yaml_version"
 }
 
 task createNodeRunner(type: Jar) {

--- a/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
@@ -17,18 +17,17 @@ import org.apache.commons.io.IOUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
-import org.junit.Before
-import org.junit.Ignore
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.TemporaryFolder
-import java.io.File
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import java.nio.file.Paths
 
 class CordformTest {
-    @Rule
-    @JvmField
-    val testProjectDir = TemporaryFolder()
-    private lateinit var buildFile: File
+    @TempDir
+    lateinit var testProjectDir: Path
+    private lateinit var buildFile: Path
 
     private companion object {
         const val cordaFinanceWorkflowsJarName = "corda-finance-workflows-4.0"
@@ -39,12 +38,12 @@ class CordformTest {
         private val testGradleUserHome = System.getProperty("test.gradle.user.home", ".")
     }
 
-    @Before
+    @BeforeEach
     fun setup() {
-        buildFile = testProjectDir.newFile("build.gradle")
+        buildFile = testProjectDir.resolve("build.gradle")
     }
 
-    @Ignore
+    @Disabled
     @Test
     fun `network parameter overrides`() {
         val runner = getStandardGradleRunnerFor("DeploySingleNodeWithNetworkParameterOverrides.gradle")
@@ -52,9 +51,9 @@ class CordformTest {
         val result = runner.build()
 
         assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isFile()
-        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isFile()
-        assertThat(getNetworkParameterOverrides(notaryNodeName)).isFile()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile()
+        assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile()
 
         ThreadLocalToggleField<SerializationEnvironment>("contextSerializationEnv")
         net.corda.core.serialization.internal._contextSerializationEnv.set(SerializationEnvironment.with(
@@ -63,7 +62,7 @@ class CordformTest {
                 },
                 AMQP_P2P_CONTEXT)
         )
-        val serializedBytes = SerializedBytes<SignedDataWithCert<NetworkParameters>>(getNetworkParameterOverrides(notaryNodeName).readBytes())
+        val serializedBytes = SerializedBytes<SignedDataWithCert<NetworkParameters>>(getNetworkParameterOverrides(notaryNodeName).toFile().readBytes())
         val deserialized = serializedBytes.deserialize(SerializationDefaults.SERIALIZATION_FACTORY).raw.deserialize().packageOwnership
         assertThat(deserialized.containsKey("com.mypackagename")).isTrue()
     }
@@ -75,9 +74,9 @@ class CordformTest {
         val result = runner.build()
 
         assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isFile()
-        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isFile()
-        assertThat(getNetworkParameterOverrides(notaryNodeName)).isFile()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile()
+        assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile()
     }
 
     @Test
@@ -87,9 +86,9 @@ class CordformTest {
         val result = runner.build()
 
         assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isFile()
-        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isFile()
-        assertThat(getNetworkParameterOverrides(notaryNodeName)).isFile()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile()
+        assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile()
     }
 
     @Test
@@ -99,10 +98,10 @@ class CordformTest {
         val result = runner.build()
 
         assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isFile()
-        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isFile()
-        assertThat(getNodeCordappConfig(notaryNodeName, cordaFinanceWorkflowsJarName)).isFile()
-        assertThat(getNodeCordappConfig(notaryNodeName, cordaFinanceContractsJarName)).isFile()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile()
+        assertThat(getNodeCordappConfig(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
+        assertThat(getNodeCordappConfig(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile()
     }
 
     @Test
@@ -112,23 +111,23 @@ class CordformTest {
         val result = runner.build()
 
         assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        assertThat(getNodeCordappJar(notaryNodeName, localCordappJarName)).isFile()
-        assertThat(getNodeCordappConfig(notaryNodeName, localCordappJarName)).isFile()
+        assertThat(getNodeCordappJar(notaryNodeName, localCordappJarName)).isRegularFile()
+        assertThat(getNodeCordappConfig(notaryNodeName, localCordappJarName)).isRegularFile()
     }
 
     private fun getStandardGradleRunnerFor(buildFileResourceName: String): GradleRunner {
         createBuildFile(buildFileResourceName)
         return GradleRunner.create()
                 .withDebug(true)
-                .withProjectDir(testProjectDir.root)
+                .withProjectDir(testProjectDir.toFile())
                 .withArguments("deployNodes", "-s", "--info", "-g", testGradleUserHome)
                 .withPluginClasspath()
     }
 
-    private fun createBuildFile(buildFileResourceName: String) = IOUtils.copy(javaClass.getResourceAsStream(buildFileResourceName), buildFile.outputStream())
-    private fun getNodeCordappJar(nodeName: String, cordappJarName: String) = File(testProjectDir.root, "build/nodes/$nodeName/cordapps/$cordappJarName.jar")
-    private fun getNodeCordappConfig(nodeName: String, cordappJarName: String) = File(testProjectDir.root, "build/nodes/$nodeName/cordapps/config/$cordappJarName.conf")
-    private fun getNetworkParameterOverrides(nodeName: String) = File(testProjectDir.root, "build/nodes/$nodeName/network-parameters")
+    private fun createBuildFile(buildFileResourceName: String) = IOUtils.copy(javaClass.getResourceAsStream(buildFileResourceName), buildFile.toFile().outputStream())
+    private fun getNodeCordappJar(nodeName: String, cordappJarName: String) = Paths.get(testProjectDir.toFile().absolutePath, "build", "nodes", nodeName, "cordapps", "$cordappJarName.jar")
+    private fun getNodeCordappConfig(nodeName: String, cordappJarName: String) = Paths.get(testProjectDir.toFile().absolutePath, "build", "nodes", nodeName, "cordapps", "config", "$cordappJarName.conf")
+    private fun getNetworkParameterOverrides(nodeName: String) = Paths.get(testProjectDir.toFile().absolutePath, "build", "nodes", nodeName, "network-parameters")
 
     private class AMQPParametersSerializationScheme : AbstractAMQPSerializationScheme(emptyList()) {
         override fun rpcClientSerializerFactory(context: SerializationContext) = throw UnsupportedOperationException()

--- a/cordformation/src/test/kotlin/net/corda/plugins/NetworkParameterOverridesTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/NetworkParameterOverridesTest.kt
@@ -4,7 +4,7 @@ import com.typesafe.config.*
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class NetworkParameterOverridesTest {
 

--- a/jar-filter/build.gradle
+++ b/jar-filter/build.gradle
@@ -53,10 +53,12 @@ dependencies {
     }
     implementation "org.ow2.asm:asm:$asm_version"
 
-    testImplementation "org.jetbrains.kotlin:kotlin-test-junit"
+    testImplementation "org.jetbrains.kotlin:kotlin-test"
     testImplementation "org.jetbrains.kotlin:kotlin-reflect"
     testImplementation "org.assertj:assertj-core:$assertj_version"
     testImplementation "junit:junit:$junit_version"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher:$junit_platform_version"
     testImplementation project(':jar-filter:unwanteds')
 
     jacocoRuntime "org.jacoco:org.jacoco.agent:${jacoco.toolVersion}:runtime"

--- a/quasar-utils/build.gradle
+++ b/quasar-utils/build.gradle
@@ -33,7 +33,9 @@ pluginBundle {
 }
 
 dependencies {
-    compile project(':cordapp')
-    testCompile "junit:junit:$junit_version"
-    testCompile "org.assertj:assertj-core:$assertj_version"
+    implementation project(':cordapp')
+    testImplementation("org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junit_jupiter_version")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junit_platform_version")
+    testImplementation "org.assertj:assertj-core:$assertj_version"
 }

--- a/quasar-utils/src/test/groovy/net/corda/plugins/QuasarPluginTest.groovy
+++ b/quasar-utils/src/test/groovy/net/corda/plugins/QuasarPluginTest.groovy
@@ -1,10 +1,11 @@
 package net.corda.plugins
 
 import org.gradle.testkit.runner.GradleRunner
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.TemporaryFolder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+import java.nio.file.Path
 
 import static org.assertj.core.api.Assertions.*
 import static org.gradle.testkit.runner.TaskOutcome.*
@@ -13,10 +14,10 @@ class QuasarPluginTest {
     private static final String TEST_GRADLE_USER_HOME = System.getProperty("test.gradle.user.home", ".")
     private static final String QUASAR_VERSION = QuasarPlugin.defaultVersion
 
-    @Rule
-    public final TemporaryFolder testProjectDir = new TemporaryFolder()
+    @TempDir
+    public Path testProjectDir
 
-    @Before
+    @BeforeEach
     void setup() {
         Utilities.installResource(testProjectDir, "settings.gradle")
     }
@@ -165,10 +166,10 @@ test {
     }
 
     private List<String> runGradleFor(String script) {
-        def buildFile = testProjectDir.newFile("build.gradle")
+        def buildFile = testProjectDir.resolve("build.gradle")
         buildFile.text = script
         def result = GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
+            .withProjectDir(testProjectDir.toFile())
             .withArguments("--info", "--stacktrace", "build", "-g", TEST_GRADLE_USER_HOME)
             .withPluginClasspath()
             .build()

--- a/quasar-utils/src/test/groovy/net/corda/plugins/Utilities.groovy
+++ b/quasar-utils/src/test/groovy/net/corda/plugins/Utilities.groovy
@@ -1,14 +1,16 @@
 package net.corda.plugins
 
-import org.junit.rules.TemporaryFolder
+import groovy.transform.CompileStatic
+
 import java.nio.file.Files
 import java.nio.file.Path
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING
 
+@CompileStatic
 class Utilities {
-    static long installResource(TemporaryFolder folder, String resourceName) {
-        File buildFile = folder.newFile(resourceName.substring(1 + resourceName.lastIndexOf('/')))
+    static long installResource(Path folder, String resourceName) {
+        Path buildFile = folder.resolve(resourceName.substring(1 + resourceName.lastIndexOf('/')))
         return copyResourceTo(resourceName, buildFile)
     }
 
@@ -22,9 +24,5 @@ class Utilities {
         } finally {
             input.close()
         }
-    }
-
-    static long copyResourceTo(String resourceName, File  target) {
-        return copyResourceTo(resourceName, target.toPath())
     }
 }


### PR DESCRIPTION
All plugin modules now use Gradle's `useJUnitPlatform()`, although some modules are still using the "vintage" test engine.