### PR TITLE
CORDA-3228: Update Quasar utils plugin to support excluding classloaders.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,10 @@
 
 ### Version 5.0.3
 
-* `webserver`: The `corda-webserver` component has been renamed to `corda-testserver.`
+* `quasar-utils`: Add `excludeClassLoaders` option to the `quasar` extension. This option requires Quasar 0.7.12_r3 and above, excluding 0.8.0.
+
+* `cordformation`: The `corda-webserver` component has been renamed to `corda-testserver.`
+
 * `jar-filter`: Support for byte-code compiled by Kotlin >= 1.3.40 (See [KT-30289](https://youtrack.jetbrains.com/issue/KT-30289)).
 
 ### Version 5.0.2

--- a/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/QuasarPlugin.groovy
@@ -38,11 +38,16 @@ class QuasarPlugin implements Plugin<Project> {
         def quasarGroup = rootProject.hasProperty('quasar_group') ? rootProject.property('quasar_group') : defaultGroup
         def quasarVersion = rootProject.hasProperty('quasar_version') ? rootProject.property('quasar_version') : defaultVersion
         def quasarClassifier = rootProject.hasProperty('quasar_classifier') ? rootProject.property('quasar_classifier') : defaultClassifier
-        def quasarExclusions = rootProject.hasProperty("quasar_exclusions") ? rootProject.property('quasar_exclusions') : Collections.emptyList()
-        if (!(quasarExclusions instanceof Iterable<?>)) {
+        def quasarPackageExclusions = rootProject.hasProperty("quasar_exclusions") ? rootProject.property('quasar_exclusions') : Collections.emptyList()
+        if (!(quasarPackageExclusions instanceof Iterable<?>)) {
             throw new InvalidUserDataException("quasar_exclusions property must be an Iterable<String>")
         }
-        def quasarExtension = project.extensions.create(QUASAR, QuasarExtension, objects, quasarGroup, quasarVersion, quasarClassifier, quasarExclusions)
+        def quasarClassLoaderExclusions = rootProject.hasProperty("quasar_classloader_exclusions") ? rootProject.property('quasar_classloader_exclusions') : Collections.emptyList()
+        if (!(quasarClassLoaderExclusions instanceof Iterable<?>)) {
+            throw new InvalidUserDataException("quasar_classloader_exclusions property must be an Iterable<String>")
+        }
+        def quasarExtension = project.extensions.create(QUASAR, QuasarExtension, objects,
+                quasarGroup, quasarVersion, quasarClassifier, quasarPackageExclusions, quasarClassLoaderExclusions)
 
         addQuasarDependencies(project, quasarExtension)
         configureQuasarTasks(project, quasarExtension)

--- a/quasar-utils/src/test/resources/repositories.gradle
+++ b/quasar-utils/src/test/resources/repositories.gradle
@@ -1,3 +1,6 @@
 repositories {
     mavenCentral()
+    maven {
+        url 'https://software.r3.com/artifactory/corda-dependencies'
+    }
 }


### PR DESCRIPTION
This adds an `excludeClassLoaders = []` option to the `quasar` extension. Currently, only Quasar 0.7.12_r3 and above (excluding 0.8.0) supports this.