### PR TITLE
NOTICK: Add extra tests to JarFilter for stubbing out constructors.

### DIFF
--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/FilterTransformer.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/FilterTransformer.kt
@@ -199,7 +199,7 @@ class FilterTransformer private constructor (
      */
     override fun processClassMetadata(kmClass: KmClass): KmClass? {
         val partitioned = deletedMethods.groupBy(MethodElement::isConstructor)
-        val prefix = "$className$"
+        val prefix = "$className\$"
         return ClassMetadataTransformer(
                 logger = logger,
                 deletedFields = unwantedFields,

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/JarFilterTask.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/JarFilterTask.kt
@@ -263,7 +263,7 @@ open class JarFilterTask @Inject constructor(objects: ObjectFactory, layouts: Pr
                 var transformer = FilterTransformer(
                     visitor = writer,
                     logger = logger,
-                    importExtra = { className: String -> initialUnwanted.remove(className) },
+                    importExtra = { className -> initialUnwanted.remove(className) },
                     removeAnnotations = descriptorsForRemove,
                     deleteAnnotations = descriptorsForDelete,
                     stubAnnotations = descriptorsForStub,

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTask.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTask.kt
@@ -5,7 +5,6 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.ProjectLayout
-import org.gradle.api.logging.Logger
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
@@ -133,6 +132,3 @@ open class MetaFixerTask @Inject constructor(objects: ObjectFactory, layouts: Pr
         return filter { it.name.endsWith(suffix) }.mapTo(LinkedHashSet()) { it.name.dropLast(suffix.length) }
     }
 }
-
-fun ByteArray.fixMetadata(logger: Logger, classNames: Set<String>): ByteArray
-                  = execute({ writer -> MetaFixerVisitor(writer, logger, classNames) })

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetadataTransformer.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetadataTransformer.kt
@@ -16,7 +16,7 @@ abstract class MetadataTransformer<out T : KmDeclarationContainer>(
     private val deletedFields: Collection<FieldElement>,
     private val deletedFunctions: Collection<MethodElement>,
     @JvmField protected val handleExtraMethod: (MethodElement) -> Unit,
-    @JvmField protected val handleSyntheticMethod: (MethodElement, MethodElement) -> Unit,
+    @JvmField protected val handleSameAs: MethodElement.(MethodElement) -> Unit,
     @JvmField protected val metadata: T
 ) {
     private val functions: MutableList<KmFunction> = metadata.functions
@@ -44,7 +44,7 @@ abstract class MetadataTransformer<out T : KmDeclarationContainer>(
 
                 // The synthetic "$default" method may not have been annotated,
                 // so ensure we handle it in the same way as its "host" method.
-                handleSyntheticMethod(synthetic, method)
+                synthetic.handleSameAs(method)
             }
         }
     }
@@ -132,14 +132,14 @@ class ClassMetadataTransformer(
     private val deletedNestedClasses: Collection<String>,
     private val deletedClasses: Collection<String>,
     handleExtraMethod: (MethodElement) -> Unit,
-    handleSyntheticMethod: (MethodElement, MethodElement) -> Unit,
+    handleSameAs: MethodElement.(MethodElement) -> Unit,
     kmClass: KmClass
 ) : MetadataTransformer<KmClass>(
     logger,
     deletedFields,
     deletedFunctions,
     handleExtraMethod,
-    handleSyntheticMethod,
+    handleSameAs,
     metadata = kmClass
 ) {
     private val className = kmClass.name
@@ -158,7 +158,7 @@ class ClassMetadataTransformer(
 
                 // The synthetic "default values" constructor may not have been annotated,
                 // so ensure we handle it in the same way as its "host" method.
-                handleSyntheticMethod(synthetic, method)
+                synthetic.handleSameAs(method)
             }
         }
     }
@@ -251,14 +251,14 @@ class PackageMetadataTransformer(
     deletedFields: Collection<FieldElement>,
     deletedFunctions: Collection<MethodElement>,
     handleExtraMethod: (MethodElement) -> Unit,
-    handleSyntheticMethod: (MethodElement, MethodElement) -> Unit,
+    handleSameAs: MethodElement.(MethodElement) -> Unit,
     kmPackage: KmPackage
 ) : MetadataTransformer<KmPackage>(
     logger,
     deletedFields,
     deletedFunctions,
     handleExtraMethod,
-    handleSyntheticMethod,
+    handleSameAs,
     metadata = kmPackage
 ) {
     override fun filter(): Int = (

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/Utils.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/Utils.kt
@@ -2,6 +2,7 @@
 package net.corda.gradle.jarfilter
 
 import org.gradle.api.InvalidUserCodeException
+import org.gradle.api.logging.Logger
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassReader.SKIP_DEBUG
 import org.objectweb.asm.ClassReader.SKIP_FRAMES
@@ -88,7 +89,9 @@ fun <T> ByteArray.execute(visitor: (ClassVisitor) -> T, flags: Int = 0, passes: 
         ClassReader(bytecode).accept(transformer, FILTER_FLAGS)
         bytecode = writer.toByteArray()
 
-        if (!transformer.hasUnwantedElements) break
+        if (!transformer.hasUnwantedElements) {
+            break
+        }
 
         writer = ClassWriter(flags)
         transformer = transformer.recreate(writer)
@@ -96,3 +99,6 @@ fun <T> ByteArray.execute(visitor: (ClassVisitor) -> T, flags: Int = 0, passes: 
 
     return bytecode
 }
+
+fun ByteArray.fixMetadata(logger: Logger, classNames: Set<String>): ByteArray
+        = execute({ writer -> MetaFixerVisitor(writer, logger, classNames) })

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteConstructorTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteConstructorTest.kt
@@ -6,7 +6,7 @@ import net.corda.gradle.unwanted.HasInt
 import net.corda.gradle.unwanted.HasLong
 import net.corda.gradle.unwanted.HasString
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.core.IsEqual.*
+import org.hamcrest.core.IsEqual.equalTo
 import org.hamcrest.core.IsIterableContaining.hasItem
 import org.hamcrest.core.IsNot.not
 import org.junit.jupiter.api.Assertions.*
@@ -24,8 +24,8 @@ class DeleteConstructorTest {
         private const val LONG_PRIMARY_CONSTRUCTOR_CLASS = "net.corda.gradle.PrimaryLongConstructorToDelete"
         private const val INT_PRIMARY_CONSTRUCTOR_CLASS = "net.corda.gradle.PrimaryIntConstructorToDelete"
         private const val SECONDARY_CONSTRUCTOR_CLASS = "net.corda.gradle.HasConstructorToDelete"
-        private const val DEFAULT_VALUE_PRIMARY_CLASS = "net.corda.gradle.PrimaryConstructorWithDefault"
-        private const val DEFAULT_VALUE_SECONDARY_CLASS = "net.corda.gradle.SecondaryConstructorWithDefault"
+        private const val DEFAULT_VALUE_PRIMARY_CLASS = "net.corda.gradle.PrimaryConstructorWithDefaultToDelete"
+        private const val DEFAULT_VALUE_SECONDARY_CLASS = "net.corda.gradle.SecondaryConstructorWithDefaultToDelete"
 
         private lateinit var testProject: JarFilterProject
 

--- a/jar-filter/src/test/resources/abstract-function/build.gradle
+++ b/jar-filter/src/test/resources/abstract-function/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -25,7 +27,6 @@ jar {
     archiveBaseName = 'abstract-function'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/delete-and-stub/build.gradle
+++ b/jar-filter/src/test/resources/delete-and-stub/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -25,7 +27,6 @@ jar {
     archiveBaseName = 'delete-and-stub'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/delete-constructor/build.gradle
+++ b/jar-filter/src/test/resources/delete-constructor/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -25,7 +27,6 @@ jar {
     archiveBaseName = 'delete-constructor'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/delete-constructor/kotlin/net/corda/gradle/PrimaryConstructorsToDelete.kt
+++ b/jar-filter/src/test/resources/delete-constructor/kotlin/net/corda/gradle/PrimaryConstructorsToDelete.kt
@@ -19,6 +19,6 @@ class PrimaryStringConstructorToDelete @DeleteMe constructor(private val value: 
     override fun stringData() = value
 }
 
-class PrimaryConstructorWithDefault @DeleteMe constructor(private val value: String = "<default-value>") : HasString {
+class PrimaryConstructorWithDefaultToDelete @DeleteMe constructor(private val value: String = "<default-value>") : HasString {
     override fun stringData() = value
 }

--- a/jar-filter/src/test/resources/delete-constructor/kotlin/net/corda/gradle/SecondaryConstructorWithDefaultToDelete.kt
+++ b/jar-filter/src/test/resources/delete-constructor/kotlin/net/corda/gradle/SecondaryConstructorWithDefaultToDelete.kt
@@ -5,7 +5,7 @@ import net.corda.gradle.jarfilter.DeleteMe
 import net.corda.gradle.unwanted.HasLong
 import net.corda.gradle.unwanted.HasString
 
-class SecondaryConstructorWithDefault(private val message: String, private val data: Long) : HasString, HasLong {
+class SecondaryConstructorWithDefaultToDelete(private val message: String, private val data: Long) : HasString, HasLong {
     @DeleteMe constructor(message: String = "<default-value>") : this(message, 0)
 
     override fun stringData(): String = message

--- a/jar-filter/src/test/resources/delete-extension-val/build.gradle
+++ b/jar-filter/src/test/resources/delete-extension-val/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -25,7 +27,6 @@ jar {
     archiveBaseName = 'delete-extension-val'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/delete-field/build.gradle
+++ b/jar-filter/src/test/resources/delete-field/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -24,7 +26,6 @@ jar {
     archiveBaseName = 'delete-field'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/delete-file-typealias/build.gradle
+++ b/jar-filter/src/test/resources/delete-file-typealias/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -24,7 +26,6 @@ jar {
     archiveBaseName = 'delete-file-typealias'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/delete-function/build.gradle
+++ b/jar-filter/src/test/resources/delete-function/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -25,7 +27,6 @@ jar {
     archiveBaseName = 'delete-function'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/delete-inner-lambda/build.gradle
+++ b/jar-filter/src/test/resources/delete-inner-lambda/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -25,7 +27,6 @@ jar {
     archiveBaseName = 'delete-inner-lambda'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/delete-lazy/build.gradle
+++ b/jar-filter/src/test/resources/delete-lazy/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -25,7 +27,6 @@ jar {
     archiveBaseName = 'delete-lazy'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/delete-multifile/build.gradle
+++ b/jar-filter/src/test/resources/delete-multifile/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -24,7 +26,6 @@ jar {
     archiveBaseName = 'delete-multifile'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/delete-nested-class/build.gradle
+++ b/jar-filter/src/test/resources/delete-nested-class/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -24,7 +26,6 @@ jar {
     archiveBaseName = 'delete-nested-class'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/delete-object/build.gradle
+++ b/jar-filter/src/test/resources/delete-object/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -25,7 +27,6 @@ jar {
     archiveBaseName = 'delete-object'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/delete-overloaded-function/build.gradle
+++ b/jar-filter/src/test/resources/delete-overloaded-function/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -24,7 +26,6 @@ jar {
     archiveBaseName = 'delete-overloaded-function'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/delete-sealed-subclass/build.gradle
+++ b/jar-filter/src/test/resources/delete-sealed-subclass/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -25,7 +27,6 @@ jar {
     archiveBaseName = 'delete-sealed-subclass'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/delete-static-field/build.gradle
+++ b/jar-filter/src/test/resources/delete-static-field/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -24,7 +26,6 @@ jar {
     archiveBaseName = 'delete-static-field'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/delete-static-function/build.gradle
+++ b/jar-filter/src/test/resources/delete-static-function/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -25,7 +27,6 @@ jar {
     archiveBaseName = 'delete-static-function'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/delete-static-val/build.gradle
+++ b/jar-filter/src/test/resources/delete-static-val/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -24,7 +26,6 @@ jar {
     archiveBaseName = 'delete-static-val'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/delete-static-var/build.gradle
+++ b/jar-filter/src/test/resources/delete-static-var/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -24,7 +26,6 @@ jar {
     archiveBaseName = 'delete-static-var'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/delete-val-property/build.gradle
+++ b/jar-filter/src/test/resources/delete-val-property/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -25,7 +27,6 @@ jar {
     archiveBaseName = 'delete-val-property'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/delete-var-property/build.gradle
+++ b/jar-filter/src/test/resources/delete-var-property/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -25,7 +27,6 @@ jar {
     archiveBaseName = 'delete-var-property'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/interface-function/build.gradle
+++ b/jar-filter/src/test/resources/interface-function/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -25,7 +27,6 @@ jar {
     archiveBaseName = 'interface-function'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/remove-annotations/build.gradle
+++ b/jar-filter/src/test/resources/remove-annotations/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -25,7 +27,6 @@ jar {
     archiveBaseName = 'remove-annotations'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/sanitise-delete-constructor/build.gradle
+++ b/jar-filter/src/test/resources/sanitise-delete-constructor/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -25,7 +27,6 @@ jar {
     archiveBaseName = 'sanitise-delete-constructor'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/sanitise-stub-constructor/build.gradle
+++ b/jar-filter/src/test/resources/sanitise-stub-constructor/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -25,7 +27,6 @@ jar {
     archiveBaseName = 'sanitise-stub-constructor'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/stub-constructor/build.gradle
+++ b/jar-filter/src/test/resources/stub-constructor/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -25,7 +27,6 @@ jar {
     archiveBaseName = 'stub-constructor'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/stub-constructor/kotlin/net/corda/gradle/PrimaryConstructorsToStub.kt
+++ b/jar-filter/src/test/resources/stub-constructor/kotlin/net/corda/gradle/PrimaryConstructorsToStub.kt
@@ -19,3 +19,6 @@ class PrimaryStringConstructorToStub @StubMeOut constructor(private val value: S
     override fun stringData() = value
 }
 
+class PrimaryConstructorWithDefaultToStub @StubMeOut constructor(private val value: String = "<default-value>") : HasString {
+    override fun stringData() = value
+}

--- a/jar-filter/src/test/resources/stub-constructor/kotlin/net/corda/gradle/SecondaryConstructorWithDefaultToStub.kt
+++ b/jar-filter/src/test/resources/stub-constructor/kotlin/net/corda/gradle/SecondaryConstructorWithDefaultToStub.kt
@@ -1,0 +1,13 @@
+@file:Suppress("UNUSED")
+package net.corda.gradle
+
+import net.corda.gradle.jarfilter.StubMeOut
+import net.corda.gradle.unwanted.HasAll
+
+class SecondaryConstructorWithDefaultToStub(private val message: String, private val data: Long) : HasAll {
+    @StubMeOut constructor(message: String = "<default-value>") : this(message, 0)
+
+    override fun stringData(): String = message
+    override fun longData(): Long = data
+    override fun intData(): Int = -1
+}

--- a/jar-filter/src/test/resources/stub-function/build.gradle
+++ b/jar-filter/src/test/resources/stub-function/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -25,7 +27,6 @@ jar {
     archiveBaseName = 'stub-function'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/stub-static-function/build.gradle
+++ b/jar-filter/src/test/resources/stub-static-function/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -25,7 +27,6 @@ jar {
     archiveBaseName = 'stub-static-function'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/stub-val-property/build.gradle
+++ b/jar-filter/src/test/resources/stub-val-property/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -25,7 +27,6 @@ jar {
     archiveBaseName = 'stub-val-property'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {

--- a/jar-filter/src/test/resources/stub-var-property/build.gradle
+++ b/jar-filter/src/test/resources/stub-var-property/build.gradle
@@ -1,3 +1,5 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.jar-filter' apply false
@@ -25,7 +27,6 @@ jar {
     archiveBaseName = 'stub-var-property'
 }
 
-import net.corda.gradle.jarfilter.JarFilterTask
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {


### PR DESCRIPTION
- Add more JarFilter unit tests for stubbing out constructors with default parameters.
- Refactor JarFilter's internal API to make its intention clearer.
- Refactor test Gradle projects slightly.