### PR TITLE
CORDA-2917: Restore stdout to JUnit HTML report.

### DIFF
--- a/cordapp/src/test/kotlin/net/corda/plugins/GradleProject.kt
+++ b/cordapp/src/test/kotlin/net/corda/plugins/GradleProject.kt
@@ -45,6 +45,7 @@ class GradleProject(private val projectDir: Path, private val reporter: TestRepo
             .build()
         output = result.output
         reporter.publishEntry("stdout", output)
+        println(output)
 
         val taskResult = result.task(":$taskName") ?: fail("No outcome for $taskName task")
         assertEquals(SUCCESS, taskResult.outcome)


### PR DESCRIPTION
Restore `println()` for now, because the HTML report generator will use it.