### PR TITLE
CORDA-2955: Remove Quasar's transitive dependencies from Gradle's runtime classpath.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@
 
 * `quasar-utils`: Add a `quasar` extension so that we can exclude packages from being instrumented by the Quasar agent. Also expose Quasar's `verbose` and `debug` options using extension properties. And `group`, `version` and `classifier` properties so that we can configure whicn agent artifact to use.
 
+* `quasar-utils`: Remove Quasar's transitive dependencies from Gradle's runtime classpath.
+
 ### Version 5.0.0
 
 * Upgrade to Gradle 5.4.1 / Kotlin 1.3.21.

--- a/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
@@ -57,17 +57,12 @@ class QuasarPlugin implements Plugin<Project> {
             dependencies.add(quasarDependency)
         }
 
-        // This adds Quasar to the compile classpath WITHOUT any of its transitive dependencies.
+        // Add Quasar to the compile classpath WITHOUT any of its transitive dependencies.
         project.dependencies.add("compileOnly", quasar)
 
-        def cordaRuntime = Utils.createRuntimeConfiguration("cordaRuntime", project.configurations)
-        cordaRuntime.withDependencies { dependencies ->
-            def transitiveDependency = project.dependencies.create(extension.dependency.get()) {
-                it.transitive = true
-            }
-            // Ensure that Quasar's transitive dependencies are available at runtime (only).
-            dependencies.add(transitiveDependency)
-        }
+        // Add Quasar to the runmtime classpath WITHOUT any of its transitive dependencies.
+        Utils.createRuntimeConfiguration("cordaRuntime", project.configurations)
+        project.dependencies.add("cordaRuntime", quasar)
     }
 
     private void configureQuasarTasks(Project project, QuasarExtension extension) {

--- a/quasar-utils/src/test/groovy/net/corda/plugins/QuasarPluginTest.groovy
+++ b/quasar-utils/src/test/groovy/net/corda/plugins/QuasarPluginTest.groovy
@@ -191,7 +191,7 @@ configs.collectEntries { [(it.name):it] }.forEach { name, files ->
         assertThat(output.findAll { it.startsWith("cordaRuntime:") }).hasSize(1)
         assertThat(output.findAll { it.startsWith("compileOnly:") }).hasSize(1)
         assertThat(output.findAll { it.startsWith("compileClasspath:") }).hasSize(1)
-        assertThat(output.findAll { it.startsWith("runtimeClasspath:") }.size()).isGreaterThan(1)
+        assertThat(output.findAll { it.startsWith("runtimeClasspath:") }).hasSize(1)
     }
 
     @Test


### PR DESCRIPTION
The Quasar agent is a fat jar and doesn't need anything else to be added to the runtime classpath.