### PR TITLE
BACKPORT: Tidy up usage of Gradle API.

### DIFF
--- a/api-scanner/build.gradle
+++ b/api-scanner/build.gradle
@@ -1,6 +1,8 @@
-apply plugin: 'java'
-apply plugin: 'jacoco'
-apply plugin: 'java-gradle-plugin'
+plugins {
+    id 'java'
+    id 'jacoco'
+    id 'java-gradle-plugin'
+}
 
 description "Generates a summary of the artifact's public API"
 

--- a/api-scanner/src/main/java/net/corda/plugins/GenerateApi.java
+++ b/api-scanner/src/main/java/net/corda/plugins/GenerateApi.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
 import static net.corda.plugins.ApiScanner.GROUP_NAME;
+import static org.gradle.api.tasks.PathSensitivity.RELATIVE;
 
 @SuppressWarnings("unused")
 public class GenerateApi extends DefaultTask {
@@ -46,6 +47,7 @@ public class GenerateApi extends DefaultTask {
         return version;
     }
 
+    @PathSensitive(RELATIVE)
     @InputFiles
     public FileCollection getSources() {
         // This will trigger configuration of every ScanApi task in the project.

--- a/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
+++ b/api-scanner/src/main/java/net/corda/plugins/ScanApi.java
@@ -23,6 +23,7 @@ import java.util.stream.StreamSupport;
 import static java.util.Collections.*;
 import static java.util.stream.Collectors.*;
 import static net.corda.plugins.ApiScanner.GROUP_NAME;
+import static org.gradle.api.tasks.PathSensitivity.RELATIVE;
 
 @SuppressWarnings("unused")
 public class ScanApi extends DefaultTask {
@@ -86,6 +87,7 @@ public class ScanApi extends DefaultTask {
         setGroup(GROUP_NAME);
     }
 
+    @PathSensitive(RELATIVE)
     @SkipWhenEmpty
     @InputFiles
     public FileCollection getSources() {

--- a/cordapp/build.gradle
+++ b/cordapp/build.gradle
@@ -1,7 +1,9 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
-apply plugin: 'kotlin'
-apply plugin: 'java-gradle-plugin'
+plugins {
+    id 'org.jetbrains.kotlin.jvm'
+    id 'java-gradle-plugin'
+}
 
 description 'Turns a project into a cordapp project that produces cordapp fat JARs'
 
@@ -44,9 +46,9 @@ dependencies {
     // Gradle plugins written in Kotlin will always use Gradle's
     // own provided Kotlin libraries at runtime. So ensure that
     // we don't add Kotlin as a dependency in our published POM.
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     testImplementation "commons-io:commons-io:$commons_io_version"
-    testImplementation "org.jetbrains.kotlin:kotlin-test"
+    testImplementation 'org.jetbrains.kotlin:kotlin-test'
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junit_jupiter_version")
     testImplementation "org.assertj:assertj-core:$assertj_version"

--- a/cordapp/src/main/kotlin/net/corda/plugins/SignJar.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/SignJar.kt
@@ -6,7 +6,13 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileCollection
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFiles
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity.RELATIVE
+import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.TaskAction
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -54,6 +60,7 @@ open class SignJar : DefaultTask() {
 
     private val _inputJars: ConfigurableFileCollection = project.files()
 
+    @get:PathSensitive(RELATIVE)
     @get:InputFiles
     @get:SkipWhenEmpty
     val inputJars: FileCollection

--- a/cordformation/build.gradle
+++ b/cordformation/build.gradle
@@ -1,7 +1,9 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
-apply plugin: 'kotlin'
-apply plugin: 'java-gradle-plugin'
+plugins {
+    id 'org.jetbrains.kotlin.jvm'
+    id 'java-gradle-plugin'
+}
 
 description 'A small gradle plugin for adding some basic Quasar tasks and configurations to reduce build.gradle bloat.'
 
@@ -58,13 +60,13 @@ dependencies {
     // Gradle plugins written in Kotlin will always use Gradle's
     // own provided Kotlin libraries at runtime. So ensure that
     // we don't add Kotlin as a dependency in our published POM.
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation "commons-io:commons-io:$commons_io_version"
     implementation "com.typesafe:config:$typesafe_config_version"
 
     noderunner "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    testImplementation "org.jetbrains.kotlin:kotlin-test"
+    testImplementation 'org.jetbrains.kotlin:kotlin-test'
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junit_jupiter_version")
     testImplementation "org.assertj:assertj-core:$assertj_version"

--- a/cordformation/build.gradle
+++ b/cordformation/build.gradle
@@ -90,6 +90,15 @@ def generateSource = tasks.register('generateSource', Copy) {
 
 compileKotlin.dependsOn generateSource
 
+tasks.withType(ValidateTaskProperties) {
+    // The official advice is to annotate Path inputs
+    // as @Input instead of @InputDirectory if we don't
+    // care about the directory contents changing,
+    // Unfortunately, Gradle also generates a warning
+    // for this which we are forced to tolerate.
+    failOnWarning = false
+}
+
 task createNodeRunner(type: Jar) {
     manifest {
         attributes('Main-Class': 'net.corda.plugins.NodeRunnerKt')

--- a/cordformation/src/main/kotlin/net/corda/plugins/Dockerform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Dockerform.kt
@@ -2,6 +2,8 @@ package net.corda.plugins
 
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity.RELATIVE
 import org.gradle.api.tasks.TaskAction
 import org.yaml.snakeyaml.DumperOptions
 import org.yaml.snakeyaml.Yaml
@@ -37,6 +39,7 @@ open class Dockerform @Inject constructor(objects: ObjectFactory) : Baseform(obj
 
     private val directoryPath: Path = project.projectDir.toPath().resolve(directory)
 
+    @get:PathSensitive(RELATIVE)
     @get:InputFile
     val dockerComposePath: Path = directoryPath.resolve("docker-compose.yml")
 

--- a/jar-filter/build.gradle
+++ b/jar-filter/build.gradle
@@ -1,8 +1,8 @@
 plugins {
+    id 'org.jetbrains.kotlin.jvm'
     id 'java-gradle-plugin'
     id 'jacoco'
 }
-apply plugin: 'kotlin'
 
 description 'Deletes or stubs out unwanted elements from Java/Kotlin byte-code.'
 
@@ -46,14 +46,14 @@ dependencies {
     // Gradle plugins written in Kotlin will always use Gradle's
     // own provided Kotlin libraries at runtime. So ensure that
     // we don't add Kotlin as a dependency in our published POM.
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm:$kotlin_metadata_version") {
         exclude group: 'org.jetbrains.kotlin'
     }
     implementation "org.ow2.asm:asm:$asm_version"
 
-    testImplementation "org.jetbrains.kotlin:kotlin-test"
-    testImplementation "org.jetbrains.kotlin:kotlin-reflect"
+    testImplementation 'org.jetbrains.kotlin:kotlin-test'
+    testImplementation 'org.jetbrains.kotlin:kotlin-reflect'
     testImplementation "org.hamcrest:hamcrest:$hamcrest_version"
     testImplementation "org.assertj:assertj-core:$assertj_version"
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version"

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/JarFilterTask.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/JarFilterTask.kt
@@ -9,15 +9,25 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.Console
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.OutputFiles
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity.RELATIVE
+import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.TaskAction
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.ClassWriter.COMPUTE_MAXS
 import java.io.Closeable
 import java.io.File
 import java.io.IOException
-import java.nio.file.*
-import java.nio.file.StandardCopyOption.*
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 import java.util.zip.Deflater.BEST_COMPRESSION
 import java.util.zip.ZipFile
 import java.util.zip.ZipOutputStream
@@ -36,6 +46,7 @@ open class JarFilterTask @Inject constructor(objects: ObjectFactory, layouts: Pr
     }
 
     private val _jars: ConfigurableFileCollection = project.files()
+    @get:PathSensitive(RELATIVE)
     @get:SkipWhenEmpty
     @get:InputFiles
     val jars: FileCollection get() = _jars

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTask.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTask.kt
@@ -8,11 +8,19 @@ import org.gradle.api.file.ProjectLayout
 import org.gradle.api.logging.Logger
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFiles
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity.RELATIVE
+import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.TaskAction
 import java.io.Closeable
 import java.io.File
 import java.io.IOException
-import java.nio.file.*
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.zip.Deflater.BEST_COMPRESSION
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
@@ -27,6 +35,7 @@ open class MetaFixerTask @Inject constructor(objects: ObjectFactory, layouts: Pr
     }
 
     private val _jars: ConfigurableFileCollection = project.files()
+    @get:PathSensitive(RELATIVE)
     @get:SkipWhenEmpty
     @get:InputFiles
     val jars: FileCollection

--- a/jar-filter/unwanteds/build.gradle
+++ b/jar-filter/unwanteds/build.gradle
@@ -1,4 +1,7 @@
-apply plugin: 'kotlin'
+plugins {
+    id 'org.jetbrains.kotlin.jvm'
+    id 'java-library'
+}
 
 description 'Test artifacts for the jar-filter plugin.'
 
@@ -7,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    api 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 }
 
 jar {

--- a/publish-utils/build.gradle
+++ b/publish-utils/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'groovy'
-apply plugin: 'java-gradle-plugin'
+plugins {
+    id 'groovy'
+    id 'java-gradle-plugin'
+}
 
 repositories {
     mavenLocal()


### PR DESCRIPTION
- Use the `plugins` DSL better.
- Apply `@PathSensitive` annotations to file input properties.