### PR TITLE
CORDA-2948: Restore quasar_exclusions Gradle property for initial configuration values.

### DIFF
--- a/quasar-utils/src/main/groovy/net/corda/plugins/QuasarExtension.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/QuasarExtension.groovy
@@ -13,8 +13,9 @@ class QuasarExtension {
     final Provider<String> exclusions
 
     @Inject
-    QuasarExtension(ObjectFactory objects) {
+    QuasarExtension(ObjectFactory objects, Iterable<? extends String> initialExclusions) {
         excludePackages = objects.listProperty(String)
+        excludePackages.set(initialExclusions)
         exclusions = excludePackages.map { excludes ->
             excludes.isEmpty() ? '' : "=x(${excludes.join(';')})".toString()
         }


### PR DESCRIPTION
Restore the `quasar_exclusions` Gradle property and use it to initialise the `quasar` extension. This enables us to declare the package exclusions only once, while still allowing us to customise them per sub-project.