### PR TITLE
added gradle settings to configure the node's database parameters

### DIFF
--- a/cordformation/src/main/kotlin/net/corda/plugins/DataSourceProperties.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/DataSourceProperties.kt
@@ -1,0 +1,39 @@
+package net.corda.plugins
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigValueFactory
+
+class DataSourceProperties {
+    private var config = ConfigFactory.empty()
+
+    /**
+     * Full class name of the JDBC driver
+     */
+    fun dataSourceClassName(className : String) = setValue("dataSourceClassName", className)
+
+    /**
+     * Database user
+     */
+    fun url(value: String) = setValue("dataSource.url", value)
+
+    /**
+     * Database user
+     */
+    fun user(value: String) = setValue("dataSource.user", value)
+
+    /**
+     * Database password.
+     */
+    fun password(value: String) = setValue("dataSource.password", value)
+
+    fun addTo(key: String, config: Config): Config {
+        return if (this.config.isEmpty) {
+            config
+        } else config.withValue(key, this.config.root())
+    }
+
+    private fun setValue(path: String, value: Any) {
+        config = config.withValue(path, ConfigValueFactory.fromAnyRef(value))
+    }
+}

--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -248,6 +248,22 @@ open class Node @Inject constructor(private val project: Project) {
         config = config.withValue("h2port", ConfigValueFactory.fromAnyRef(h2Port))
     }
 
+    /**
+     * This section is used to configure the JDBC connection and database driver used for the node’s persistence.
+     */
+    fun dataSourceProperties(options: DataSourceProperties) {
+        config = options.addTo("dataSourceProperties", config)
+    }
+
+    /**
+     * This section is used to configure the JDBC connection and database driver used for the node’s persistence.
+     */
+    fun dataSourceProperties(configureClosure: Closure<in DataSourceProperties>) {
+        val dataSource = project.configure(DataSourceProperties(), configureClosure) as DataSourceProperties
+        dataSourceProperties(dataSource)
+    }
+
+
     fun useTestClock(useTestClock: Boolean) {
         config = config.withValue("useTestClock", ConfigValueFactory.fromAnyRef(useTestClock))
     }


### PR DESCRIPTION
this allow to configure the data source parameters in the `node.conf` file in the following way

```
node {
    dataSourceProperties {
        dataSourceClassName "org.postgresql.ds.PGSimpleDataSource"
        url "jdbc:postgresql:corda_bob"
        user "Bob"
        password "mypassword"
    }
}
```

JDBC driver, URL, user and password are supported at the moment
