### PR TITLE
enhance node dirname parsing to include OU and fix trim

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,6 +22,7 @@ changes to this list.
 * Austin Moothart (R3)
 * Barry Childe (HSBC)
 * Barry Flower (Westpac)
+* Ben Shi (GROW Super)
 * Benjamin Abineri (R3)
 * Benoit Lafontaine (OCTO)
 * Berit Bourgonje (ING)

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 
 * `publish-utils`: Generate appropriate `compile` and `runtime` dependencies when publishing from a given Gradle configuration.
 
+* `cordformation`: Add support for OU when generating nodes directories.
+
 ### Version 4.0.45
 
 * `api-scanner`: Update to support Gradle's `java-library` plugin.

--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -401,9 +401,9 @@ open class Node @Inject constructor(private val project: Project) {
         }
         // Parsing O= & OU= part directly because importing BouncyCastle provider in Cordformation causes problems
         // with loading our custom X509EdDSAEngine.
-        val attributes = name!!.trim().split(",")
-        val organizationName = attributes.find { it.trim().startsWith("O=") }?.substringAfter("=")
-        val organizationUnit = attributes.find { it.trim().startsWith("OU=") }?.substringAfter("=")
+        val attributes = name!!.trim().split(",").map(String::trim)
+        val organizationName = attributes.find { it.startsWith("O=") }?.substringAfter("=")
+        val organizationUnit = attributes.find { it.startsWith("OU=") }?.substringAfter("=")
         val dirName = when {
             organizationName.isNullOrBlank() -> name
             organizationUnit.isNullOrBlank() -> organizationName

--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -399,13 +399,20 @@ open class Node @Inject constructor(private val project: Project) {
             project.logger.error("Node has a null name - cannot create node")
             throw IllegalStateException("Node has a null name - cannot create node")
         }
-        // Parsing O= part directly because importing BouncyCastle provider in Cordformation causes problems
+        // Parsing O= & OU= part directly because importing BouncyCastle provider in Cordformation causes problems
         // with loading our custom X509EdDSAEngine.
-        val organizationName = name!!.trim().split(",").firstOrNull { it.startsWith("O=") }?.substringAfter("=")
-        val dirName = organizationName ?: name
+        val attributes = name!!.trim().split(",")
+        val organizationName = attributes.find { it.trim().startsWith("O=") }?.substringAfter("=")
+        val organizationUnit = attributes.find { it.trim().startsWith("OU=") }?.substringAfter("=")
+        val dirName = when {
+            organizationName.isNullOrBlank() -> name
+            organizationUnit.isNullOrBlank() -> organizationName
+            else -> organizationName + '_' + organizationUnit
+        }
+
         containerName = dirName!!.replace("\\s++".toRegex(), "-").toLowerCase()
         this.rootDir = rootDir.toFile()
-        nodeDir = File(this.rootDir, dirName.replace("\\s", ""))
+        nodeDir = File(this.rootDir, dirName.replace("\\s++".toRegex(), ""))
         Files.createDirectories(nodeDir.toPath())
     }
 

--- a/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
@@ -34,7 +34,7 @@ class CordformTest {
         const val cordaFinanceContractsJarName = "corda-finance-contracts-4.0"
         const val localCordappJarName = "locally-built-cordapp"
         const val notaryNodeName = "NotaryService"
-
+        const val notaryNodeUnitName = "_OrgUnit"
         private val testGradleUserHome = System.getProperty("test.gradle.user.home", ".")
     }
 
@@ -90,6 +90,19 @@ class CordformTest {
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile()
         assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile()
     }
+
+    @Test
+    fun `a node with cordapp dependency with OU in name`() {
+        val runner = getStandardGradleRunnerFor("DeploySingleNodeWithCordappWithOU.gradle")
+
+        val result = runner.build()
+
+        assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(getNodeCordappJar(notaryNodeName + notaryNodeUnitName, cordaFinanceWorkflowsJarName)).isRegularFile()
+        assertThat(getNodeCordappJar(notaryNodeName + notaryNodeUnitName, cordaFinanceContractsJarName)).isRegularFile()
+        assertThat(getNetworkParameterOverrides(notaryNodeName + notaryNodeUnitName)).isRegularFile()
+    }
+
 
     @Test
     fun `deploy a node with cordapp config`() {

--- a/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
@@ -33,7 +33,7 @@ class CordformTest {
         const val cordaFinanceWorkflowsJarName = "corda-finance-workflows-4.0"
         const val cordaFinanceContractsJarName = "corda-finance-contracts-4.0"
         const val localCordappJarName = "locally-built-cordapp"
-        const val notaryNodeName = "Notary Service"
+        const val notaryNodeName = "NotaryService"
 
         private val testGradleUserHome = System.getProperty("test.gradle.user.home", ".")
     }

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappWithOU.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappWithOU.gradle
@@ -1,0 +1,42 @@
+buildscript {
+    ext {
+        corda_group = 'net.corda'
+        corda_release_version = '4.0'
+        jolokia_version = '1.6.0'
+    }
+}
+
+plugins {
+    id 'net.corda.plugins.cordformation'
+}
+
+repositories {
+    mavenCentral()
+    maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-dev' }
+    maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }
+    maven { url 'https://jitpack.io' }
+}
+
+dependencies {
+    runtime "$corda_group:corda:$corda_release_version"
+    runtime "$corda_group:corda-node-api:$corda_release_version"
+    cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
+    cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
+}
+
+task deployNodes(type: net.corda.plugins.Cordform) {
+    node {
+        projectCordapp {
+            deploy false
+        }
+        name 'OU=Org Unit, O=Notary Service, L=Zurich, C=CH'
+        notary = [validating : true]
+        p2pPort 10002
+        rpcPort 10003
+        rpcSettings {
+            adminAddress "localhost:10004"
+        }
+        cordapps = ["$corda_group:corda-finance-contracts:$corda_release_version",
+                    "$corda_group:corda-finance-workflows:$corda_release_version"]
+    }
+}


### PR DESCRIPTION
Add support for `OU` when generating node directories in cordformation. This is to prevent duplicate organizations from overwriting the node directory.

Also fixed a couple small issues relative to trim / regex handling.

First PR so please let me know if anything else is required on my end.

# PR Checklist:

- [x] Have you run the unit, integration and smoke tests as described here? https://docs.corda.net/head/testing.html
- [n/a] If you added/changed public APIs, did you write/update the JavaDocs?
- [x] If the changes are of interest to application developers, have you added them to the changelog, and potentially release notes?
- [x] If you are contributing for the first time, please read the agreement in CONTRIBUTING.md now and add to this Pull Request that you agree to it.

Thanks for your code, it's appreciated! :)
