### PR TITLE
make 5005 & 7005 port configuare to avoid port confict if running two…

### DIFF
--- a/cordformation/src/noderunner/kotlin/net/corda/plugins/NodeRunner.kt
+++ b/cordformation/src/noderunner/kotlin/net/corda/plugins/NodeRunner.kt
@@ -6,8 +6,8 @@ import java.util.*
 
 private const val HEADLESS_FLAG = "--headless"
 private const val CAPSULE_DEBUG_FLAG = "--capsule-debug"
-private const val BASE_DEBUG_PORT_FLAG = "-Dnet.corda.noderunner.debug.port="
-private const val BASE_MONITORING_PORT_FLAG = "-Dnet.corda.noderunner.monitoring.port="
+private const val BASE_DEBUG_PORT_FLAG = "--debug.port="
+private const val BASE_MONITORING_PORT_FLAG = "--monitoring.port="
 private const val CORDA_JAR_NAME = "corda.jar"
 private const val CORDA_WEBSERVER_JAR_NAME = "corda-testserver.jar"
 private const val OLD_CORDA_WEBSERVER_JAR_NAME = "corda-webserver.jar"
@@ -42,19 +42,19 @@ fun main(args: Array<String>) {
     val headless = ((!isTmux() && GraphicsEnvironment.isHeadless()) || args.contains(HEADLESS_FLAG))
     val capsuleDebugMode = args.contains(CAPSULE_DEBUG_FLAG)
     try{
-        base_debug_port = Integer.valueOf(args.first { it -> it.contains(BASE_DEBUG_PORT_FLAG)}.removePrefix(BASE_DEBUG_PORT_FLAG))
+        base_debug_port = Integer.valueOf(args.first { it -> it.startsWith(BASE_DEBUG_PORT_FLAG)}.removePrefix(BASE_DEBUG_PORT_FLAG))
         println("base_debug_port set to: $base_debug_port")
-    }catch(e: Throwable){
+    }catch(e: NumberFormatException){
         println("base_debug_port set to default： $base_debug_port")
     }
     try{
-        base_monitoring_port = Integer.valueOf(args.first { it -> it.contains(BASE_MONITORING_PORT_FLAG)}.removePrefix(BASE_MONITORING_PORT_FLAG))
+        base_monitoring_port = Integer.valueOf(args.first { it -> it.startsWith(BASE_MONITORING_PORT_FLAG)}.removePrefix(BASE_MONITORING_PORT_FLAG))
         println("base_monitoring_port set to: $base_monitoring_port")
-    }catch(e: Throwable){
+    }catch(e: NumberFormatException){
         println("base_monitoring_port set to default: $base_monitoring_port")
     }
     val workingDir = File(System.getProperty("user.dir"))
-    val javaArgs = args.filter { it != HEADLESS_FLAG && it != CAPSULE_DEBUG_FLAG && !it.contains(BASE_DEBUG_PORT_FLAG) && !it.contains(BASE_MONITORING_PORT_FLAG) }
+    val javaArgs = args.filter { it != HEADLESS_FLAG && it != CAPSULE_DEBUG_FLAG && !it.startsWith(BASE_DEBUG_PORT_FLAG) && !it.startsWith(BASE_MONITORING_PORT_FLAG) }
     val jvmArgs = if (capsuleDebugMode) listOf("-Dcapsule.log=verbose") else emptyList()
     println("Starting nodes in $workingDir")
     workingDir.listFiles { file -> file.isDirectory }.forEach { dir ->

--- a/cordformation/src/noderunner/kotlin/net/corda/plugins/NodeRunner.kt
+++ b/cordformation/src/noderunner/kotlin/net/corda/plugins/NodeRunner.kt
@@ -6,12 +6,17 @@ import java.util.*
 
 private const val HEADLESS_FLAG = "--headless"
 private const val CAPSULE_DEBUG_FLAG = "--capsule-debug"
+private const val BASE_DEBUG_PORT_FLAG = "-Dnet.corda.noderunner.debug.port="
+private const val BASE_MONITORING_PORT_FLAG = "-Dnet.corda.noderunner.monitoring.port="
 private const val CORDA_JAR_NAME = "corda.jar"
 private const val CORDA_WEBSERVER_JAR_NAME = "corda-testserver.jar"
 private const val OLD_CORDA_WEBSERVER_JAR_NAME = "corda-webserver.jar"
 private const val CORDA_CONFIG_NAME = "node.conf"
 private const val CORDA_WEBSERVER_CONFIG_NAME = "web-server.conf"
 private val CORDA_HEADLESS_ARGS = listOf("--no-local-shell")
+
+private var base_debug_port = 5005
+private var base_monitoring_port = 7005
 
 private val os by lazy {
     val osName = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH)
@@ -23,12 +28,12 @@ private val os by lazy {
 private enum class OS { MACOS, WINDOWS, LINUX }
 
 private object DebugPortAlloc {
-    private var basePort = 5005
+    private var basePort = base_debug_port
     internal fun next() = basePort++
 }
 
 private object MonitoringPortAlloc {
-    private var basePort = 7005
+    private var basePort = base_monitoring_port
     internal fun next() = basePort++
 }
 
@@ -36,8 +41,20 @@ fun main(args: Array<String>) {
     val startedProcesses = mutableListOf<Process>()
     val headless = ((!isTmux() && GraphicsEnvironment.isHeadless()) || args.contains(HEADLESS_FLAG))
     val capsuleDebugMode = args.contains(CAPSULE_DEBUG_FLAG)
+    try{
+        base_debug_port = Integer.valueOf(args.first { it -> it.contains(BASE_DEBUG_PORT_FLAG)}.removePrefix(BASE_DEBUG_PORT_FLAG))
+        println("base_debug_port set to: $base_debug_port")
+    }catch(e: Throwable){
+        println("base_debug_port set to default： $base_debug_port")
+    }
+    try{
+        base_monitoring_port = Integer.valueOf(args.first { it -> it.contains(BASE_MONITORING_PORT_FLAG)}.removePrefix(BASE_MONITORING_PORT_FLAG))
+        println("base_monitoring_port set to: $base_monitoring_port")
+    }catch(e: Throwable){
+        println("base_monitoring_port set to default: $base_monitoring_port")
+    }
     val workingDir = File(System.getProperty("user.dir"))
-    val javaArgs = args.filter { it != HEADLESS_FLAG && it != CAPSULE_DEBUG_FLAG }
+    val javaArgs = args.filter { it != HEADLESS_FLAG && it != CAPSULE_DEBUG_FLAG && !it.contains(BASE_DEBUG_PORT_FLAG) && !it.contains(BASE_MONITORING_PORT_FLAG) }
     val jvmArgs = if (capsuleDebugMode) listOf("-Dcapsule.log=verbose") else emptyList()
     println("Starting nodes in $workingDir")
     workingDir.listFiles { file -> file.isDirectory }.forEach { dir ->


### PR DESCRIPTION
👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻

The noderunner command `runnodes` or `runnodes.bat` is great for development, because it allow developers to run mutiple nodes in a single command (say, one batch), Instead of using `java -Dcapsule.jvm.args="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005" -jar corda.jar`

Howerver, it could be protential problem if there are mutiple `batches` running at the same time. The problem comes here:  [sourcegraph: NodeRunner.kt ](https://sourcegraph.com/github.com/corda/corda-gradle-plugins/-/blob/cordformation/src/noderunner/kotlin/net/corda/plugins/NodeRunner.kt#L25-28)

To solve this, I introduce two configuatable system enviroment variables to support that: 
```zsh
# to overide default starting port: 5005
--debug.port=5105
```

```zsh
# to override jmx starting port 7005
--monitoring.port=7105
```

This would allow developer change the switching starting port 5005++ to avoid `address already be used`

The config could be null, because I applied default value 5005 and 7005 to let legacy code works. 

# PR Checklist:

- [X] Have you run the unit, integration and smoke tests as described here? https://docs.corda.net/head/testing.html
- [X] If you added/changed public APIs, did you write/update the JavaDocs?  
- [X] If the changes are of interest to application developers, have you added them to the changelog, and potentially release notes?
- [x] If you are contributing for the first time, please read the agreement in CONTRIBUTING.md now and add to this Pull Request that you agree to it.

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.

