### PR TITLE
Use screen on macOS when the user is already running screen

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -69,6 +69,7 @@ changes to this list.
 * Jonathan Sartin (R3)
 * Jose Coll (R3)
 * Jose Luu (Natixis)
+* Joseph Zuniga-Daly (R3)
 * Josh Lindl (BCS)
 * Justin Chapman (Northern Trust)
 * Kai-Michael Schramm (Credit Suisse)

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ### Version 5.0.9
 
+* `cordformation`: Use GNU Screen in `runnodes` on macOS to start nodes in different Screen windows. Activated when the user is already running `screen`.
+
 ### Version 5.0.8
 
 * `cordformation`: Allow `dataSource.url` to be overridden in `Dockerform` task.


### PR DESCRIPTION
This allows runnodes to use screen as an alternative to osascript on macOS. screen is included in macOS making it an easy alternative to use.

The change behaves the same as tmux support on Linux. If the user is already running screen, it will be used; otherwise it will run osascript like normal.
