### PR TITLE
Update Node.kt

### DIFF
--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -568,7 +568,7 @@ open class Node @Inject constructor(private val project: Project) {
             sshdPort(defaultSsh)
         }
         val configDefaults = ConfigFactory.empty()
-            .withValue("dataSourceProperties.dataSource.url", ConfigValueFactory.fromAnyRef("jdbc:h2:file:./persistence/persistence;DB_CLOSE_ON_EXIT=FALSE;WRITE_DELAY=0;LOCK_TIMEOUT=10000"))
+            .withValue("dataSourceProperties.dataSource.url", ConfigValueFactory.fromAnyRef("jdbc:h2:file:./persistence;DB_CLOSE_ON_EXIT=FALSE;WRITE_DELAY=0;LOCK_TIMEOUT=10000"))
         val dockerConf = config
             .withValue("p2pAddress", ConfigValueFactory.fromAnyRef("$containerName:$p2pPort"))
             .withValue("rpcSettings.address", ConfigValueFactory.fromAnyRef("$containerName:${rpcSettings.port}"))


### PR DESCRIPTION
## DockerForm plugin generates h2 url not properly.

generated_ url is : 
node.conf : 

```
dataSourceProperties {
    dataSource {
        password=sa
        url="jdbc:h2:file:./persistence/persistence;DB_CLOSE_ON_EXIT=FALSE;WRITE_DELAY=0;LOCK_TIMEOUT=10000"
        user=sa
    }
}
```

but should be : 
```
dataSourceProperties {
    dataSource {
        password=sa
        url="jdbc:h2:file:./persistence;DB_CLOSE_ON_EXIT=FALSE;WRITE_DELAY=0;LOCK_TIMEOUT=10000"
        user=sa
    }
}
```

Test context : 
generated the ./build/nodes/partyA configuration with target "prepareDockerNodes"
docker-compose.yml :
```
  partya:
    env_file:
      - ./corda_docker.env
    container_name: partya
    volumes:
    - ./build/nodes/PartyA/node.conf:/etc/corda/node.conf
    - ./build/nodes/PartyA/certificates:/opt/corda/certificates
    - ./build/nodes/PartyA/logs:/opt/corda/logs
    - ./build/nodes/PartyA/persistence:/opt/corda/persistence
    - ./build/nodes/PartyA/cordapps:/opt/corda/cordapps
    - ./build/nodes/PartyA/network-parameters:/opt/corda/network-parameters
    - ./build/nodes/PartyA/additional-node-infos:/opt/corda/additional-node-infos
    - ./build/nodes/PartyA/drivers:/opt/corda/drivers
    ports:
    - "10006:10006"
    - "10046:10046"
      #    - "22022"
    - "10007:10007"
    expose:
      - "10005"
    image: corda/corda-zulu-java1.8-4.3
``` 

Result get : 
from the h2 console, when connecting to : 
get the error message : 

```
Database "/opt/corda/persistence/persistence/persistence" not found, and IFEXISTS=true, so we cant auto-create it [90146-197] 90146/90146 (Help)
org.h2.jdbc.JdbcSQLNonTransientConnectionException: Database "/opt/corda/persistence/persistence/persistence" not found, and IFEXISTS=true, so we cant auto-create it [90146-199]
    at org.h2.message.DbException.getJdbcSQLException(DbException.java:617)
    at org.h2.message.DbException.getJdbcSQLException(DbException.java:427)
    at org.h2.message.DbException.get(DbException.java:205)
    at org.h2.message.DbException.get(DbException.java:181)
    at org.h2.engine.Engine.openSession(Engine.java:67)
    at org.h2.engine.Engine.openSession(Engine.java:201)
    at org.h2.engine.Engine.createSessionAndValidate(Engine.java:178)
    at org.h2.engine.Engine.createSession(Engine.java:161)
    at org.h2.server.TcpServerThread.run(TcpServerThread.java:160)
    at java.lang.Thread.run(Thread.java:748)
```


By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this
