### PR TITLE
Replace `quasar_exclusions` project property with a `quasar` extension.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -49,6 +49,7 @@ changes to this list.
 * Garrett Macey (Wells Fargo)
 * Gavin Thomas (R3)
 * George Marcel Smetana (Bradesco)
+* Gino Cardillo
 * Giulio Katis (Westpac)
 * Giuseppe Cardone (Intesa Sanpaolo)
 * Guy Hochstetler (IBM)

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 
 * `api-scanner`: Update to support Gradle's `java-library` plugin.
 
+* `quasar-utils`: Add a `quasar` extension so that we can exclude packages from being instrumented by the Quasar agent.
+
 ### Version 5.0.0
 
 * Upgrade to Gradle 5.4.1 / Kotlin 1.3.21.

--- a/quasar-utils/src/main/groovy/net/corda/plugins/QuasarExtension.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/QuasarExtension.groovy
@@ -1,0 +1,22 @@
+package net.corda.plugins
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Provider
+
+import javax.inject.Inject
+
+class QuasarExtension {
+
+    final ListProperty<String> excludePackages
+
+    final Provider<String> exclusions
+
+    @Inject
+    QuasarExtension(ObjectFactory objects) {
+        excludePackages = objects.listProperty(String)
+        exclusions = excludePackages.map { excludes ->
+            excludes.isEmpty() ? '' : "=x(${excludes.join(';')})".toString()
+        }
+    }
+}

--- a/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
@@ -2,9 +2,12 @@ package net.corda.plugins
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.testing.Test
+
+import javax.inject.Inject
 
 /**
  * QuasarPlugin creates a "quasar" configuration and adds quasar as a dependency.
@@ -13,7 +16,13 @@ class QuasarPlugin implements Plugin<Project> {
 
     static final defaultGroup = "co.paralleluniverse"
     static final defaultVersion = "0.7.10"
-    static final List<String> defaultExclusions = ["antlr**", "bftsmart**", "co.paralleluniverse**", "com.codahale**", "com.esotericsoftware**", "com.fasterxml**", "com.google**", "com.ibm**", "com.intellij**", "com.jcabi**", "com.nhaarman**", "com.opengamma**", "com.typesafe**", "com.zaxxer**", "de.javakaffee**", "groovy**", "groovyjarjarantlr**", "groovyjarjarasm**", "io.atomix**", "io.github**", "io.netty**", "jdk**", "junit**", "kotlin**", "net.bytebuddy**", "net.i2p**", "org.apache**", "org.assertj**", "org.bouncycastle**", "org.codehaus**", "org.crsh**", "org.dom4j**", "org.fusesource**", "org.h2**", "org.hamcrest**", "org.hibernate**", "org.jboss**", "org.jcp**", "org.joda**", "org.junit**", "org.mockito**", "org.objectweb**", "org.objenesis**", "org.slf4j**", "org.w3c**", "org.xml**", "org.yaml**", "reflectasm**", "rx**", "org.jolokia**"]
+
+    private final ObjectFactory objects
+
+    @Inject
+    QuasarPlugin(ObjectFactory objects) {
+        this.objects = objects
+    }
 
     @Override
     void apply(Project project) {
@@ -21,13 +30,14 @@ class QuasarPlugin implements Plugin<Project> {
         // This will also create the "compile", "compileOnly" and "runtime" configurations.
         project.pluginManager.apply(JavaPlugin)
 
+        def quasarExtension = project.extensions.create("quasar", QuasarExtension, objects)
+
         Utils.createRuntimeConfiguration("cordaRuntime", project.configurations)
         def quasar = project.configurations.create("quasar")
 
         def rootProject = project.rootProject
-        def quasarGroup = rootProject.hasProperty("quasar_group") ? rootProject.ext.quasar_group : defaultGroup
-        def quasarVersion = rootProject.hasProperty("quasar_version") ? rootProject.ext.quasar_version : defaultVersion
-        def quasarExclusions = rootProject.hasProperty("quasar_exclusions") ? rootProject.ext.quasar_exclusions : defaultExclusions
+        def quasarGroup = rootProject.hasProperty('quasar_group') ? rootProject.property('quasar_group') : defaultGroup
+        def quasarVersion = rootProject.hasProperty('quasar_version') ? rootProject.property('quasar_version') : defaultVersion
         def quasarDependency = "${quasarGroup}:quasar-core:${quasarVersion}:jdk8@jar"
         project.dependencies.add("quasar", quasarDependency)
         project.dependencies.add("cordaRuntime", quasarDependency) {
@@ -37,18 +47,17 @@ class QuasarPlugin implements Plugin<Project> {
         // This adds Quasar to the compile classpath WITHOUT any of its transitive dependencies.
         project.dependencies.add("compileOnly", quasar)
 
-        def quasarExclusionsString = ""
-        if (!quasarExclusions.isEmpty()) {
-            quasarExclusionsString = "=x(${quasarExclusions.join(';')})"
-        }
-
         project.tasks.withType(Test) {
-            jvmArgs "-javaagent:${project.configurations.quasar.singleFile}$quasarExclusionsString"
-            jvmArgs "-Dco.paralleluniverse.fibers.verifyInstrumentation"
+            doFirst {
+                jvmArgs "-javaagent:${project.configurations.quasar.singleFile}${quasarExtension.exclusions.get()}"
+                jvmArgs "-Dco.paralleluniverse.fibers.verifyInstrumentation"
+            }
         }
         project.tasks.withType(JavaExec) {
-            jvmArgs "-javaagent:${project.configurations.quasar.singleFile}$quasarExclusionsString"
-            jvmArgs "-Dco.paralleluniverse.fibers.verifyInstrumentation"
+            doFirst {
+                jvmArgs "-javaagent:${project.configurations.quasar.singleFile}${quasarExtension.exclusions.get()}"
+                jvmArgs "-Dco.paralleluniverse.fibers.verifyInstrumentation"
+            }
         }
     }
 }

--- a/quasar-utils/src/test/groovy/net/corda/plugins/Utilities.groovy
+++ b/quasar-utils/src/test/groovy/net/corda/plugins/Utilities.groovy
@@ -4,13 +4,15 @@ import groovy.transform.CompileStatic
 
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.Paths
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING
 
 @CompileStatic
 class Utilities {
-    static long installResource(Path folder, String resourceName) {
-        Path buildFile = folder.resolve(resourceName.substring(1 + resourceName.lastIndexOf('/')))
+    static long installResource(Path rootDir, String resourceName) {
+        Path buildFile = Paths.get(rootDir.toAbsolutePath().toString(), resourceName.split('/'))
+        Files.createDirectories(buildFile.parent)
         return copyResourceTo(resourceName, buildFile)
     }
 

--- a/quasar-utils/src/test/resources/src/test/java/BasicTest.java
+++ b/quasar-utils/src/test/resources/src/test/java/BasicTest.java
@@ -1,0 +1,4 @@
+public class BasicTest {
+    @org.junit.Test
+    public void doNothing() {}
+}


### PR DESCRIPTION
Create a `quasar` Gradle extension to configure which packages should not be instrumented by the Quasar agent at runtime. Ideally, the `quasar_group` and `quasar_version` project properties should also be migrated to this extension in due course.