### PR TITLE
Fix data source url override

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -45,6 +45,7 @@ changes to this list.
 * Daniel Roig (SEB)
 * Dave Hudson (R3)
 * David Lee (BCS)
+* Eduard Klementev (Firmshift)
 * Farzad Pezeshkpour (RBS)
 * Frederic Dalibard (Natixis)
 * Garrett Macey (Wells Fargo)

--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -562,15 +562,16 @@ open class Node @Inject constructor(private val project: Project) {
         if (!config.hasPath("sshd.port")) {
             sshdPort(defaultSsh)
         }
+        val configDefaults = ConfigFactory.empty()
+              .withValue("dataSourceProperties.dataSource.url", ConfigValueFactory.fromAnyRef("jdbc:h2:file:./persistence/persistence;DB_CLOSE_ON_EXIT=FALSE;WRITE_DELAY=0;LOCK_TIMEOUT=10000"))
         val dockerConf = config
                 .withValue("p2pAddress", ConfigValueFactory.fromAnyRef("$containerName:$p2pPort"))
                 .withValue("rpcSettings.address", ConfigValueFactory.fromAnyRef("$containerName:${rpcSettings.port}"))
                 .withValue("rpcSettings.adminAddress", ConfigValueFactory.fromAnyRef("$containerName:${rpcSettings.adminPort}"))
                 .withValue("detectPublicIp", ConfigValueFactory.fromAnyRef(false))
+                .withFallback(configDefaults)
+
         config = dockerConf
-        if (!config.hasPath("dataSourceProperties.dataSource.url")) {
-            config = config.withValue("dataSourceProperties.dataSource.url", ConfigValueFactory.fromAnyRef("jdbc:h2:file:./persistence/persistence;DB_CLOSE_ON_EXIT=FALSE;WRITE_DELAY=0;LOCK_TIMEOUT=10000"))
-        }
         createNodeAndWebServerConfigFiles(config)
     }
 

--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -567,9 +567,10 @@ open class Node @Inject constructor(private val project: Project) {
                 .withValue("rpcSettings.address", ConfigValueFactory.fromAnyRef("$containerName:${rpcSettings.port}"))
                 .withValue("rpcSettings.adminAddress", ConfigValueFactory.fromAnyRef("$containerName:${rpcSettings.adminPort}"))
                 .withValue("detectPublicIp", ConfigValueFactory.fromAnyRef(false))
-                .withValue("dataSourceProperties.dataSource.url", ConfigValueFactory.fromAnyRef("jdbc:h2:file:./persistence/persistence;DB_CLOSE_ON_EXIT=FALSE;WRITE_DELAY=0;LOCK_TIMEOUT=10000"))
-
         config = dockerConf
+        if (!config.hasPath("dataSourceProperties.dataSource.url")) {
+            config = config.withValue("dataSourceProperties.dataSource.url", ConfigValueFactory.fromAnyRef("jdbc:h2:file:./persistence/persistence;DB_CLOSE_ON_EXIT=FALSE;WRITE_DELAY=0;LOCK_TIMEOUT=10000"))
+        }
         createNodeAndWebServerConfigFiles(config)
     }
 


### PR DESCRIPTION
The database url that is specified in extraConfig in the node configuration like this:
```
      extraConfig = [
          dataSourceProperties: [
            dataSourceClassName: "org.postgresql.ds.PGSimpleDataSource",
            'dataSource.url': "jdbc:postgresql://localhost:5434/postgres",
            'dataSource.user': "postgres",
            'dataSource.password': "password"
          ],
          database: [
            transactionIsolationLevel : "READ_COMMITTED"
          ]
        ]
```
is overridden by the default h2 url.

PR fixes this override. 
        
# PR Checklist:

- [x] Have you run the unit, integration and smoke tests as described here? https://docs.corda.net/head/testing.html
- [x] If you added/changed public APIs, did you write/update the JavaDocs?
- [x] If the changes are of interest to application developers, have you added them to the changelog, and potentially release notes?
- [x] If you are contributing for the first time, please read the agreement in CONTRIBUTING.md now and add to this Pull Request that you agree to it.

Agree.

Thanks for your code, it's appreciated! :)
