### PR TITLE
CORDA-3224 Java 11 support tweaks.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import static org.gradle.api.JavaVersion.*
 
 buildscript {
     ext {
-        gradle_plugins_version = '5.0.4-SNAPSHOT'
+        gradle_plugins_version = '5.0.4'
         typesafe_config_version = '1.3.1'
         kotlin_version = '1.3.21'
         snake_yaml_version = '1.19'

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import static org.gradle.api.JavaVersion.*
 
 buildscript {
     ext {
-        gradle_plugins_version = '5.0.4'
+        gradle_plugins_version = '5.0.4-SNAPSHOT'
         typesafe_config_version = '1.3.1'
         kotlin_version = '1.3.21'
         snake_yaml_version = '1.19'

--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,6 @@
 
 ## Version 5
 
-### Version 5.0.5
-
 ### Version 5.0.4
 
 * `cordformation`: remove hard dependency on java 1.8 for macos in runnodes (and allow for usage of JAVA_HOME if set)

--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,7 @@
 
 * `cordformation`: remove hard dependency on java 1.8 for macos in runnodes (and allow for usage of JAVA_HOME if set)
 
-* `cordformation`: add support for classifier (eg. jdk11) in detection of corda.jar file.  
+* `cordformation`: add support for classifier (eg. jdk11) in detection of corda runtime artifacts (eg. corda.jar, test-server.jar).  
 
 ### Version 5.0.3
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,13 @@
 
 ## Version 5
 
+### Version 5.0.5
+
 ### Version 5.0.4
+
+* `cordformation`: remove hard dependency on java 1.8 for macos in runnodes (and allow for usage of JAVA_HOME if set)
+
+* `cordformation`: add support for classifier (eg. jdk11) in detection of corda.jar file.  
 
 ### Version 5.0.3
 

--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
@@ -37,12 +37,16 @@ class Cordformation : Plugin<Project> {
          * @param jarName The name of the JAR you wish to access.
          * @return A file handle to the file in the JAR.
          */
+        private const val VERSION_ID_PATTERN = "\\d\\.\\d(-SNAPSHOT|-RC\\d{2}|.\\d{8})?"
+        private val CORDA_JAR_REGEX = ".*corda-$VERSION_ID_PATTERN(-.*)?\\.jar\$".toRegex(RegexOption.IGNORE_CASE)
+        private val CORDA_ENT_JAR_REGEX = ".*corda-enterprise-$VERSION_ID_PATTERN(-.*)?\\.jar\$".toRegex(RegexOption.IGNORE_CASE)
+
         fun verifyAndGetRuntimeJar(project: Project, jarName: String): File {
             val releaseVersion = project.findRootProperty<String>("corda_release_version")
                     ?: throw IllegalStateException("Could not find a valid declaration of \"corda_release_version\"")
             val maybeJar = project.configuration("runtime").filter {
-                it.toString().contains("$jarName-enterprise-$releaseVersion(-*)?.jar".toRegex()) ||
-                it.toString().contains("$jarName-$releaseVersion(-.*)?.jar".toRegex())
+                it.toString().contains(CORDA_ENT_JAR_REGEX) ||
+                it.toString().contains(CORDA_JAR_REGEX)
             }
             if (maybeJar.isEmpty) {
                 throw IllegalStateException("No $jarName JAR found. Have you deployed the Corda project to Maven? Looked for \"$jarName-$releaseVersion.jar\"")

--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
@@ -41,7 +41,8 @@ class Cordformation : Plugin<Project> {
             val releaseVersion = project.findRootProperty<String>("corda_release_version")
                     ?: throw IllegalStateException("Could not find a valid declaration of \"corda_release_version\"")
             val maybeJar = project.configuration("runtime").filter {
-                "$jarName-$releaseVersion.jar" in it.toString() || "$jarName-enterprise-$releaseVersion.jar" in it.toString()
+                it.toString().contains("$jarName-enterprise-$releaseVersion(-*)?.jar".toRegex()) ||
+                it.toString().contains("$jarName-$releaseVersion(-.*)?.jar".toRegex())
             }
             if (maybeJar.isEmpty) {
                 throw IllegalStateException("No $jarName JAR found. Have you deployed the Corda project to Maven? Looked for \"$jarName-$releaseVersion.jar\"")

--- a/cordformation/src/main/resources/net/corda/plugins/runnodes
+++ b/cordformation/src/main/resources/net/corda/plugins/runnodes
@@ -6,7 +6,7 @@ set -eo pipefail
 basedir=$( dirname "$0" )
 cd "$basedir"
 
-if [ -z $JAVA_HOME ] && which osascript >/dev/null; then
+if [ -z "$JAVA_HOME" ] && which osascript >/dev/null; then
     # use default version of java installed on mac
     /usr/libexec/java_home --exec java -jar runnodes.jar "$@"
 else

--- a/cordformation/src/main/resources/net/corda/plugins/runnodes
+++ b/cordformation/src/main/resources/net/corda/plugins/runnodes
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -eo pipefail
 
 # Allow the script to be run from outside the nodes directory.
 basedir=$( dirname "$0" )
 cd "$basedir"
 
-if which osascript >/dev/null; then
-    /usr/libexec/java_home -v 1.8 --exec java -jar runnodes.jar "$@"
+if [ -z $JAVA_HOME ] && which osascript >/dev/null; then
+    # use default version of java installed on mac
+    /usr/libexec/java_home --exec java -jar runnodes.jar "$@"
 else
     "${JAVA_HOME:+$JAVA_HOME/bin/}java" -jar runnodes.jar "$@"
 fi

--- a/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
@@ -89,6 +89,30 @@ class CordformTest : BaseformTest() {
         assertThat(getNodeCordappConfig(notaryNodeName, localCordappJarName)).isRegularFile()
     }
 
+    @Test
+    fun `regex matching used by verifyAndGetRuntimeJar()`() {
+        val jarName = "corda"
 
+        var releaseVersion = "4.3"
+        var pattern = "\\Q$jarName\\E(-enterprise)?-\\Q$releaseVersion\\E(-.+)?\\.jar\$".toRegex()
+        assertThat("corda-4.3.jar".contains(pattern)).isTrue()
+        assertThat("corda-4.3.jar".contains(pattern)).isTrue()
+        assertThat("corda-4.3.jarBla".contains(pattern)).isFalse()
+        assertThat("bla\\bla\\bla\\corda-4.3.jar".contains(pattern)).isTrue()
+        assertThat("corda-4.3-jdk11.jar".contains(pattern)).isTrue()
+        assertThat("corda-4.3jdk11.jar".contains(pattern)).isFalse()
+        assertThat("bla\\bla\\bla\\corda-enterprise-4.3.jar".contains(pattern)).isTrue()
+        assertThat("corda-enterprise-4.3.jar".contains(pattern)).isTrue()
+        assertThat("corda-enterprise-4.3-jdk11.jar".contains(pattern)).isTrue()
 
+        releaseVersion = "4.3-RC01"
+        pattern = "\\Q$jarName\\E(-enterprise)?-\\Q$releaseVersion\\E(-.+)?\\.jar\$".toRegex()
+        assertThat("corda-4.3-RC01.jar".contains(pattern)).isTrue()
+        assertThat("corda-4.3RC01.jar".contains(pattern)).isFalse()
+
+        releaseVersion = "4.3.20190925"
+        pattern = "\\Q$jarName\\E(-enterprise)?-\\Q$releaseVersion\\E(-.+)?\\.jar\$".toRegex()
+        assertThat("corda-4.3.20190925.jar".contains(pattern)).isTrue()
+        assertThat("corda-4.3.20190925-TEST.jar".contains(pattern)).isTrue()
+    }
 }


### PR DESCRIPTION
* `cordformation`: remove hard dependency on java 1.8 for macos in runnodes (and allow for usage of JAVA_HOME if set)

* `cordformation`: add support for classifier (eg. jdk11) in detection of corda runtime artifacts (eg. corda.jar, test-server.jar).  
