### PR TITLE
CORDA-3586: Backport fixes for Gradle cordformation task validation warnings.

### DIFF
--- a/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
@@ -80,9 +80,9 @@ open class Baseform(objects: ObjectFactory) : DefaultTask() {
      * support this for a [Closure]. However, these defaults are
      * applied to every node anyway so [Internal] should be fine.
      */
-    @get:Optional
     @get:Internal
     var nodeDefaults: Closure<in Node>? = null
+        protected set
 
     /**
      * Configuration for keystore generation and JAR signing.

--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -47,7 +47,7 @@ open class Node @Inject constructor(private val project: Project) {
     private val internalCordapps = mutableListOf<Cordapp>()
     @get:Optional
     @get:Nested
-    val projectCordapp = project.objects.newInstance(Cordapp::class.java, "", project)
+    val projectCordapp: Cordapp = project.objects.newInstance(Cordapp::class.java, "", project)
     internal lateinit var nodeDir: File
         @Internal get
         private set
@@ -663,5 +663,6 @@ open class Node @Inject constructor(private val project: Project) {
         flowOverrides.add(initiator to responder)
     }
 
+    @get:Input
     val flowOverrides: MutableList<Pair<String, String>> = mutableListOf()
 }


### PR DESCRIPTION
Apply Gradle's task property annotations more correctly, and make some of the property setters non-public too.
Unfortunately, some of these warnings are unfixable in Gradle 4.x.