### PR TITLE
CORDA-3026: Allow publish-utils to choose suitable Maven scopes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 
 * `cordformation`: Migrate DockerForm task to use the official Corda images
 
+* `publish-utils`: Generate appropriate `compile` and `runtime` dependencies when publishing from a given Gradle configuration.
+
 ### Version 5.0.1
 
 * `api-scanner`: Update to support Gradle's `java-library` plugin.

--- a/publish-utils/src/main/groovy/net/corda/plugins/MavenMapper.groovy
+++ b/publish-utils/src/main/groovy/net/corda/plugins/MavenMapper.groovy
@@ -1,0 +1,79 @@
+package net.corda.plugins
+
+import groovy.transform.CompileStatic
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.artifacts.ModuleVersionIdentifier
+import org.gradle.api.artifacts.ResolvedConfiguration
+import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+
+@CompileStatic
+class MavenMapper {
+    private final Map<ModuleVersionIdentifier, String> publishedAliases
+    private final Set<ModuleVersionIdentifier> apiElements
+    private final Set<ModuleVersionIdentifier> compileOnly
+    private final Set<ModuleVersionIdentifier> compile
+    private final Set<ModuleVersionIdentifier> runtime
+
+    MavenMapper(ConfigurationContainer configurations, ResolvedConfiguration resolvedConfiguration) {
+        // Ensure that we use these artifacts' published names, because
+        // these aren't necessarily the same as their internal names.
+        publishedAliases = resolvedConfiguration.resolvedArtifacts.collectEntries {
+            [ (it.moduleVersion.id):it.name ]
+        }
+
+        apiElements = getDependenciesFor(configurations, "apiElements", publishedAliases)
+        compileOnly = resolveArtifactsFor(configurations, "compileOnly")
+        compile = resolveArtifactsFor(configurations, "compileClasspath")
+        runtime = resolveArtifactsFor(configurations, "runtimeClasspath")
+    }
+
+    String getScopeFor(ModuleVersionIdentifier id, String defaultScope) {
+        if (compile.contains(id) && (!compileOnly.contains(id) || apiElements.contains(id))) {
+            // This dependency is on the compile classpath. Also, it has
+            //    EITHER not been declared as "compileOnly"
+            //    OR been explicitly declared as an "api" element (c.f. java-library plugin)
+            return "compile"
+        } else if (runtime.contains(id)) {
+            // This dependency is on the runtime classpath and hasn't been
+            // claimed by the "compile" scope.
+            return "runtime"
+        } else {
+            // This dependency probably belongs to a configuration created by the user.
+            return defaultScope
+        }
+    }
+
+    String getModuleNameFor(ModuleVersionIdentifier id) {
+        return publishedAliases[id]
+    }
+
+    private static Set<ModuleVersionIdentifier> resolveArtifactsFor(
+        ConfigurationContainer configurations,
+        String configName
+    ) {
+        Configuration configuration = configurations.findByName(configName)
+        if (configuration) {
+            return configuration.resolvedConfiguration.resolvedArtifacts.collect { it.moduleVersion.id }.toSet()
+        } else {
+            return Collections.<ModuleVersionIdentifier>emptySet()
+        }
+    }
+
+    private static Set<ModuleVersionIdentifier> getDependenciesFor(
+        ConfigurationContainer configurations,
+        String configName,
+        Map<ModuleVersionIdentifier, String> publishedAliases
+    ) {
+        Configuration configuration = configurations.findByName(configName)
+        if (configuration) {
+            return configuration.allDependencies.iterator().collect { dep ->
+                ModuleVersionIdentifier id = DefaultModuleVersionIdentifier.newId(dep.group, dep.name, dep.version)
+                String alias = publishedAliases[id]
+                alias == null ? id : DefaultModuleVersionIdentifier.newId(id.group, alias, id.version)
+            }.toSet()
+        } else {
+            return Collections.<ModuleVersionIdentifier>emptySet()
+        }
+    }
+}

--- a/publish-utils/src/main/groovy/net/corda/plugins/ProjectPublishExtension.groovy
+++ b/publish-utils/src/main/groovy/net/corda/plugins/ProjectPublishExtension.groovy
@@ -1,15 +1,19 @@
 package net.corda.plugins
 
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.model.ObjectFactory
 import org.gradle.util.ConfigureUtil
+
+import javax.inject.Inject
 
 class ProjectPublishExtension {
     private final PublishTasks task
     private final MavenDependencyExtension dependencyConfig
 
-    ProjectPublishExtension(PublishTasks task) {
+    @Inject
+    ProjectPublishExtension(ObjectFactory objects, PublishTasks task) {
         this.task = task
-        this.dependencyConfig = new MavenDependencyExtension()
+        this.dependencyConfig = objects.newInstance(MavenDependencyExtension)
     }
 
     /**


### PR DESCRIPTION
Allow publish-utils to choose suitable Maven scopes when publishing dependencies from a given Gradle configuration. This will allow us to generate a POM for `corda-core-deterministic` that will work correctly in Gradle 5.x.

This change enhances the
```gradle
publish {
    dependenciesFrom configurationName
}
```
functionality, which is used mainly by the deterministic artifacts.