### PR TITLE
CORDA-2955: Revert 710651d8b0f85dd283b3ddf793aae9f62b054795.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,8 +8,6 @@
 
 * `quasar-utils`: Add a `quasar` extension so that we can exclude packages from being instrumented by the Quasar agent. Also expose Quasar's `verbose` and `debug` options using extension properties. And `group`, `version` and `classifier` properties so that we can configure whicn agent artifact to use.
 
-* `quasar-utils`: Remove Quasar's transitive dependencies from Gradle's runtime classpath.
-
 ### Version 5.0.0
 
 * Upgrade to Gradle 5.4.1 / Kotlin 1.3.21.

--- a/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
@@ -60,9 +60,14 @@ class QuasarPlugin implements Plugin<Project> {
         // Add Quasar to the compile classpath WITHOUT any of its transitive dependencies.
         project.dependencies.add("compileOnly", quasar)
 
-        // Add Quasar to the runmtime classpath WITHOUT any of its transitive dependencies.
-        Utils.createRuntimeConfiguration("cordaRuntime", project.configurations)
-        project.dependencies.add("cordaRuntime", quasar)
+        // Instrumented code needs both the Quasar agent and its transitive dependencies at runtime.
+        def cordaRuntime = Utils.createRuntimeConfiguration("cordaRuntime", project.configurations)
+        cordaRuntime.withDependencies { dependencies ->
+            def quasarDependency = project.dependencies.create(extension.dependency.get()) {
+                it.transitive = true
+            }
+            dependencies.add(quasarDependency)
+        }
     }
 
     private void configureQuasarTasks(Project project, QuasarExtension extension) {

--- a/quasar-utils/src/test/groovy/net/corda/plugins/QuasarPluginTest.groovy
+++ b/quasar-utils/src/test/groovy/net/corda/plugins/QuasarPluginTest.groovy
@@ -191,7 +191,7 @@ configs.collectEntries { [(it.name):it] }.forEach { name, files ->
         assertThat(output.findAll { it.startsWith("cordaRuntime:") }).hasSize(1)
         assertThat(output.findAll { it.startsWith("compileOnly:") }).hasSize(1)
         assertThat(output.findAll { it.startsWith("compileClasspath:") }).hasSize(1)
-        assertThat(output.findAll { it.startsWith("runtimeClasspath:") }).hasSize(1)
+        assertThat(output.findAll { it.startsWith("runtimeClasspath:") }.size()).isGreaterThan(1)
     }
 
     @Test


### PR DESCRIPTION
Instrumented code needs these transitive dependencies at runtime.