### PR TITLE
Maintenance on Gradle files.

### DIFF
--- a/api-scanner/build.gradle
+++ b/api-scanner/build.gradle
@@ -6,7 +6,6 @@ description "Generates a summary of the artifact's public API"
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 gradlePlugin {

--- a/build.gradle
+++ b/build.gradle
@@ -8,14 +8,13 @@ buildscript {
         snake_yaml_version = '1.19'
         commons_io_version = '2.6'
         assertj_version = '3.12.1'
-        junit_jupiter_version = '5.5.0'
+        junit_jupiter_version = '5.5.2'
         hamcrest_version = '2.1'
-        asm_version = '7.1'
+        asm_version = '7.2'
     }
 
     repositories {
         mavenCentral()
-        jcenter()
     }
 
     dependencies {

--- a/cordapp/build.gradle
+++ b/cordapp/build.gradle
@@ -5,7 +5,6 @@ description 'Turns a project into a cordapp project that produces cordapp fat JA
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 gradlePlugin {

--- a/cordapp/src/test/kotlin/net/corda/plugins/CordappGradleConfigurationsTest.kt
+++ b/cordapp/src/test/kotlin/net/corda/plugins/CordappGradleConfigurationsTest.kt
@@ -32,7 +32,7 @@ class CordappGradleConfigurationsTest {
                     |
                     |dependencies {
                     |    compile "org.slf4j:slf4j-api:1.7.26"
-                    |    runtime "commons-io:commons-io:2.4"
+                    |    runtime "commons-io:commons-io:2.6"
                     |    cordaCompile "com.google.guava:guava:20.0"
                     |    cordaRuntime "javax.servlet:javax.servlet-api:3.1.0"
                     |    implementation "javax.persistence:javax.persistence-api:2.2"
@@ -77,7 +77,7 @@ class CordappGradleConfigurationsTest {
     @Test
     fun testRuntimeIncluded() {
         assertThat(testProject.output)
-            .contains("CorDapp dependency: commons-io-2.4.jar")
+            .contains("CorDapp dependency: commons-io-2.6.jar")
         assertThat(poms)
             .anyMatch { it.name == "META-INF/maven/commons-io/commons-io/pom.xml" }
     }

--- a/cordapp/src/test/kotlin/net/corda/plugins/CordappLibraryGradleConfigurationsTest.kt
+++ b/cordapp/src/test/kotlin/net/corda/plugins/CordappLibraryGradleConfigurationsTest.kt
@@ -33,7 +33,7 @@ class CordappLibraryGradleConfigurationsTest {
                     |
                     |dependencies {
                     |    compile "org.slf4j:slf4j-api:1.7.26"
-                    |    runtime "commons-io:commons-io:2.4"
+                    |    runtime "commons-io:commons-io:2.6"
                     |    cordaCompile "com.google.guava:guava:20.0"
                     |    cordaRuntime "javax.servlet:javax.servlet-api:3.1.0"
                     |    api "javax.annotation:javax.annotation-api:1.3.2"
@@ -87,7 +87,7 @@ class CordappLibraryGradleConfigurationsTest {
     @Test
     fun testRuntimeIncluded() {
         assertThat(testProject.output)
-            .contains("CorDapp dependency: commons-io-2.4.jar")
+            .contains("CorDapp dependency: commons-io-2.6.jar")
         assertThat(poms)
             .anyMatch { it.name == "META-INF/maven/commons-io/commons-io/pom.xml" }
     }

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordapp.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordapp.gradle
@@ -14,7 +14,6 @@ repositories {
     mavenCentral()
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-dev' }
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }
-    maven { url 'https://jitpack.io' }
 }
 
 dependencies {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappBackwardsCompatibility.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappBackwardsCompatibility.gradle
@@ -14,7 +14,6 @@ repositories {
     mavenCentral()
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-dev' }
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }
-    maven { url 'https://jitpack.io' }
 }
 
 dependencies {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappConfig.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappConfig.gradle
@@ -14,7 +14,6 @@ repositories {
     mavenCentral()
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-dev' }
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }
-    maven { url 'https://jitpack.io' }
 }
 
 dependencies {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappWithOU.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappWithOU.gradle
@@ -14,7 +14,6 @@ repositories {
     mavenCentral()
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-dev' }
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }
-    maven { url 'https://jitpack.io' }
 }
 
 dependencies {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
@@ -14,7 +14,6 @@ repositories {
     mavenCentral()
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-dev' }
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }
-    maven { url 'https://jitpack.io' }
 }
 
 dependencies {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithNetworkParameterOverrides.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithNetworkParameterOverrides.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         corda_group = 'net.corda'
-        corda_release_version = '5.0-SNAPSHOT' // TODO: Set to 5.0 when Corda 5 is released
+        corda_release_version = '4.2'
         finance_release_version = '4.0'
         jolokia_version = '1.6.0'
     }
@@ -16,7 +16,6 @@ repositories {
     mavenCentral()
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-dev' }
     maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }
-    maven { url 'https://jitpack.io' }
 }
 
 dependencies {

--- a/jar-filter/build.gradle
+++ b/jar-filter/build.gradle
@@ -8,7 +8,6 @@ description 'Deletes or stubs out unwanted elements from Java/Kotlin byte-code.'
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 ext {

--- a/jar-filter/src/test/resources/repositories.gradle
+++ b/jar-filter/src/test/resources/repositories.gradle
@@ -1,4 +1,3 @@
 repositories {
-    mavenLocal()
-    jcenter()
+    mavenCentral()
 }

--- a/jar-filter/unwanteds/build.gradle
+++ b/jar-filter/unwanteds/build.gradle
@@ -4,7 +4,6 @@ description 'Test artifacts for the jar-filter plugin.'
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 dependencies {


### PR DESCRIPTION
- Remove the `jcenter` repository  because `mavenCentral` has a longer memory.
- Remove the Jitpack repository because it is (and should be!) unused.
- Replace the stale reference to Corda 5.0-SNAPSHOT with 4.2