### PR TITLE
Add script plugin to configure Kotlin compiler for JarFilter tests.

### DIFF
--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterProject.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterProject.kt
@@ -22,7 +22,8 @@ class JarFilterProject(private val projectDir: Path, private val name: String) {
             "$name/build.gradle",
             "repositories.gradle",
             "gradle.properties",
-            "settings.gradle"
+            "settings.gradle",
+            "kotlin.gradle"
         )
 
         val result = GradleRunner.create()

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixProject.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixProject.kt
@@ -24,7 +24,8 @@ class MetaFixProject(private val projectDir: Path, private val name: String) {
             "$name/build.gradle",
             "repositories.gradle",
             "gradle.properties",
-            "settings.gradle"
+            "settings.gradle",
+            "kotlin.gradle"
         )
 
         val result = GradleRunner.create()

--- a/jar-filter/src/test/resources/abstract-function/build.gradle
+++ b/jar-filter/src/test/resources/abstract-function/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/delete-and-stub/build.gradle
+++ b/jar-filter/src/test/resources/delete-and-stub/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/delete-constructor/build.gradle
+++ b/jar-filter/src/test/resources/delete-constructor/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/delete-extension-val/build.gradle
+++ b/jar-filter/src/test/resources/delete-extension-val/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/delete-field/build.gradle
+++ b/jar-filter/src/test/resources/delete-field/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/delete-file-typealias/build.gradle
+++ b/jar-filter/src/test/resources/delete-file-typealias/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/delete-function/build.gradle
+++ b/jar-filter/src/test/resources/delete-function/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/delete-inner-lambda/build.gradle
+++ b/jar-filter/src/test/resources/delete-inner-lambda/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/delete-lazy/build.gradle
+++ b/jar-filter/src/test/resources/delete-lazy/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/delete-multifile/build.gradle
+++ b/jar-filter/src/test/resources/delete-multifile/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/delete-nested-class/build.gradle
+++ b/jar-filter/src/test/resources/delete-nested-class/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/delete-object/build.gradle
+++ b/jar-filter/src/test/resources/delete-object/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/delete-overloaded-function/build.gradle
+++ b/jar-filter/src/test/resources/delete-overloaded-function/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/delete-sealed-subclass/build.gradle
+++ b/jar-filter/src/test/resources/delete-sealed-subclass/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/delete-static-field/build.gradle
+++ b/jar-filter/src/test/resources/delete-static-field/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/delete-static-function/build.gradle
+++ b/jar-filter/src/test/resources/delete-static-function/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/delete-static-val/build.gradle
+++ b/jar-filter/src/test/resources/delete-static-val/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/delete-static-var/build.gradle
+++ b/jar-filter/src/test/resources/delete-static-var/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/delete-val-property/build.gradle
+++ b/jar-filter/src/test/resources/delete-val-property/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/delete-var-property/build.gradle
+++ b/jar-filter/src/test/resources/delete-var-property/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/interface-function/build.gradle
+++ b/jar-filter/src/test/resources/interface-function/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/kotlin.gradle
+++ b/jar-filter/src/test/resources/kotlin.gradle
@@ -1,4 +1,4 @@
-import static org.gradle.api.JavaVersion.VERSION_1_8
+import static org.gradle.api.JavaVersion.*
 
 tasks.named('compileKotlin', AbstractCompile) {
     kotlinOptions {
@@ -8,3 +8,4 @@ tasks.named('compileKotlin', AbstractCompile) {
         freeCompilerArgs = ['-Xjvm-default=enable']
     }
 }
+

--- a/jar-filter/src/test/resources/remove-annotations/build.gradle
+++ b/jar-filter/src/test/resources/remove-annotations/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/sanitise-delete-constructor/build.gradle
+++ b/jar-filter/src/test/resources/sanitise-delete-constructor/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/sanitise-stub-constructor/build.gradle
+++ b/jar-filter/src/test/resources/sanitise-stub-constructor/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/stub-constructor/build.gradle
+++ b/jar-filter/src/test/resources/stub-constructor/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/stub-function/build.gradle
+++ b/jar-filter/src/test/resources/stub-function/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/stub-static-function/build.gradle
+++ b/jar-filter/src/test/resources/stub-static-function/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/stub-val-property/build.gradle
+++ b/jar-filter/src/test/resources/stub-val-property/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {

--- a/jar-filter/src/test/resources/stub-var-property/build.gradle
+++ b/jar-filter/src/test/resources/stub-var-property/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 sourceSets {
     main {


### PR DESCRIPTION
The JarFilter tests were not configuring the `compileKotlin` tasks, which means that the byte-code being tested isn't necessarily representative of Corda's byte-code. Fix this.

The tests are confirmed still to work for both `apiVersion=1.2` and `apiVersion=1.3`.