### PR TITLE
CORDA-3377: Add `excludePackages` to the `scanApi` task.

### DIFF
--- a/api-scanner/README.md
+++ b/api-scanner/README.md
@@ -34,12 +34,21 @@ scanApi {
     // Enable / disable the task within this module.
     enabled = {true|false}
 
+    // The `archiveClassifier` value for the Jar artifact that will be scanned.
+    // This is empty by default, to select the module's primary Jar artifact.
+    targetClassifier = '<classifier>'
+
     // Names of classes that should be excluded from the output.
     excludeClasses = [
         ...
     ]
 
-    //Methods that should be excluded from the output.
+    // Names of packages that should be excluded from the output.
+    excludePackages = [
+        ...
+    ]
+
+    // Methods that should be excluded from the output.
     excludeMethods = [
         "class_name": [
             "method_1_signature",

--- a/api-scanner/src/main/java/net/corda/plugins/ApiPrintWriter.java
+++ b/api-scanner/src/main/java/net/corda/plugins/ApiPrintWriter.java
@@ -54,8 +54,8 @@ public class ApiPrintWriter extends PrintWriter {
         println();
     }
 
-    public void println(MethodInfo method, String indentation) {
-        append(asAnnotations(method.getAnnotationNames(), indentation));
+    public void println(MethodInfo method, List<String> visibleAnnotations, String indentation) {
+        append(asAnnotations(visibleAnnotations, indentation));
         append(indentation);
         if (method.getModifiersStr() != null) {
             append(method.getModifiersStr()).append(' ');
@@ -79,8 +79,8 @@ public class ApiPrintWriter extends PrintWriter {
         println(')');
     }
 
-    public void println(FieldInfo field, String indentation) {
-        append(asAnnotations(field.getAnnotationNames(), indentation))
+    public void println(FieldInfo field, List<String> visibleAnnotations, String indentation) {
+        append(asAnnotations(visibleAnnotations, indentation))
             .append(indentation)
             .append(field.getModifierStr())
             .append(' ')

--- a/api-scanner/src/main/java/net/corda/plugins/ApiScanner.java
+++ b/api-scanner/src/main/java/net/corda/plugins/ApiScanner.java
@@ -47,6 +47,7 @@ public class ApiScanner implements Plugin<Project> {
             scanTask.setClasspath(compilationClasspath(project.getConfigurations()));
             // Automatically creates a dependency on jar tasks.
             scanTask.setSources(jarSources);
+            scanTask.setExcludePackages(extension.getExcludePackages());
             scanTask.setExcludeClasses(extension.getExcludeClasses());
             scanTask.setExcludeMethods(extension.getExcludeMethods());
             scanTask.setVerbose(extension.isVerbose());

--- a/api-scanner/src/main/java/net/corda/plugins/ScannerExtension.java
+++ b/api-scanner/src/main/java/net/corda/plugins/ScannerExtension.java
@@ -2,12 +2,12 @@ package net.corda.plugins;
 
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
 
 import javax.inject.Inject;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
@@ -15,12 +15,15 @@ public class ScannerExtension {
 
     private boolean verbose;
     private boolean enabled = true;
-    private List<String> excludeClasses = emptyList();
+    private final SetProperty<String> excludeClasses;
     private Map<String, List<String>> excludeMethods = emptyMap();
+    private final SetProperty<String> excludePackages;
     private final Property<String> targetClassifier;
 
     @Inject
     public ScannerExtension(ObjectFactory objectFactory, String defaultClassifier) {
+        excludeClasses = objectFactory.setProperty(String.class);
+        excludePackages = objectFactory.setProperty(String.class);
         targetClassifier = objectFactory.property(String.class).convention(defaultClassifier);
     }
 
@@ -40,12 +43,8 @@ public class ScannerExtension {
         this.enabled = enabled;
     }
 
-    public List<String> getExcludeClasses() {
+    public SetProperty<String> getExcludeClasses() {
         return excludeClasses;
-    }
-
-    public void setExcludeClasses(List<String> excludeClasses) {
-        this.excludeClasses = excludeClasses;
     }
 
     public Map<String, List<String>> getExcludeMethods() {
@@ -54,6 +53,10 @@ public class ScannerExtension {
 
     public void setExcludeMethods(Map<String, List<String>> excludeMethods) {
         this.excludeMethods = excludeMethods;
+    }
+
+    public SetProperty<String> getExcludePackages() {
+        return excludePackages;
     }
 
     public Property<String> getTargetClassifier() {

--- a/api-scanner/src/test/java/net/corda/plugins/ClassWithInternalAnnotationTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/ClassWithInternalAnnotationTest.java
@@ -24,5 +24,9 @@ class ClassWithInternalAnnotationTest {
         assertEquals("public class net.corda.example.AnnotatedClass extends java.lang.Object\n" +
             "  public <init>()\n" +
             "##", testProject.getApiText());
+
+        // Make this explicit - the InternalClass has NOT been included!
+        assertThat(testProject.getOutput()).contains("net.corda.example.InternalClass");
+        assertThat(testProject.getApiText()).doesNotContain("class net.corda.example.InternalClass ");
     }
 }

--- a/api-scanner/src/test/java/net/corda/plugins/ExcludePackageTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/ExcludePackageTest.java
@@ -1,0 +1,33 @@
+package net.corda.plugins;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ExcludePackageTest {
+    private GradleProject testProject;
+
+    @BeforeEach
+    void setup(@TempDir Path testProjectDir) throws IOException {
+        testProject = new GradleProject(testProjectDir, "exclude-package").build();
+    }
+
+    @Test
+    void testExcludingEntirePackage() throws IOException {
+        assertEquals("public class net.corda.example.wanted.WantedClass extends java.lang.Object\n" +
+            "  public <init>()\n" +
+            "##", testProject.getApiText());
+
+        // Make this explicit - the unwanted classes have NOT been included!
+        assertThat(testProject.getApiText()).doesNotContain(
+            "class net.corda.example.unwanted.UnwantedClass ",
+            "class net.corda.example.unwanted.very.VeryUnwantedClass "
+        );
+    }
+}

--- a/api-scanner/src/test/resources/class-internal-annotation/java/net/corda/example/AnnotatedClass.java
+++ b/api-scanner/src/test/resources/class-internal-annotation/java/net/corda/example/AnnotatedClass.java
@@ -1,5 +1,9 @@
 package net.corda.example;
 
+/**
+ * This class should appear in the scan output,
+ * but its @InvisibleAnnotation should not.
+ */
 @InvisibleAnnotation
 public class AnnotatedClass {
 }

--- a/api-scanner/src/test/resources/class-internal-annotation/java/net/corda/example/InternalClass.java
+++ b/api-scanner/src/test/resources/class-internal-annotation/java/net/corda/example/InternalClass.java
@@ -1,0 +1,11 @@
+package net.corda.example;
+
+import net.corda.core.CordaInternal;
+
+/**
+ * This class should not appear in the scan output
+ * because it has been annotated with @CordaInternal.
+ */
+@CordaInternal
+public class InternalClass {
+}

--- a/api-scanner/src/test/resources/exclude-package/build.gradle
+++ b/api-scanner/src/test/resources/exclude-package/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'java'
+    id 'net.corda.plugins.api-scanner'
+}
+apply from: 'repositories.gradle'
+
+description 'Test behaviour of scanApi.excludePackages'
+
+sourceSets {
+    main {
+        java {
+            srcDir files("../resources/test/exclude-package/java",)
+        }
+    }
+}
+
+jar {
+    archiveBaseName = 'exclude-package'
+}
+
+scanApi {
+    excludePackages = [
+        'net.corda.example.unwanted'
+    ]
+    verbose = true
+}

--- a/api-scanner/src/test/resources/exclude-package/java/net/corda/example/unwanted/UnwantedClass.java
+++ b/api-scanner/src/test/resources/exclude-package/java/net/corda/example/unwanted/UnwantedClass.java
@@ -1,0 +1,8 @@
+package net.corda.example.unwanted;
+
+/**
+ * This class should not be included in the scan
+ * because we have excluded the entire package.
+ */
+public class UnwantedClass {
+}

--- a/api-scanner/src/test/resources/exclude-package/java/net/corda/example/unwanted/very/VeryUnwantedClass.java
+++ b/api-scanner/src/test/resources/exclude-package/java/net/corda/example/unwanted/very/VeryUnwantedClass.java
@@ -1,0 +1,8 @@
+package net.corda.example.unwanted.very;
+
+/**
+ * This class should not be included in the scan
+ * because we have also excluded the sub-packages.
+ */
+public class VeryUnwantedClass {
+}

--- a/api-scanner/src/test/resources/exclude-package/java/net/corda/example/wanted/WantedClass.java
+++ b/api-scanner/src/test/resources/exclude-package/java/net/corda/example/wanted/WantedClass.java
@@ -1,0 +1,7 @@
+package net.corda.example.wanted;
+
+/**
+ * This class should be included in the scan.
+ */
+public class WantedClass {
+}

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,8 @@
 
 * `cordformation`: Add `--base-debug-port=` and `--base-monitoring-port=` options to the `runnodes` script to change the port numbers that the script will begin incrementing from.
 
+* `api-scanner`: Add `excludePackages` option to the `scanApi` task.
+
 ### Version 5.0.4
 
 * `cordformation`: remove hard dependency on java 1.8 for macos in runnodes (and allow for usage of JAVA_HOME if set)


### PR DESCRIPTION
Add `excludePackages` to the API Scanner plugin's DSL. This is so that it can ignore all of the classes in the DJVM's `sandbox.**` packages.

I've also simplified some of the code to make it easier to upgrade to ClassGraph.