### PR TITLE
CORDA-3013: Modify JarFilter to update Kotlin metadata via public API.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,8 +50,8 @@ allprojects {
             // Gradle 4.10.x uses Kotlin 1.2.
             // Gradle 5.x uses Kotlin 1.3.
             jvmTarget = VERSION_1_8
-            apiVersion = "1.2"
-            languageVersion = "1.2"
+            apiVersion = "1.3"
+            languageVersion = "1.3"
             freeCompilerArgs = ['-Xjvm-default=enable']
         }
     }

--- a/jar-filter/build.gradle
+++ b/jar-filter/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 ext {
-    kotlin_metadata_version = '0.0.5'
+    kotlin_metadata_version = '0.1.0'
 }
 
 gradlePlugin {

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTransformer.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTransformer.kt
@@ -1,66 +1,155 @@
 package net.corda.gradle.jarfilter
 
-import kotlinx.metadata.internal.metadata.ProtoBuf
-import kotlinx.metadata.internal.metadata.ProtoBuf.Class.Kind.*
-import kotlinx.metadata.internal.metadata.deserialization.Flags.*
-import kotlinx.metadata.internal.metadata.deserialization.NameResolver
-import kotlinx.metadata.internal.metadata.deserialization.TypeTable
-import kotlinx.metadata.internal.metadata.jvm.JvmProtoBuf.*
-import kotlinx.metadata.internal.metadata.jvm.deserialization.BitEncoding
-import kotlinx.metadata.internal.metadata.jvm.deserialization.JvmNameResolver
-import kotlinx.metadata.internal.metadata.jvm.deserialization.JvmProtoBufUtil
-import kotlinx.metadata.internal.metadata.jvm.deserialization.JvmProtoBufUtil.EXTENSION_REGISTRY
-import kotlinx.metadata.internal.protobuf.ExtensionRegistryLite
-import kotlinx.metadata.internal.protobuf.MessageLite
+import kotlinx.metadata.*
+import kotlinx.metadata.jvm.fieldSignature
+import kotlinx.metadata.jvm.getterSignature
+import kotlinx.metadata.jvm.signature
 import org.gradle.api.logging.Logger
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
-import java.io.InputStream
 
 /**
  * Base class for aligning the contents of [kotlin.Metadata] annotations
  * with the contents of the host byte-code.
  * This is used by [MetaFixerVisitor] for [MetaFixerTask].
  */
-internal abstract class MetaFixerTransformer<out T : MessageLite>(
-    private val logger: Logger,
+abstract class MetaFixerTransformer<out T : KmDeclarationContainer>(
+    protected val logger: Logger,
     private val actualFields: Collection<FieldElement>,
-    private val actualMethods: Collection<String>,
-    private val actualNestedClasses: Collection<String>,
-    private val actualClasses: Collection<String>,
-    data1: List<String>,
-    data2: List<String>,
-    parser: (InputStream, ExtensionRegistryLite) -> T
+    protected val actualMethods: Collection<String>,
+    protected val metadata: T
 ) {
-    private val stringTableTypes: StringTableTypes
-    protected val nameResolver: NameResolver
-    protected val message: T
+    private val properties: MutableList<KmProperty> = metadata.properties
+    private val functions: MutableList<KmFunction> = metadata.functions
 
-    protected abstract val typeTable: TypeTable
     protected open val classDescriptor: String = ""
-    protected open val classKind: ProtoBuf.Class.Kind? = null
-    protected abstract val properties: MutableList<ProtoBuf.Property>
-    protected abstract val functions: MutableList<ProtoBuf.Function>
-    protected abstract val constructors: MutableList<ProtoBuf.Constructor>
-    protected open val nestedClassNames: MutableList<Int> get() = throw UnsupportedOperationException("No nestedClassNames")
-    protected open val sealedSubclassNames: MutableList<Int> get() = throw UnsupportedOperationException("No sealedSubclassNames")
 
-    init {
-        val input = ByteArrayInputStream(BitEncoding.decodeBytes(data1.toTypedArray()))
-        stringTableTypes = StringTableTypes.parseDelimitedFrom(input, EXTENSION_REGISTRY)
-        nameResolver = JvmNameResolver(stringTableTypes, data2.toTypedArray())
-        message = parser(input, EXTENSION_REGISTRY)
+    protected abstract fun filter(): Int
+
+    protected fun filterFunctions(): Int {
+        var count = 0
+        var idx = 0
+        removed@ while (idx < functions.size) {
+            val function = functions[idx]
+            val signature = function.signature?.asString()
+            if (signature != null) {
+                if (!actualMethods.contains(signature)) {
+                    logger.info("-- removing method: {}", signature)
+                    functions.removeAt(idx)
+                    ++count
+                    continue@removed
+                } else if (function.valueParameters.hasAnyDefaultValues
+                             && !actualMethods.contains(signature.toKotlinDefaultFunction(classDescriptor))) {
+                    logger.info("-- removing default parameter values: {}", signature)
+                    function.valueParameters.forEach { it.clearDeclaresDefaultValue() }
+                    ++count
+                }
+            }
+            ++idx
+        }
+        return count
     }
 
-    abstract fun rebuild(): T
+    protected fun filterProperties(): Int {
+        var count = 0
+        var idx = 0
+        removed@ while (idx < properties.size) {
+            val property = properties[idx]
+            val field = property.fieldSignature
+            val getterMethod = property.getterSignature
+
+            /**
+             * A property annotated with [JvmField] will use a field instead of a getter method.
+             * But properties without [JvmField] will also usually have a backing field. So we only
+             * remove a property that has either lost its getter method, or never had a getter method
+             * and has lost its field.
+             *
+             * Having said that, we cannot remove [JvmField] properties from a companion object class
+             * because these properties are implemented as static fields on the companion's host class.
+             */
+            val isValidProperty = if (getterMethod == null) {
+                (field == null) || actualFields.contains(field.toFieldElement()) || (metadata is KmClass && Flag.Class.IS_COMPANION_OBJECT(metadata.flags))
+            } else {
+                actualMethods.contains(getterMethod.asString())
+            }
+
+            if (!isValidProperty) {
+                logger.info("-- removing property: {},{}", property.name, field?.desc ?: getterMethod?.desc)
+                properties.removeAt(idx)
+                ++count
+                continue@removed
+            }
+            ++idx
+        }
+        return count
+    }
+
+    fun transform(): T? {
+        return if (filter() == 0) {
+            null
+        } else {
+            metadata
+        }
+    }
+}
+
+/**
+ * Aligns a [kotlin.Metadata] annotation containing a [KmClass] object
+ * in its [data1][kotlin.Metadata.data1] field with the byte-code of its host class.
+ */
+class ClassMetaFixerTransformer(
+    logger: Logger,
+    actualFields: Collection<FieldElement>,
+    actualMethods: Collection<String>,
+    private val actualNestedClasses: Collection<String>,
+    private val actualClasses: Collection<String>,
+    kmClass: KmClass
+) : MetaFixerTransformer<KmClass>(
+    logger,
+    actualFields,
+    actualMethods,
+    kmClass
+) {
+    override val classDescriptor = "L${kmClass.name.toInternalName()};"
+    private val constructors = kmClass.constructors
+    private val nestedClassNames = kmClass.nestedClasses
+    private val sealedSubclassNames= kmClass.sealedSubclasses
+
+    override fun filter(): Int {
+        var count = filterProperties() + filterFunctions() + filterNestedClasses() + filterSealedSubclassNames()
+        if (!Flag.Class.IS_ANNOTATION_CLASS(metadata.flags)) {
+            count += filterConstructors()
+        }
+        return count
+    }
+
+    private fun filterConstructors(): Int {
+        var count = 0
+        var idx = 0
+        removed@ while (idx < constructors.size) {
+            val constructor = constructors[idx]
+            val signature = constructor.signature?.asString()
+            if (signature != null) {
+                if (!actualMethods.contains(signature)) {
+                    logger.info("-- removing constructor: {}", signature)
+                    constructors.removeAt(idx)
+                    ++count
+                    continue@removed
+                } else if (constructor.valueParameters.hasAnyDefaultValues
+                        && !actualMethods.contains(signature.toKotlinDefaultConstructor())) {
+                    logger.info("-- removing default parameter values: {}", signature)
+                    constructor.valueParameters.forEach { it.clearDeclaresDefaultValue() }
+                    ++count
+                }
+            }
+            ++idx
+        }
+        return count
+    }
 
     private fun filterNestedClasses(): Int {
-        if (classKind == null) return 0
-
         var count = 0
         var idx = 0
         while (idx < nestedClassNames.size) {
-            val nestedClassName = nameResolver.getString(nestedClassNames[idx])
+            val nestedClassName = nestedClassNames[idx]
             if (actualNestedClasses.contains(nestedClassName)) {
                 ++idx
             } else {
@@ -73,12 +162,10 @@ internal abstract class MetaFixerTransformer<out T : MessageLite>(
     }
 
     private fun filterSealedSubclassNames(): Int {
-        if (classKind == null) return 0
-
         var count = 0
         var idx = 0
         while (idx < sealedSubclassNames.size) {
-            val sealedSubclassName = nameResolver.getClassInternalName(sealedSubclassNames[idx])
+            val sealedSubclassName = sealedSubclassNames[idx].toInternalName()
             if (actualClasses.contains(sealedSubclassName)) {
                 ++idx
             } else {
@@ -89,189 +176,22 @@ internal abstract class MetaFixerTransformer<out T : MessageLite>(
         }
         return count
     }
-
-    private fun filterFunctions(): Int {
-        var count = 0
-        var idx = 0
-        removed@ while (idx < functions.size) {
-            val function = functions[idx]
-            val signature = JvmProtoBufUtil.getJvmMethodSignature(function, nameResolver, typeTable)?.asString()
-            if (signature != null) {
-                if (!actualMethods.contains(signature)) {
-                    logger.info("-- removing method: {}", signature)
-                    functions.removeAt(idx)
-                    ++count
-                    continue@removed
-                } else if (function.valueParameterList.hasAnyDefaultValues
-                             && !actualMethods.contains(signature.toKotlinDefaultFunction(classDescriptor))) {
-                    logger.info("-- removing default parameter values: {}", signature)
-                    functions[idx] = function.toBuilder()
-                        .updateValueParameters(ProtoBuf.ValueParameter::clearDeclaresDefaultValue)
-                        .build()
-                    ++count
-                }
-            }
-            ++idx
-        }
-        return count
-    }
-
-    private fun filterConstructors(): Int {
-        var count = 0
-        var idx = 0
-        removed@ while (idx < constructors.size) {
-            val constructor = constructors[idx]
-            val signature = JvmProtoBufUtil.getJvmConstructorSignature(constructor, nameResolver, typeTable)?.asString()
-            if (signature != null) {
-                if (!actualMethods.contains(signature)) {
-                    logger.info("-- removing constructor: {}", signature)
-                    constructors.removeAt(idx)
-                    ++count
-                    continue@removed
-                } else if (constructor.valueParameterList.hasAnyDefaultValues
-                             && !actualMethods.contains(signature.toKotlinDefaultConstructor())) {
-                    logger.info("-- removing default parameter values: {}", signature)
-                    constructors[idx] = constructor.toBuilder()
-                        .updateValueParameters(ProtoBuf.ValueParameter::clearDeclaresDefaultValue)
-                        .build()
-                    ++count
-                }
-            }
-            ++idx
-        }
-        return count
-    }
-
-    private fun filterProperties(): Int {
-        var count = 0
-        var idx = 0
-        removed@ while (idx < properties.size) {
-            val property = properties[idx]
-            val signature = property.getExtensionOrNull(propertySignature)
-            if (signature != null) {
-                val field = signature.toFieldElement(property, nameResolver, typeTable)
-                val getterMethod = signature.toGetter(nameResolver)
-
-                /**
-                 * A property annotated with [JvmField] will use a field instead of a getter method.
-                 * But properties without [JvmField] will also usually have a backing field. So we only
-                 * remove a property that has either lost its getter method, or never had a getter method
-                 * and has lost its field.
-                 *
-                 * Having said that, we cannot remove [JvmField] properties from a companion object class
-                 * because these properties are implemented as static fields on the companion's host class.
-                 */
-                val isValidProperty = if (getterMethod == null) {
-                    actualFields.contains(field) || classKind == COMPANION_OBJECT
-                } else {
-                    actualMethods.contains(getterMethod.signature)
-                }
-
-                if (!isValidProperty) {
-                    logger.info("-- removing property: {},{}", field.name, field.descriptor)
-                    properties.removeAt(idx)
-                    ++count
-                    continue@removed
-                }
-            }
-            ++idx
-        }
-        return count
-    }
-
-    fun transform(): List<String> {
-        var count = filterProperties() + filterFunctions() + filterNestedClasses() + filterSealedSubclassNames()
-        if (classKind != ANNOTATION_CLASS) {
-            count += filterConstructors()
-        }
-        if (count == 0) {
-            return emptyList()
-        }
-
-        val bytes = ByteArrayOutputStream()
-        stringTableTypes.writeDelimitedTo(bytes)
-        rebuild().writeTo(bytes)
-        return BitEncoding.encodeBytes(bytes.toByteArray()).toList()
-    }
 }
 
 /**
- * Aligns a [kotlin.Metadata] annotation containing a [ProtoBuf.Class] object
+ * Aligns a [kotlin.Metadata] annotation containing a [KmPackage] object
  * in its [data1][kotlin.Metadata.data1] field with the byte-code of its host class.
  */
-internal class ClassMetaFixerTransformer(
+class PackageMetaFixerTransformer(
     logger: Logger,
     actualFields: Collection<FieldElement>,
     actualMethods: Collection<String>,
-    actualNestedClasses: Collection<String>,
-    actualClasses: Collection<String>,
-    data1: List<String>,
-    data2: List<String>
-) : MetaFixerTransformer<ProtoBuf.Class>(
+    kmPackage: KmPackage
+) : MetaFixerTransformer<KmPackage>(
     logger,
     actualFields,
     actualMethods,
-    actualNestedClasses,
-    actualClasses,
-    data1,
-    data2,
-    ProtoBuf.Class::parseFrom
+    kmPackage
 ) {
-    override val typeTable = TypeTable(message.typeTable)
-    override val classDescriptor = "L${nameResolver.getClassInternalName(message.fqName)};"
-    override val classKind: ProtoBuf.Class.Kind = CLASS_KIND.get(message.flags)
-    override val properties = mutableList(message.propertyList)
-    override val functions = mutableList(message.functionList)
-    override val constructors = mutableList(message.constructorList)
-    override val nestedClassNames = mutableList(message.nestedClassNameList)
-    override val sealedSubclassNames= mutableList(message.sealedSubclassFqNameList)
-
-    override fun rebuild(): ProtoBuf.Class = message.toBuilder().apply {
-        clearConstructor().addAllConstructor(constructors)
-        clearFunction().addAllFunction(functions)
-
-        if (nestedClassNames.size != nestedClassNameCount) {
-            clearNestedClassName().addAllNestedClassName(nestedClassNames)
-        }
-        if (sealedSubclassNames.size != sealedSubclassFqNameCount) {
-            clearSealedSubclassFqName().addAllSealedSubclassFqName(sealedSubclassNames)
-        }
-        if (properties.size != propertyCount) {
-            clearProperty().addAllProperty(properties)
-        }
-    }.build()
-}
-
-/**
- * Aligns a [kotlin.Metadata] annotation containing a [ProtoBuf.Package] object
- * in its [data1][kotlin.Metadata.data1] field with the byte-code of its host class.
- */
-internal class PackageMetaFixerTransformer(
-    logger: Logger,
-    actualFields: Collection<FieldElement>,
-    actualMethods: Collection<String>,
-    data1: List<String>,
-    data2: List<String>
-) : MetaFixerTransformer<ProtoBuf.Package>(
-    logger,
-    actualFields,
-    actualMethods,
-    emptyList(),
-    emptyList(),
-    data1,
-    data2,
-    ProtoBuf.Package::parseFrom
-) {
-    override val typeTable = TypeTable(message.typeTable)
-    override val properties = mutableList(message.propertyList)
-    override val functions = mutableList(message.functionList)
-    override val constructors = mutableListOf<ProtoBuf.Constructor>()
-
-    override fun rebuild(): ProtoBuf.Package = message.toBuilder().apply {
-        clearFunction().addAllFunction(functions)
-
-        if (properties.size != propertyCount) {
-            clearProperty().addAllProperty(properties)
-        }
-    }.build()
+    override fun filter(): Int = filterProperties() + filterFunctions()
 }

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerVisitor.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerVisitor.kt
@@ -1,5 +1,7 @@
 package net.corda.gradle.jarfilter
 
+import kotlinx.metadata.KmClass
+import kotlinx.metadata.KmPackage
 import org.gradle.api.logging.Logger
 import org.objectweb.asm.*
 import org.objectweb.asm.Opcodes.*
@@ -12,7 +14,7 @@ import org.objectweb.asm.Opcodes.*
 class MetaFixerVisitor private constructor(
     visitor: ClassVisitor,
     logger: Logger,
-    kotlinMetadata: MutableMap<String, List<String>>,
+    kotlinMetadata: MutableMap<String, Array<String>>,
     private val classNames: Set<String>,
     private val fields: MutableSet<FieldElement>,
     private val methods: MutableSet<String>,
@@ -52,25 +54,23 @@ class MetaFixerVisitor private constructor(
         return super.visitInnerClass(clsName, outerName, innerName, access)
     }
 
-    override fun processClassMetadata(data1: List<String>, data2: List<String>): List<String> {
+    override fun processClassMetadata(kmClass: KmClass): KmClass? {
         return ClassMetaFixerTransformer(
                 logger = logger,
                 actualFields = fields,
                 actualMethods = methods,
                 actualNestedClasses = nestedClasses,
                 actualClasses = classNames,
-                data1 = data1,
-                data2 = data2)
+                kmClass = kmClass)
             .transform()
     }
 
-    override fun processPackageMetadata(data1: List<String>, data2: List<String>): List<String> {
+    override fun processPackageMetadata(kmPackage: KmPackage): KmPackage? {
         return PackageMetaFixerTransformer(
                 logger = logger,
                 actualFields = fields,
                 actualMethods = methods,
-                data1 = data1,
-                data2 = data2)
+                kmPackage = kmPackage)
             .transform()
     }
 }

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetadataTransformer.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetadataTransformer.kt
@@ -1,135 +1,44 @@
 package net.corda.gradle.jarfilter
 
-import kotlinx.metadata.internal.metadata.ProtoBuf
-import kotlinx.metadata.internal.metadata.deserialization.Flags.*
-import kotlinx.metadata.internal.metadata.deserialization.NameResolver
-import kotlinx.metadata.internal.metadata.deserialization.TypeTable
-import kotlinx.metadata.internal.metadata.jvm.JvmProtoBuf.*
-import kotlinx.metadata.internal.metadata.jvm.deserialization.BitEncoding
-import kotlinx.metadata.internal.metadata.jvm.deserialization.JvmNameResolver
-import kotlinx.metadata.internal.metadata.jvm.deserialization.JvmProtoBufUtil
-import kotlinx.metadata.internal.metadata.jvm.deserialization.JvmProtoBufUtil.EXTENSION_REGISTRY
-import kotlinx.metadata.internal.protobuf.ExtensionRegistryLite
-import kotlinx.metadata.internal.protobuf.MessageLite
+import kotlinx.metadata.*
+import kotlinx.metadata.Flag.Constructor.IS_PRIMARY
+import kotlinx.metadata.jvm.getterSignature
+import kotlinx.metadata.jvm.setterSignature
+import kotlinx.metadata.jvm.signature
 import org.gradle.api.logging.Logger
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
-import java.io.InputStream
 
 /**
  * Base class for removing unwanted elements from [kotlin.Metadata] annotations.
  * This is used by [FilterTransformer] for [JarFilterTask].
  */
-internal abstract class MetadataTransformer<out T : MessageLite>(
-    private val logger: Logger,
+abstract class MetadataTransformer<out T : KmDeclarationContainer>(
+    protected val logger: Logger,
     private val deletedFields: Collection<FieldElement>,
     private val deletedFunctions: Collection<MethodElement>,
-    private val deletedConstructors: Collection<MethodElement>,
-    private val deletedNestedClasses: Collection<String>,
-    private val deletedClasses: Collection<String>,
     private val handleExtraMethod: (MethodElement) -> Unit,
-    data1: List<String>,
-    data2: List<String>,
-    parser: (InputStream, ExtensionRegistryLite) -> T
+    protected val metadata: T
 ) {
-    private val stringTableTypes: StringTableTypes
-    protected val nameResolver: NameResolver
-    protected val message: T
+    private val functions: MutableList<KmFunction> = metadata.functions
+    private val properties: MutableList<KmProperty> = metadata.properties
+    private val typeAliases: MutableList<KmTypeAlias> = metadata.typeAliases
 
-    protected abstract val typeTable: TypeTable
-    protected open val className: String get() = throw UnsupportedOperationException("No className")
-    protected open val nestedClassNames: MutableList<Int> get() = throw UnsupportedOperationException("No nestedClassNames")
-    protected open val sealedSubclassNames: MutableList<Int> get() = throw UnsupportedOperationException("No sealedSubclassNames")
-    protected abstract val properties: MutableList<ProtoBuf.Property>
-    protected abstract val functions: MutableList<ProtoBuf.Function>
-    protected open val constructors: MutableList<ProtoBuf.Constructor> get() = throw UnsupportedOperationException("No constructors")
-    protected abstract val typeAliases: MutableList<ProtoBuf.TypeAlias>
+    protected abstract fun filter(): Int
 
-    init {
-        val input = ByteArrayInputStream(BitEncoding.decodeBytes(data1.toTypedArray()))
-        stringTableTypes = StringTableTypes.parseDelimitedFrom(input, EXTENSION_REGISTRY)
-        nameResolver = JvmNameResolver(stringTableTypes, data2.toTypedArray())
-        message = parser(input, EXTENSION_REGISTRY)
-    }
-
-    abstract fun rebuild(): T
-
-    fun transform(): List<String> {
-        val count = (
-            filterProperties()
-            + filterFunctions()
-            + filterConstructors()
-            + filterNestedClasses()
-            + filterTypeAliases()
-            + filterSealedSubclasses()
-        )
-        if (count == 0) {
-            return emptyList()
+    fun transform(): T? {
+        return if (filter() == 0) {
+            null
+        } else {
+            metadata
         }
-
-        val bytes = ByteArrayOutputStream()
-        stringTableTypes.writeDelimitedTo(bytes)
-        rebuild().writeTo(bytes)
-        return BitEncoding.encodeBytes(bytes.toByteArray()).toList()
     }
 
-    private fun filterNestedClasses(): Int {
-        if (deletedNestedClasses.isEmpty()) return 0
-
-        var count = 0
-        var idx = 0
-        while (idx < nestedClassNames.size) {
-            val nestedClassName = nameResolver.getString(nestedClassNames[idx])
-            if (deletedNestedClasses.contains(nestedClassName)) {
-                logger.info("-- removing nested class: {}", nestedClassName)
-                nestedClassNames.removeAt(idx)
-                ++count
-            } else {
-                ++idx
-            }
-        }
-        return count
-    }
-
-    private fun filterConstructors(): Int = deletedConstructors.count(::filterConstructor)
-
-    private fun filterConstructor(deleted: MethodElement): Boolean {
-        /*
-         * Constructors with the default parameter marker are synthetic and DO NOT have
-         * entries in the metadata. So we construct an element for the "primary" one
-         * that it was synthesised for, and which we DO expect to find.
-         */
-        val deletedPrimary = deleted.asKotlinNonDefaultConstructor()
-
-        for (idx in 0 until constructors.size) {
-            val constructor = constructors[idx]
-            val signature = (JvmProtoBufUtil.getJvmConstructorSignature(constructor, nameResolver, typeTable) ?: continue).toMethodElement()
-            if (signature == deleted) {
-                if (IS_SECONDARY.get(constructor.flags)) {
-                    logger.info("-- removing constructor: {}", deleted.signature)
-                } else {
-                    logger.warn("Removing primary constructor: {}{}", className, deleted.descriptor)
-                }
-                constructors.removeAt(idx)
-                return true
-            } else if (signature == deletedPrimary) {
-                constructors[idx] = constructor.toBuilder()
-                    .updateValueParameters(ProtoBuf.ValueParameter::clearDeclaresDefaultValue)
-                    .build()
-                logger.info("-- removing default parameter values: {}", deletedPrimary.signature)
-                return true
-            }
-        }
-        return false
-    }
-
-    private fun filterFunctions(): Int = deletedFunctions.count(::filterFunction)
+    protected fun filterFunctions(): Int = deletedFunctions.count(::filterFunction)
 
     private fun filterFunction(deleted: MethodElement): Boolean {
         for (idx in 0 until functions.size) {
             val function = functions[idx]
-            if (nameResolver.getString(function.name) == deleted.name) {
-                val signature = JvmProtoBufUtil.getJvmMethodSignature(function, nameResolver, typeTable)?.toMethodElement()
+            if (function.name == deleted.name) {
+                val signature = function.signature?.toMethodElement()
                 if (signature == deleted) {
                     logger.info("-- removing function: {}", deleted.signature)
                     functions.removeAt(idx)
@@ -140,26 +49,26 @@ internal abstract class MetadataTransformer<out T : MessageLite>(
         return false
     }
 
-    private fun filterProperties(): Int = deletedFields.count(::filterProperty)
+    protected fun filterProperties(): Int = deletedFields.count(::filterProperty)
 
     private fun filterProperty(deleted: FieldElement): Boolean {
         for (idx in 0 until properties.size) {
             val property = properties[idx]
-            val signature = property.getExtensionOrNull(propertySignature) ?: continue
-            val field = signature.toFieldElement(property, nameResolver, typeTable)
-            if (field.name.toVisible() == deleted.name) {
+            if (property.name == deleted.name) {
                 // Check that this property's getter has the correct descriptor.
                 // If it doesn't then we have the wrong property here.
-                val getter = signature.toGetter(nameResolver)
+                val getter = property.getterSignature
                 if (getter != null) {
-                    if (!getter.descriptor.startsWith(deleted.extension)) {
+                    if (!getter.desc.startsWith(deleted.extension)) {
                         continue
                     }
-                    deleteExtra(getter)
+                    deleteExtra(getter.toMethodElement())
                 }
-                signature.toSetter(nameResolver)?.apply(::deleteExtra)
+                property.setterSignature?.run {
+                    deleteExtra(toMethodElement())
+                }
 
-                logger.info("-- removing property: {},{}", field.name, field.descriptor)
+                logger.info("-- removing property: {},{}", deleted.name, deleted.descriptor)
                 properties.removeAt(idx)
                 return true
             }
@@ -175,13 +84,13 @@ internal abstract class MetadataTransformer<out T : MessageLite>(
         }
     }
 
-    private fun filterTypeAliases(): Int {
+    protected fun filterTypeAliases(): Int {
         if (deletedFields.isEmpty()) return 0
 
         var count = 0
         var idx = 0
         while (idx < typeAliases.size) {
-            val aliasName = nameResolver.getString(typeAliases[idx].name)
+            val aliasName = typeAliases[idx].name
             if (deletedFields.any { it.name == aliasName && it.extension == "()" }) {
                 logger.info("-- removing typealias: {}", aliasName)
                 typeAliases.removeAt(idx)
@@ -192,6 +101,92 @@ internal abstract class MetadataTransformer<out T : MessageLite>(
         }
         return count
     }
+}
+
+/**
+ * Removes elements from a [kotlin.Metadata] annotation that contains
+ * a [KmClass] object in its [data1][kotlin.Metadata.data1] field.
+ */
+class ClassMetadataTransformer(
+    logger: Logger,
+    deletedFields: Collection<FieldElement>,
+    deletedFunctions: Collection<MethodElement>,
+    private val deletedConstructors: Collection<MethodElement>,
+    private val deletedNestedClasses: Collection<String>,
+    private val deletedClasses: Collection<String>,
+    handleExtraMethod: (MethodElement) -> Unit,
+    kmClass: KmClass
+) : MetadataTransformer<KmClass>(
+    logger,
+    deletedFields,
+    deletedFunctions,
+    handleExtraMethod,
+    metadata = kmClass
+) {
+    private val className = kmClass.name
+    private val nestedClassNames = kmClass.nestedClasses
+    private val sealedSubclassNames = kmClass.sealedSubclasses
+    private val constructors = kmClass.constructors
+
+    override fun filter(): Int = (
+        filterProperties()
+        + filterFunctions()
+        + filterConstructors()
+        + filterNestedClasses()
+        + filterTypeAliases()
+        + filterSealedSubclasses()
+    )
+
+    private fun filterConstructors(): Int = deletedConstructors.count(::filterConstructor)
+
+    private fun filterConstructor(deleted: MethodElement): Boolean {
+        /*
+         * Constructors with the default parameter marker are synthetic and DO NOT have
+         * entries in the metadata. So we construct an element for the "primary" one
+         * that it was synthesised for, and which we DO expect to find.
+         */
+        val deletedPrimary = deleted.asKotlinNonDefaultConstructor()
+
+        for (idx in 0 until constructors.size) {
+            val constructor = constructors[idx]
+            val signature = (constructor.signature ?: continue).toMethodElement()
+            if (signature == deleted) {
+                if (IS_PRIMARY(constructor.flags)) {
+                    logger.warn("Removing primary constructor: {}{}", className, deleted.descriptor)
+                } else {
+                    logger.info("-- removing constructor: {}", deleted.signature)
+                }
+                constructors.removeAt(idx)
+                return true
+            } else if (signature == deletedPrimary) {
+                constructor.valueParameters.forEach { value ->
+                    value.clearDeclaresDefaultValue()
+                }
+                logger.info("-- removing default parameter values: {}", deletedPrimary.signature)
+                return true
+            }
+        }
+        return false
+    }
+
+    private fun filterNestedClasses(): Int {
+        if (deletedNestedClasses.isEmpty()) return 0
+
+        var count = 0
+        var idx = 0
+        while (idx < nestedClassNames.size) {
+            val nestedClassName = nestedClassNames[idx]
+            if (deletedNestedClasses.contains(nestedClassName)) {
+                logger.info("-- removing nested class: {}", nestedClassName)
+                nestedClassNames.removeAt(idx)
+                ++count
+            } else {
+                ++idx
+            }
+        }
+        return count
+    }
+
 
     private fun filterSealedSubclasses(): Int {
         if (deletedClasses.isEmpty()) return 0
@@ -199,7 +194,7 @@ internal abstract class MetadataTransformer<out T : MessageLite>(
         var count = 0
         var idx = 0
         while (idx < sealedSubclassNames.size) {
-            val subclassName = nameResolver.getClassInternalName(sealedSubclassNames[idx])
+            val subclassName = sealedSubclassNames[idx].toInternalName()
             if (deletedClasses.contains(subclassName)) {
                 logger.info("-- removing sealed subclass: {}", subclassName)
                 sealedSubclassNames.removeAt(idx)
@@ -210,109 +205,28 @@ internal abstract class MetadataTransformer<out T : MessageLite>(
         }
         return count
     }
-
-    /**
-     * Removes any Kotlin suffix, e.g. "$delegate" or "$annotations".
-     */
-    private fun String.toVisible(): String {
-        val idx = indexOf('$')
-        return if (idx == -1) this else substring(0, idx)
-    }
 }
 
 /**
  * Removes elements from a [kotlin.Metadata] annotation that contains
- * a [ProtoBuf.Class] object in its [data1][kotlin.Metadata.data1] field.
+ * a [KmPackage] object in its [data1][kotlin.Metadata.data1] field.
  */
-internal class ClassMetadataTransformer(
-    logger: Logger,
-    deletedFields: Collection<FieldElement>,
-    deletedFunctions: Collection<MethodElement>,
-    deletedConstructors: Collection<MethodElement>,
-    deletedNestedClasses: Collection<String>,
-    deletedClasses: Collection<String>,
-    handleExtraMethod: (MethodElement) -> Unit,
-    data1: List<String>,
-    data2: List<String>
-) : MetadataTransformer<ProtoBuf.Class>(
-    logger,
-    deletedFields,
-    deletedFunctions,
-    deletedConstructors,
-    deletedNestedClasses,
-    deletedClasses,
-    handleExtraMethod,
-    data1,
-    data2,
-    ProtoBuf.Class::parseFrom
-) {
-    override val typeTable = TypeTable(message.typeTable)
-    override val className = nameResolver.getClassInternalName(message.fqName)
-    override val nestedClassNames = mutableList(message.nestedClassNameList)
-    override val sealedSubclassNames = mutableList(message.sealedSubclassFqNameList)
-    override val properties = mutableList(message.propertyList)
-    override val functions = mutableList(message.functionList)
-    override val constructors = mutableList(message.constructorList)
-    override val typeAliases = mutableList(message.typeAliasList)
-
-    override fun rebuild(): ProtoBuf.Class = message.toBuilder().apply {
-        clearConstructor().addAllConstructor(constructors)
-
-        if (nestedClassNames.size != nestedClassNameCount) {
-            clearNestedClassName().addAllNestedClassName(nestedClassNames)
-        }
-        if (functions.size != functionCount) {
-            clearFunction().addAllFunction(functions)
-        }
-        if (properties.size != propertyCount) {
-            clearProperty().addAllProperty(properties)
-        }
-        if (typeAliases.size != typeAliasCount) {
-            clearTypeAlias().addAllTypeAlias(typeAliases)
-        }
-        if (sealedSubclassNames.size != sealedSubclassFqNameCount) {
-            clearSealedSubclassFqName().addAllSealedSubclassFqName(sealedSubclassNames)
-        }
-    }.build()
-}
-
-/**
- * Removes elements from a [kotlin.Metadata] annotation that contains
- * a [ProtoBuf.Package] object in its [data1][kotlin.Metadata.data1] field.
- */
-internal class PackageMetadataTransformer(
+class PackageMetadataTransformer(
     logger: Logger,
     deletedFields: Collection<FieldElement>,
     deletedFunctions: Collection<MethodElement>,
     handleExtraMethod: (MethodElement) -> Unit,
-    data1: List<String>,
-    data2: List<String>
-) : MetadataTransformer<ProtoBuf.Package>(
+    kmPackage: KmPackage
+) : MetadataTransformer<KmPackage>(
     logger,
     deletedFields,
     deletedFunctions,
-    emptyList(),
-    emptyList(),
-    emptyList(),
     handleExtraMethod,
-    data1,
-    data2,
-    ProtoBuf.Package::parseFrom
+    metadata = kmPackage
 ) {
-    override val typeTable = TypeTable(message.typeTable)
-    override val properties = mutableList(message.propertyList)
-    override val functions = mutableList(message.functionList)
-    override val typeAliases = mutableList(message.typeAliasList)
-
-    override fun rebuild(): ProtoBuf.Package = message.toBuilder().apply {
-        if (functions.size != functionCount) {
-            clearFunction().addAllFunction(functions)
-        }
-        if (properties.size != propertyCount) {
-            clearProperty().addAllProperty(properties)
-        }
-        if (typeAliases.size != typeAliasCount) {
-            clearTypeAlias().addAllTypeAlias(typeAliases)
-        }
-    }.build()
+    override fun filter(): Int = (
+        filterProperties()
+        + filterFunctions()
+        + filterTypeAliases()
+    )
 }

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/Utils.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/Utils.kt
@@ -14,7 +14,7 @@ import java.util.zip.ZipEntry.STORED
 import kotlin.math.max
 import kotlin.text.RegexOption.*
 
-internal val JAR_PATTERN = "(\\.jar)\$".toRegex(IGNORE_CASE)
+val JAR_PATTERN = "(\\.jar)\$".toRegex(IGNORE_CASE)
 
 // Use the same constant file timestamp as Gradle.
 private val CONSTANT_TIME: FileTime = FileTime.fromMillis(
@@ -23,7 +23,7 @@ private val CONSTANT_TIME: FileTime = FileTime.fromMillis(
 
 // Declared as inline to avoid polluting the exception stack trace.
 @Suppress("NOTHING_TO_INLINE")
-internal inline fun Exception.asUncheckedException(): RuntimeException
+inline fun Exception.asUncheckedException(): RuntimeException
     = (this as? RuntimeException) ?: InvalidUserCodeException(message ?: "", this)
 
 /**
@@ -31,7 +31,7 @@ internal inline fun Exception.asUncheckedException(): RuntimeException
  * will be compressed automatically, and its CRC, size and
  * compressed size fields populated.
  */
-internal fun ZipEntry.asCompressed(): ZipEntry {
+fun ZipEntry.asCompressed(): ZipEntry {
     return ZipEntry(name).also { entry ->
         entry.lastModifiedTime = lastModifiedTime
         lastAccessTime?.also { at -> entry.lastAccessTime = at }
@@ -42,11 +42,11 @@ internal fun ZipEntry.asCompressed(): ZipEntry {
     }
 }
 
-internal fun ZipEntry.copy(): ZipEntry {
+fun ZipEntry.copy(): ZipEntry {
     return if (method == STORED) ZipEntry(this) else asCompressed()
 }
 
-internal fun ZipEntry.withFileTimestamps(preserveTimestamps: Boolean): ZipEntry {
+fun ZipEntry.withFileTimestamps(preserveTimestamps: Boolean): ZipEntry {
     if (!preserveTimestamps) {
         lastModifiedTime = CONSTANT_TIME
         lastAccessTime?.apply { lastAccessTime = CONSTANT_TIME }
@@ -55,24 +55,22 @@ internal fun ZipEntry.withFileTimestamps(preserveTimestamps: Boolean): ZipEntry 
     return this
 }
 
-internal fun <T : Any> mutableList(c: Collection<T>): MutableList<T> = ArrayList(c)
-
 /**
  * Converts Java class names to Java descriptors.
  */
-internal fun toDescriptors(classNames: Iterable<String>): Set<String> {
+fun toDescriptors(classNames: Iterable<String>): Set<String> {
     return classNames.map(String::descriptor).toSet()
 }
 
-internal val String.toPathFormat: String get() = replace('.', '/')
-internal val String.descriptor: String get() = "L$toPathFormat;"
+val String.toPathFormat: String get() = replace('.', '/')
+val String.descriptor: String get() = "L$toPathFormat;"
 
 
 /**
  * Performs the given number of passes of the repeatable visitor over the byte-code.
  * Used by [MetaFixerVisitor], but also by some of the test visitors.
  */
-internal fun <T> ByteArray.execute(visitor: (ClassVisitor) -> T, flags: Int = 0, passes: Int = 2): ByteArray
+fun <T> ByteArray.execute(visitor: (ClassVisitor) -> T, flags: Int = 0, passes: Int = 2): ByteArray
     where T : ClassVisitor,
           T : Repeatable<T> {
     var bytecode = this

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterProject.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterProject.kt
@@ -29,6 +29,7 @@ class JarFilterProject(private val projectDir: Path, private val name: String) {
             .withProjectDir(projectDir.toFile())
             .withArguments(getGradleArgsForTasks("jarFilter"))
             .withPluginClasspath()
+            .withDebug(true)
             .build()
         output = result.output
         println(output)

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFieldValPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFieldValPropertyTest.kt
@@ -1,0 +1,55 @@
+package net.corda.gradle.jarfilter
+
+import net.corda.gradle.jarfilter.asm.recodeMetadataFor
+import net.corda.gradle.jarfilter.asm.toClass
+import net.corda.gradle.jarfilter.matcher.isProperty
+import org.gradle.api.logging.Logger
+import org.hamcrest.MatcherAssert.*
+import org.hamcrest.core.IsIterableContaining.*
+import org.hamcrest.core.IsNot.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import kotlin.reflect.full.declaredMemberProperties
+
+class MetaFixFieldValPropertyTest {
+    companion object {
+        private val logger: Logger = StdOutLogging(MetaFixFieldValPropertyTest::class)
+        private val unwantedVal = isProperty("unwantedVal", String::class)
+        private val wantedVal = isProperty("wantedVal", Int::class)
+    }
+
+    @Test
+    fun testFieldPropertyRemovedFromMetadata() {
+        val bytecode = recodeMetadataFor<WithFieldValProperty, MetadataTemplate>()
+        val sourceClass = bytecode.toClass<WithFieldValProperty, Any>()
+
+        // Check that the unwanted property has been successfully
+        // added to the metadata, and that the class is valid.
+        val sourceObj = sourceClass.newInstance()
+        assertEquals(NUMBER, sourceClass.getField("wantedVal").get(sourceObj))
+        assertThat("unwantedVal not found", sourceClass.kotlin.declaredMemberProperties, hasItem(unwantedVal))
+        assertThat("wantedVal not found", sourceClass.kotlin.declaredMemberProperties, hasItem(wantedVal))
+
+        // Rewrite the metadata according to the contents of the bytecode.
+        val fixedClass = bytecode.fixMetadata(logger, pathsOf(WithFieldValProperty::class)).toClass<WithFieldValProperty, Any>()
+        val fixedObj = fixedClass.newInstance()
+        assertEquals(NUMBER, fixedClass.getField("wantedVal").get(fixedObj))
+        assertThat("unwantedVal still exists", fixedClass.kotlin.declaredMemberProperties, not(hasItem(unwantedVal)))
+        assertThat("wantedVal not found", fixedClass.kotlin.declaredMemberProperties, hasItem(wantedVal))
+    }
+
+    class MetadataTemplate {
+        @JvmField
+        @Suppress("unused")
+        val wantedVal: Int = 0
+
+        @JvmField
+        val unwantedVal: String = "UNWANTED"
+    }
+}
+
+class WithFieldValProperty {
+    @JvmField
+    @Suppress("unused")
+    val wantedVal: Int = NUMBER
+}

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFieldVarPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFieldVarPropertyTest.kt
@@ -1,0 +1,56 @@
+package net.corda.gradle.jarfilter
+
+import net.corda.gradle.jarfilter.asm.recodeMetadataFor
+import net.corda.gradle.jarfilter.asm.toClass
+import net.corda.gradle.jarfilter.matcher.*
+import org.gradle.api.logging.Logger
+import org.hamcrest.MatcherAssert.*
+import org.hamcrest.core.IsIterableContaining.*
+import org.hamcrest.core.IsNot.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import kotlin.reflect.full.declaredMemberProperties
+
+class MetaFixFieldVarPropertyTest {
+    companion object {
+        private val logger: Logger = StdOutLogging(MetaFixVarPropertyTest::class)
+        private val unwantedVar = isProperty("unwantedVar", String::class)
+        private val wantedVar = isProperty("wantedVar", Int::class)
+    }
+
+    @Test
+    fun testPropertyRemovedFromMetadata() {
+        val bytecode = recodeMetadataFor<WithFieldVarProperty, MetadataTemplate>()
+        val sourceClass = bytecode.toClass<WithFieldVarProperty, Any>()
+
+        // Check that the unwanted property has been successfully
+        // added to the metadata, and that the class is valid.
+        val sourceObj = sourceClass.newInstance()
+        assertEquals(NUMBER, sourceClass.getField("wantedVar").get(sourceObj))
+        assertThat("unwantedVar not found", sourceClass.kotlin.declaredMemberProperties, hasItem(unwantedVar))
+        assertThat("wantedVar not found", sourceClass.kotlin.declaredMemberProperties, hasItem(wantedVar))
+
+        // Rewrite the metadata according to the contents of the bytecode.
+        val fixedClass = bytecode.fixMetadata(logger, pathsOf(WithFieldVarProperty::class)).toClass<WithFieldVarProperty, Any>()
+        val fixedObj = fixedClass.newInstance()
+        assertEquals(NUMBER, fixedClass.getField("wantedVar").get(fixedObj))
+        assertThat("unwantedVar still exists", fixedClass.kotlin.declaredMemberProperties, not(hasItem(unwantedVar)))
+        assertThat("wantedVar not found", fixedClass.kotlin.declaredMemberProperties, hasItem(wantedVar))
+    }
+
+    class MetadataTemplate {
+        @Suppress("unused")
+        @JvmField
+        var wantedVar: Int = 0
+
+        @Suppress("unused")
+        @JvmField
+        var unwantedVar: String = "UNWANTED"
+    }
+}
+
+class WithFieldVarProperty {
+    @Suppress("unused")
+    @JvmField
+    var wantedVar: Int = NUMBER
+}

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixProject.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixProject.kt
@@ -31,6 +31,7 @@ class MetaFixProject(private val projectDir: Path, private val name: String) {
             .withProjectDir(projectDir.toFile())
             .withArguments(getGradleArgsForTasks("metafix"))
             .withPluginClasspath()
+            .withDebug(true)
             .build()
         output = result.output
         println(output)

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/asm/AsmTools.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/asm/AsmTools.kt
@@ -20,7 +20,7 @@ fun ByteArray.accept(visitor: (ClassVisitor) -> ClassVisitor): ByteArray {
 
 private val String.resourceName: String get() = "$toPathFormat.class"
 val Class<*>.resourceName get() = name.resourceName
-val Class<*>.bytecode: ByteArray get() = classLoader.getResourceAsStream(resourceName).use { it.readBytes() }
+val Class<*>.bytecode: ByteArray get() = classLoader.getResourceAsStream(resourceName).use(InputStream::readBytes)
 val Class<*>.descriptor: String get() = name.descriptor
 
 /**
@@ -37,7 +37,7 @@ private class BytecodeClassLoader(
     parent: ClassLoader
 ) : ClassLoader(parent) {
     internal fun createClass(): Class<*> {
-        return defineClass(className, bytecode, 0, bytecode.size).apply { resolveClass(this) }
+        return defineClass(className, bytecode, 0, bytecode.size).apply(::resolveClass)
     }
 
     // Ensure that the class we create also honours Class<*>.bytecode (above).

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/asm/ClassMetadata.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/asm/ClassMetadata.kt
@@ -1,28 +1,18 @@
 package net.corda.gradle.jarfilter.asm
 
 import kotlinx.metadata.ClassName
-import kotlinx.metadata.Flags
-import kotlinx.metadata.KmClassVisitor
+import kotlinx.metadata.KmClass
+import net.corda.gradle.jarfilter.toInternalName
 import net.corda.gradle.jarfilter.toPackageFormat
 
-internal class ClassMetadata : KmClassVisitor() {
-    private var className: ClassName = ""
+class ClassMetadata(metadata: KmClass) {
+    private val className: ClassName = metadata.name.toPackageFormat
 
-    private val _sealedSubclasses: MutableList<ClassName> = mutableListOf()
-    val sealedSubclasses: List<ClassName> get() = _sealedSubclasses
-
-    private val _nestedClasses: MutableList<ClassName> = mutableListOf()
-    val nestedClasses: List<ClassName> get() = _nestedClasses
-
-    override fun visit(flags: Flags, name: ClassName) {
-        className = name.toPackageFormat
+    val sealedSubclasses: List<ClassName> = metadata.sealedSubclasses.map {
+        it.toInternalName().toPackageFormat
     }
 
-    override fun visitNestedClass(name: String) {
-        _nestedClasses += "$className\$$name"
-    }
-
-    override fun visitSealedSubclass(name: ClassName) {
-        _sealedSubclasses += name.replace('.', '$').toPackageFormat
+    val nestedClasses: List<ClassName> = metadata.nestedClasses.map { name ->
+        "$className\$$name"
     }
 }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/asm/FileMetadata.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/asm/FileMetadata.kt
@@ -1,15 +1,8 @@
 package net.corda.gradle.jarfilter.asm
 
-import kotlinx.metadata.Flags
-import kotlinx.metadata.KmPackageVisitor
-import kotlinx.metadata.KmTypeAliasVisitor
+import kotlinx.metadata.KmPackage
+import kotlinx.metadata.KmTypeAlias
 
-internal class FileMetadata : KmPackageVisitor() {
-    private val _typeAliasNames: MutableList<String> = mutableListOf()
-    val typeAliasNames: List<String> get() = _typeAliasNames
-
-    override fun visitTypeAlias(flags: Flags, name: String): KmTypeAliasVisitor? {
-        _typeAliasNames += name
-        return super.visitTypeAlias(flags, name)
-    }
+class FileMetadata(metadata: KmPackage) {
+    val typeAliasNames: List<String> = metadata.typeAliases.map(KmTypeAlias::name)
 }


### PR DESCRIPTION
Stop using Kotlin's internal ProtoBuf classes to manipulate the `kotlin.Metadata` annotations. Use the `kotlin-metadata-jvm` artifact's new API to do this instead.