### PR TITLE
NOTICK: Configure properties for Gradle test projects.

### DIFF
--- a/api-scanner/src/test/resources/gradle.properties
+++ b/api-scanner/src/test/resources/gradle.properties
@@ -1,2 +1,2 @@
-org.gradle.jvmargs=-javaagent:"$jacocoAgent"=destfile="$buildDir/jacoco/test.exec",includes=net/corda/plugins/**
+org.gradle.jvmargs=-XX:+UseG1GC -Xmx512m -javaagent:"$jacocoAgent"=destfile="$buildDir/jacoco/test.exec",includes=net/corda/plugins/**
 org.gradle.caching=false

--- a/cordapp/src/test/resources/gradle.properties
+++ b/cordapp/src/test/resources/gradle.properties
@@ -1,1 +1,3 @@
 # Placeholder for common Gradle properties.
+org.gradle.jvmargs=-XX:+UseG1GC -Xmx512m
+org.gradle.caching=false

--- a/cordformation/src/test/resources/gradle.properties
+++ b/cordformation/src/test/resources/gradle.properties
@@ -1,1 +1,3 @@
 # Placeholder for common Gradle properties.
+org.gradle.jvmargs=-XX:+UseG1GC -Xmx512m
+org.gradle.caching=false

--- a/jar-filter/src/test/resources/gradle.properties
+++ b/jar-filter/src/test/resources/gradle.properties
@@ -1,1 +1,2 @@
-org.gradle.jvmargs=-javaagent:"$jacocoAgent"=destfile="$buildDir/jacoco/test.exec",includes=net/corda/gradle/jarfilter/**
+org.gradle.jvmargs=-XX:+UseG1GC -Xmx512m -javaagent:"$jacocoAgent"=destfile="$buildDir/jacoco/test.exec",includes=net/corda/gradle/jarfilter/**
+org.gradle.caching=false

--- a/quasar-utils/src/test/resources/gradle.properties
+++ b/quasar-utils/src/test/resources/gradle.properties
@@ -1,0 +1,3 @@
+# Placeholder for common Gradle properties.
+org.gradle.jvmargs=-XX:+UseG1GC -Xmx512m
+org.gradle.caching=false


### PR DESCRIPTION
- Disable Gradle's cache for all tests.
- Configure JVM for each `GradleRunner` with 512 MB of memory.