### PR TITLE
replaced `org.apache.commons.io.IOUtils` with `java.nio.file.Files`

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -137,6 +137,7 @@ changes to this list.
 * Timothy Smith (Credit Suisse)
 * Tommy Lillehagen (R3)
 * Viktor Kolomeyko (R3)
+* Walter Oggioni (R3)
 * Wawrzek Niewodniczanski (R3)
 * Wei Wu Zhang (Commonwealth Bank of Australia)
 * William Yang

--- a/cordapp/build.gradle
+++ b/cordapp/build.gradle
@@ -47,7 +47,6 @@ dependencies {
     // own provided Kotlin libraries at runtime. So ensure that
     // we don't add Kotlin as a dependency in our published POM.
     compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
-    testImplementation "commons-io:commons-io:$commons_io_version"
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junit_jupiter_version")

--- a/cordapp/src/test/kotlin/net/corda/plugins/CordappTest.kt
+++ b/cordapp/src/test/kotlin/net/corda/plugins/CordappTest.kt
@@ -1,12 +1,12 @@
 package net.corda.plugins
 
-import org.apache.commons.io.IOUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.jar.JarInputStream
@@ -261,6 +261,6 @@ class CordappTest {
                 .withPluginClasspath()
     }
 
-    private fun createBuildFile(buildFileResourceName: String) = IOUtils.copy(javaClass.getResourceAsStream(buildFileResourceName), buildFile.toFile().outputStream())
+    private fun createBuildFile(buildFileResourceName: String) = Files.copy(javaClass.getResourceAsStream(buildFileResourceName), buildFile)
     private fun getCordappJar(cordappJarName: String): Path = Paths.get(testProjectDir.toFile().absolutePath, "build", "libs", "$cordappJarName.jar")
 }

--- a/cordformation/build.gradle
+++ b/cordformation/build.gradle
@@ -61,7 +61,6 @@ dependencies {
     // own provided Kotlin libraries at runtime. So ensure that
     // we don't add Kotlin as a dependency in our published POM.
     compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
-    implementation "commons-io:commons-io:$commons_io_version"
     implementation "com.typesafe:config:$typesafe_config_version"
 
     noderunner "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"

--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -2,7 +2,6 @@ package net.corda.plugins
 
 import com.typesafe.config.*
 import groovy.lang.Closure
-import org.apache.commons.io.FilenameUtils.removeExtension
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
@@ -541,7 +540,13 @@ open class Node @Inject constructor(private val project: Project) {
         Files.createDirectories(configDir)
         for ((jarFile, config) in cordapps) {
             if (config == null) continue
-            val configFile = configDir.resolve("${removeExtension(jarFile.fileName.toString())}.conf")
+            val fileNameWithoutExtension = jarFile.fileName.toString().let {
+                when(val dotIndex = it.lastIndexOf('.')) {
+                    -1 -> it
+                    else -> it.substring(0, dotIndex)
+                }
+            }
+            val configFile = configDir.resolve("${fileNameWithoutExtension}.conf")
             Files.write(configFile, config.toByteArray())
         }
     }

--- a/cordformation/src/test/kotlin/net/corda/plugins/BaseformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/BaseformTest.kt
@@ -4,11 +4,11 @@ import net.corda.core.serialization.SerializationContext
 import net.corda.serialization.internal.CordaSerializationMagic
 import net.corda.serialization.internal.amqp.AbstractAMQPSerializationScheme
 import net.corda.serialization.internal.amqp.amqpMagic
-import org.apache.commons.io.IOUtils
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.io.TempDir
 import java.io.FileNotFoundException
+import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -44,11 +44,11 @@ open class BaseformTest {
                 .withPluginClasspath()
     }
 
-    fun createBuildFile(buildFileResourceName: String) = IOUtils.copy(javaClass.getResourceAsStream(buildFileResourceName), buildFile.toFile().outputStream())
+    fun createBuildFile(buildFileResourceName: String) = Files.copy(javaClass.getResourceAsStream(buildFileResourceName), buildFile)
     fun installResource(resourceName: String) {
         val buildFile = testProjectDir.resolve(resourceName.substring(1 + resourceName.lastIndexOf('/')))
         javaClass.classLoader.getResourceAsStream(resourceName)?.use { input ->
-            IOUtils.copy(input, buildFile.toFile().outputStream())
+            Files.copy(input, buildFile)
         } ?: throw FileNotFoundException(resourceName)
     }
 


### PR DESCRIPTION
`IOUtils.copy` doesn't close the output stream which means that needs to be used inside a **try/finally** block (or **try-with-resource** in Java or **use** block in Kotlin)
The way it was used in the unit test was simply leaking an opened file descriptor with possible unwanted side effects; it actually calls `flush` before exiting, which is the reason why nothing bad happens, but it still doesn't look quite right. In Windows for example you cannot delete a file while it is opened by another process, which is something that could happen here since the unit tests create temporary directories that are deleted afterwards, and there is no synchronization between the leaked `FileOutputStream`s closing (which at this point depends entirely on the garbage collector's mood) and the temporary directory deletion (which happens at the end of every single test case)
