### PR TITLE
CORDA-3453: Fix NPE in publish-utils when publishing dependencies from a custom Gradle configuration.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ### Version 5.0.7
 
+`publish-utils`: Fix NPE for dependencies without group, name or version when generating POMs from custom Gradle configurations.
+
 ### Version 5.0.6
 
 `api-scanner`: Update FastClasspathScanner 2.18.2 to ClassGraph 4.8.53. This will break the API scan output in the follwing ways:

--- a/publish-utils/src/main/groovy/net/corda/plugins/MavenMapper.groovy
+++ b/publish-utils/src/main/groovy/net/corda/plugins/MavenMapper.groovy
@@ -68,7 +68,10 @@ class MavenMapper {
     ) {
         Configuration configuration = configurations.findByName(configName)
         if (configuration) {
-            return configuration.allDependencies.iterator().collect { Dependency dep ->
+            return configuration.allDependencies.iterator().findAll { Dependency dep ->
+                dep.version && dep.group
+            }.collect {
+                Dependency dep = (Dependency) it
                 ModuleVersionIdentifier id = DefaultModuleVersionIdentifier.newId(dep.group, dep.name, dep.version)
                 String alias = publishedAliases[id]
                 alias == null ? id : DefaultModuleVersionIdentifier.newId(id.group, alias, id.version)


### PR DESCRIPTION
The code incorrectly assumes that dependencies returned from `Configuration.getAllDependencies()` will always have a non-null `group` and `version`. Apply a filter to remove any unusable entries.