### PR TITLE
CORDA-2917: Simplify use of JUnit 5 by removing platform launcher dependency.

### DIFF
--- a/api-scanner/build.gradle
+++ b/api-scanner/build.gradle
@@ -42,7 +42,6 @@ dependencies {
     testImplementation "org.assertj:assertj-core:$assertj_version"
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_jupiter_version"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:$junit_platform_version"
 
     // This dependency is only to prevent IntelliJ from choking
     // on the Kotlin classes in the test/resources directory.

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ buildscript {
         commons_io_version = '2.6'
         assertj_version = '3.12.1'
         junit_jupiter_version = '5.4.2'
-        junit_platform_version = '1.4.2'
         junit_version = '4.12'
         asm_version = '7.1'
     }

--- a/cordapp/build.gradle
+++ b/cordapp/build.gradle
@@ -40,6 +40,5 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test"
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junit_jupiter_version")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junit_platform_version")
     testImplementation "org.assertj:assertj-core:$assertj_version"
 }

--- a/cordformation/build.gradle
+++ b/cordformation/build.gradle
@@ -63,7 +63,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test"
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junit_jupiter_version")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junit_platform_version")
     testImplementation "org.assertj:assertj-core:$assertj_version"
     testImplementation "net.corda:corda-serialization:$corda_release_version"
     testRuntimeOnly "net.corda:corda-node-api:$corda_release_version"

--- a/jar-filter/build.gradle
+++ b/jar-filter/build.gradle
@@ -57,7 +57,6 @@ dependencies {
     testImplementation "org.assertj:assertj-core:$assertj_version"
     testImplementation "junit:junit:$junit_version"
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:$junit_jupiter_version"
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher:$junit_platform_version"
     testImplementation project(':jar-filter:unwanteds')
 
     jacocoRuntime "org.jacoco:org.jacoco.agent:${jacoco.toolVersion}:runtime"

--- a/quasar-utils/build.gradle
+++ b/quasar-utils/build.gradle
@@ -36,6 +36,5 @@ dependencies {
     implementation project(':cordapp')
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junit_jupiter_version")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher:$junit_platform_version")
     testImplementation "org.assertj:assertj-core:$assertj_version"
 }


### PR DESCRIPTION
The JUnit5 platform launcher is packaged as part of Gradle.