### PR TITLE
CORDA-3664: Update JarFilter with preliminary support for Kotlin 1.4.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 
 * `cordformation`: Use GNU Screen in `runnodes` on macOS to start nodes in different Screen windows. Activated when the user is already running `screen`.
 
+* `jar-filter`: Initial support for byte-code compiled by Kotlin >= 1.4.0 (See [KT-31352](https://youtrack.jetbrains.com/issue/KT-31352)).
+
 ### Version 5.0.8
 
 * `cordformation`: Allow `dataSource.url` to be overridden in `Dockerform` task.

--- a/jar-filter/build.gradle
+++ b/jar-filter/build.gradle
@@ -12,6 +12,7 @@ repositories {
 
 ext {
     kotlin_metadata_version = '0.1.0'
+    test_kotlin_api_version = '1.2'
 }
 
 gradlePlugin {
@@ -68,8 +69,13 @@ processTestResources {
     }
     filesMatching('gradle.properties') {
         expand(['jacocoAgent': configurations.jacocoRuntime.asPath.replace('\\', '/'),
+                'kotlin_api_version': test_kotlin_api_version,
                 'buildDir': buildDir])
     }
+}
+
+tasks.withType(Test) {
+    systemProperty 'test.kotlin.api', test_kotlin_api_version
 }
 
 // We need to modify how the publish task works.

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/FilterAnnotations.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/FilterAnnotations.kt
@@ -6,6 +6,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import javax.inject.Inject
 
+@Suppress("UnstableApiUsage")
 open class FilterAnnotations @Inject constructor(objects: ObjectFactory) {
     @get:Input
     val forDelete: SetProperty<String> = objects.setProperty(String::class.java)

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/JarFilterTask.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/JarFilterTask.kt
@@ -34,7 +34,7 @@ import java.util.zip.ZipOutputStream
 import javax.inject.Inject
 import kotlin.math.max
 
-@Suppress("Unused")
+@Suppress("Unused", "UnstableApiUsage")
 open class JarFilterTask @Inject constructor(objects: ObjectFactory, layouts: ProjectLayout) : DefaultTask() {
     private companion object {
         private const val DEFAULT_MAX_PASSES = 5

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTask.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTask.kt
@@ -26,7 +26,7 @@ import java.util.zip.ZipFile
 import java.util.zip.ZipOutputStream
 import javax.inject.Inject
 
-@Suppress("Unused")
+@Suppress("Unused", "UnstableApiUsage")
 open class MetaFixerTask @Inject constructor(objects: ObjectFactory, layouts: ProjectLayout) : DefaultTask() {
     init {
         description = "Rewrites kotlin.Metadata annotations to match their classes' methods and fields."

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTransformer.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTransformer.kt
@@ -19,6 +19,7 @@ abstract class MetaFixerTransformer<out T : KmDeclarationContainer>(
 ) {
     private val properties: MutableList<KmProperty> = metadata.properties
     private val functions: MutableList<KmFunction> = metadata.functions
+    private val isCompanion: Boolean = metadata is KmClass && Flag.Class.IS_COMPANION_OBJECT(metadata.flags)
 
     protected open val classDescriptor: ClassName = ""
 
@@ -66,7 +67,7 @@ abstract class MetaFixerTransformer<out T : KmDeclarationContainer>(
              * because these properties are implemented as static fields on the companion's host class.
              */
             val isValidProperty = if (getterMethod == null) {
-                (field == null) || actualFields.contains(field.toFieldElement()) || (metadata is KmClass && Flag.Class.IS_COMPANION_OBJECT(metadata.flags))
+                (field == null) || actualFields.contains(field.toFieldElement()) || isCompanion
             } else {
                 actualMethods.contains(getterMethod.asString())
             }

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerVisitor.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerVisitor.kt
@@ -34,7 +34,7 @@ class MetaFixerVisitor private constructor(
     }
 
     override fun visitField(access: Int, fieldName: String, descriptor: String, signature: String?, value: Any?): FieldVisitor? {
-        if (fields.add(FieldElement(fieldName, descriptor))) {
+        if (fields.add(FieldElement(fieldName, descriptor, access))) {
             logger.info("- field {},{}", fieldName, descriptor)
         }
         return super.visitField(access, fieldName, descriptor, signature, value)

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetadataTransformer.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetadataTransformer.kt
@@ -105,6 +105,11 @@ abstract class MetadataTransformer<out T : KmDeclarationContainer>(
                  * The underlying field itself was annotated for deletion.
                  */
                 deleteAccessorsFor(property)
+
+                if (deleted.extension.isEmpty()) {
+                    handleExtraMethod(deleted.asKotlinAnnotationsMethod(property.name))
+                }
+
                 logger.info("-- removing property: {},{}", property.name, deleted.descriptor)
                 properties.removeAt(idx)
                 return true

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/Utils.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/Utils.kt
@@ -33,6 +33,13 @@ private val CONSTANT_TIME: FileTime = FileTime.fromMillis(
 inline fun Exception.asUncheckedException(): RuntimeException
     = (this as? RuntimeException) ?: InvalidUserCodeException(message ?: "", this)
 
+fun <T : Element> MutableCollection<T>.expire(element: T) {
+    if (remove(element)) {
+        element.kill()
+        add(element)
+    }
+}
+
 /**
  * Recreates a [ZipEntry] object. The entry's byte contents
  * will be compressed automatically, and its CRC, size and

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteAmbiguousPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteAmbiguousPropertyTest.kt
@@ -1,0 +1,74 @@
+package net.corda.gradle.jarfilter
+
+import net.corda.gradle.jarfilter.matcher.isMethod
+import net.corda.gradle.jarfilter.matcher.isExtensionProperty
+import net.corda.gradle.jarfilter.matcher.javaDeclaredMethods
+import net.corda.gradle.jarfilter.matcher.typeOfCollection
+import net.corda.gradle.jarfilter.matcher.typeOfMap
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.core.IsIterableContaining.hasItem
+import org.hamcrest.core.IsNot.not
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.reflect.full.declaredMemberExtensionProperties
+
+@RequiresKotlin14
+class DeleteAmbiguousPropertyTest {
+    companion object {
+        private const val PROPERTY_CLASS = "net.corda.gradle.DeleteAmbiguousValProperty"
+
+        private val nameIntToInt = isMethod("nameIntToInt", String::class.java, Map::class.java)
+        private val nameIntToByte = isMethod("nameIntToByte", String::class.java, Map::class.java)
+        private val nameString = isMethod("nameString", String::class.java, Collection::class.java)
+        private val nameLong = isMethod("nameLong", String::class.java, Collection::class.java)
+
+        private val mapIntToIntName = isExtensionProperty("name", String::class, typeOfMap(Int::class, Int::class))
+        private val mapIntToByteName = isExtensionProperty("name", String::class, typeOfMap(Int::class, Byte::class))
+        private val collectionStringName = isExtensionProperty("name", String::class, typeOfCollection(String::class))
+        private val collectionLongName = isExtensionProperty("name", String::class, typeOfCollection(Long::class))
+
+        private lateinit var testProject: JarFilterProject
+
+        @BeforeAll
+        @JvmStatic
+        fun setup(@TempDir testProjectDir: Path) {
+            testProject = JarFilterProject(testProjectDir, "delete-ambiguous-property").build()
+        }
+    }
+
+    @Test
+    fun deleteAmbiguousProperty() {
+        classLoaderFor(testProject.sourceJar).use { cl ->
+            cl.load<Any>(PROPERTY_CLASS).apply {
+                assertNotNull(getDeclaredConstructor().newInstance())
+                assertThat("nameIntToInt(Map) missing", kotlin.javaDeclaredMethods, hasItem(nameIntToInt))
+                assertThat("nameIntToByte(Map) missing", kotlin.javaDeclaredMethods, hasItem(nameIntToByte))
+                assertThat("nameString(Collection) missing", kotlin.javaDeclaredMethods, hasItem(nameString))
+                assertThat("nameLong(Collection) missing", kotlin.javaDeclaredMethods, hasItem(nameLong))
+
+                assertThat("Map<Int,Int>.name missing", kotlin.declaredMemberExtensionProperties, hasItem(mapIntToIntName))
+                assertThat("Map<Int,Byte>.name missing", kotlin.declaredMemberExtensionProperties, hasItem(mapIntToByteName))
+                assertThat("Collection<String>.name missing", kotlin.declaredMemberExtensionProperties, hasItem(collectionStringName))
+                assertThat("Collection<Long>.name missing", kotlin.declaredMemberExtensionProperties, hasItem(collectionLongName))
+            }
+        }
+
+        classLoaderFor(testProject.filteredJar).use { cl ->
+            cl.load<Any>(PROPERTY_CLASS).apply {
+                assertNotNull(getDeclaredConstructor().newInstance())
+                assertThat("nameIntToInt(Map) still exists", kotlin.javaDeclaredMethods, not(hasItem(nameIntToInt)))
+                assertThat("nameIntToByte(Map) does not exist", kotlin.javaDeclaredMethods, hasItem(nameIntToByte))
+                assertThat("nameString(Collection) does not exist", kotlin.javaDeclaredMethods, hasItem(nameString))
+                assertThat("nameLong(Collection) still exists", kotlin.javaDeclaredMethods, not(hasItem(nameLong)))
+
+                assertThat("Map<Int,Int>.name still exists", kotlin.declaredMemberExtensionProperties, not(hasItem(mapIntToIntName)))
+                assertThat("Map<Int,Byte>.name does not exist", kotlin.declaredMemberExtensionProperties, hasItem(mapIntToByteName))
+                assertThat("Collection<String>.name still exists", kotlin.declaredMemberExtensionProperties, hasItem(collectionStringName))
+                assertThat("Collection<Long>.name does not exist", kotlin.declaredMemberExtensionProperties, not(hasItem(collectionLongName)))
+            }
+        }
+    }
+}

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteExtensionValPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteExtensionValPropertyTest.kt
@@ -1,8 +1,10 @@
 package net.corda.gradle.jarfilter
 
+import net.corda.gradle.jarfilter.matcher.isExtensionProperty
 import net.corda.gradle.jarfilter.matcher.isMethod
 import net.corda.gradle.jarfilter.matcher.isProperty
 import net.corda.gradle.jarfilter.matcher.javaDeclaredMethods
+import net.corda.gradle.jarfilter.matcher.typeOfList
 import net.corda.gradle.unwanted.HasUnwantedVal
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsIterableContaining.*
@@ -19,6 +21,7 @@ class DeleteExtensionValPropertyTest {
         private const val PROPERTY_CLASS = "net.corda.gradle.HasValExtension"
 
         private val unwantedVal = isProperty("unwantedVal", String::class)
+        private val listUnwantedVal = isExtensionProperty("unwantedVal", String::class, typeOfList(String::class))
         private val getUnwantedVal = isMethod("getUnwantedVal", String::class.java, List::class.java)
         private lateinit var testProject: JarFilterProject
 
@@ -35,7 +38,7 @@ class DeleteExtensionValPropertyTest {
             cl.load<HasUnwantedVal>(PROPERTY_CLASS).apply {
                 assertThat("unwantedVal not found", kotlin.declaredMemberProperties, hasItem(unwantedVal))
                 assertThat("getUnwantedVal not found", kotlin.javaDeclaredMethods, hasItem(getUnwantedVal))
-                assertThat("List.unwantedVal not found", kotlin.declaredMemberExtensionProperties, hasItem(unwantedVal))
+                assertThat("List.unwantedVal not found", kotlin.declaredMemberExtensionProperties, hasItem(listUnwantedVal))
             }
         }
 
@@ -43,7 +46,7 @@ class DeleteExtensionValPropertyTest {
             cl.load<HasUnwantedVal>(PROPERTY_CLASS).apply {
                 assertThat("unwantedVal not found", kotlin.declaredMemberProperties, hasItem(unwantedVal))
                 assertThat("getUnwantedVal still exists", kotlin.javaDeclaredMethods, not(hasItem(getUnwantedVal)))
-                assertThat("List.unwantedVal still exists", kotlin.declaredMemberExtensionProperties, not(hasItem(unwantedVal)))
+                assertThat("List.unwantedVal still exists", kotlin.declaredMemberExtensionProperties, not(hasItem(listUnwantedVal)))
             }
         }
     }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteObjectTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteObjectTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.objectweb.asm.Opcodes.ACC_PRIVATE
 import java.nio.file.Path
 import kotlin.test.assertFailsWith
 
@@ -47,7 +48,7 @@ class DeleteObjectTest {
                     }
                 }
                 getDeclaredField(UNWANTED_OBJ_FIELD).also { field ->
-                    assertFalse(field.isAccessible)
+                    assertTrue(field.hasModifiers(ACC_PRIVATE))
                 }
             }
         }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteObjectTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteObjectTest.kt
@@ -7,12 +7,15 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.objectweb.asm.Opcodes.ACC_PRIVATE
+import org.objectweb.asm.Opcodes.ACC_PUBLIC
 import java.nio.file.Path
 import kotlin.test.assertFailsWith
 
 class DeleteObjectTest {
     companion object {
         private const val OBJECT_CLASS = "net.corda.gradle.HasObjects"
+        private const val UNWANTED_FIELD_OBJ_FIELD = "unwantedFieldObj"
+        private const val UNWANTED_GET_OBJ_METHOD = "getUnwantedGetObj"
         private const val UNWANTED_OBJ_METHOD = "getUnwantedObj"
         private const val UNWANTED_OBJ_FIELD = "unwantedObj"
         private const val UNWANTED_FUN_METHOD = "unwantedFun"
@@ -57,6 +60,49 @@ class DeleteObjectTest {
             cl.load<Any>(OBJECT_CLASS).apply {
                 assertFailsWith<NoSuchMethodException> { getDeclaredMethod(UNWANTED_OBJ_METHOD) }
                 assertFailsWith<NoSuchFieldException> { getDeclaredField(UNWANTED_OBJ_FIELD) }
+            }
+        }
+    }
+
+    @Test
+    fun deleteObjectThatHasGetterOnly() {
+        assertThat(sourceClasses).anyMatch { it.contains("\$unwantedGetObj\$") }
+
+        classLoaderFor(testProject.sourceJar).use { cl ->
+            cl.load<Any>(OBJECT_CLASS).apply {
+                getDeclaredMethod(UNWANTED_GET_OBJ_METHOD).also { method ->
+                    (method.invoke(null) as HasUnwantedFun).also { obj ->
+                        assertEquals(MESSAGE, obj.unwantedFun(MESSAGE))
+                    }
+                }
+            }
+        }
+
+        classLoaderFor(testProject.filteredJar).use { cl ->
+            cl.load<Any>(OBJECT_CLASS).apply {
+                assertFailsWith<NoSuchMethodException> { getDeclaredMethod(UNWANTED_GET_OBJ_METHOD) }
+            }
+        }
+    }
+
+    @Test
+    fun deleteFieldObject() {
+        assertThat(sourceClasses).anyMatch { it.contains("\$unwantedFieldObj\$") }
+
+        classLoaderFor(testProject.sourceJar).use { cl ->
+            cl.load<Any>(OBJECT_CLASS).apply {
+                getDeclaredField(UNWANTED_FIELD_OBJ_FIELD).also { field ->
+                    assertTrue(field.hasModifiers(ACC_PUBLIC))
+                    (field.get(null) as HasUnwantedFun).also { obj ->
+                        assertEquals(MESSAGE, obj.unwantedFun(MESSAGE))
+                    }
+                }
+            }
+        }
+
+        classLoaderFor(testProject.filteredJar).use { cl ->
+            cl.load<Any>(OBJECT_CLASS).apply {
+                assertFailsWith<NoSuchFieldException> { getDeclaredField(UNWANTED_FIELD_OBJ_FIELD) }
             }
         }
     }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteValPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteValPropertyTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.objectweb.asm.Opcodes.ACC_PRIVATE
 import java.nio.file.Path
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.test.assertFailsWith
@@ -37,7 +38,7 @@ class DeleteValPropertyTest {
                 getDeclaredConstructor(String::class.java).newInstance(MESSAGE).also { obj ->
                     assertEquals(MESSAGE, obj.unwantedVal)
                 }
-                assertFalse(getDeclaredField("unwantedVal").isAccessible)
+                assertTrue(getDeclaredField("unwantedVal").hasModifiers(ACC_PRIVATE))
                 assertThat("unwantedVal not found", kotlin.declaredMemberProperties, hasItem(unwantedVal))
                 assertThat("getUnwantedVal not found", kotlin.javaDeclaredMethods, hasItem(getUnwantedVal))
             }
@@ -62,7 +63,7 @@ class DeleteValPropertyTest {
                 getDeclaredConstructor(String::class.java).newInstance(MESSAGE).also { obj ->
                     assertEquals(MESSAGE, obj.unwantedVal)
                 }
-                assertFalse(getDeclaredField("unwantedVal").isAccessible)
+                assertTrue(getDeclaredField("unwantedVal").hasModifiers(ACC_PRIVATE))
                 assertThat("getUnwantedVal not found", kotlin.javaDeclaredMethods, hasItem(getUnwantedVal))
             }
         }
@@ -72,7 +73,7 @@ class DeleteValPropertyTest {
                 getDeclaredConstructor(String::class.java).newInstance(MESSAGE).also { obj ->
                     assertFailsWith<AbstractMethodError> { obj.unwantedVal }
                 }
-                assertFalse(getDeclaredField("unwantedVal").isAccessible)
+                assertTrue(getDeclaredField("unwantedVal").hasModifiers(ACC_PRIVATE))
                 assertThat("getUnwantedVal still exists", kotlin.javaDeclaredMethods, not(hasItem(getUnwantedVal)))
             }
         }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteVarPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteVarPropertyTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.objectweb.asm.Opcodes.ACC_PRIVATE
 import java.nio.file.Path
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.test.assertFailsWith
@@ -41,7 +42,7 @@ class DeleteVarPropertyTest {
                     obj.unwantedVar = MESSAGE
                     assertEquals(MESSAGE, obj.unwantedVar)
                 }
-                assertFalse(getDeclaredField("unwantedVar").isAccessible)
+                assertTrue(getDeclaredField("unwantedVar").hasModifiers(ACC_PRIVATE))
                 assertThat("unwantedVar not found", kotlin.declaredMemberProperties, hasItem(unwantedVar))
                 assertThat("getUnwantedVar not found", kotlin.javaDeclaredMethods, hasItem(getUnwantedVar))
                 assertThat("setUnwantedVar not found", kotlin.javaDeclaredMethods, hasItem(setUnwantedVar))
@@ -69,7 +70,7 @@ class DeleteVarPropertyTest {
                 getDeclaredConstructor(String::class.java).newInstance(MESSAGE).also { obj ->
                     assertEquals(MESSAGE, obj.unwantedVar)
                 }
-                assertFalse(getDeclaredField("unwantedVar").isAccessible)
+                assertTrue(getDeclaredField("unwantedVar").hasModifiers(ACC_PRIVATE))
                 assertThat("getUnwantedVar not found", kotlin.javaDeclaredMethods, hasItem(getUnwantedVar))
             }
         }
@@ -79,7 +80,7 @@ class DeleteVarPropertyTest {
                 getDeclaredConstructor(String::class.java).newInstance(MESSAGE).also { obj ->
                     assertFailsWith<AbstractMethodError> { obj.unwantedVar }
                 }
-                assertFalse(getDeclaredField("unwantedVar").isAccessible)
+                assertTrue(getDeclaredField("unwantedVar").hasModifiers(ACC_PRIVATE))
                 assertThat("getUnwantedVar still exists", kotlin.javaDeclaredMethods, not(hasItem(getUnwantedVar)))
             }
         }
@@ -95,7 +96,7 @@ class DeleteVarPropertyTest {
                     assertEquals(MESSAGE, obj.unwantedVar)
                 }
                 getDeclaredField("unwantedVar").also { field ->
-                    assertFalse(field.isAccessible)
+                    assertTrue(field.hasModifiers(ACC_PRIVATE))
                 }
                 assertThat("setUnwantedVar not found", kotlin.javaDeclaredMethods, hasItem(setUnwantedVar))
             }
@@ -108,7 +109,7 @@ class DeleteVarPropertyTest {
                     assertFailsWith<AbstractMethodError> { obj.unwantedVar = MESSAGE }
                 }
                 getDeclaredField("unwantedVar").also { field ->
-                    assertFalse(field.isAccessible)
+                    assertTrue(field.hasModifiers(ACC_PRIVATE))
                 }
                 assertThat("setUnwantedVar still exists", kotlin.javaDeclaredMethods, not(hasItem(setUnwantedVar)))
             }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/FieldElementTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/FieldElementTest.kt
@@ -2,6 +2,7 @@ package net.corda.gradle.jarfilter
 
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.objectweb.asm.Opcodes.ACC_PUBLIC
 
 
 class FieldElementTest {
@@ -12,20 +13,20 @@ class FieldElementTest {
     @Test
     fun testFieldsMatchByNameOnly() {
         val elt = FieldElement(name = "fieldName", descriptor = DESCRIPTOR)
-        assertEquals(FieldElement(name = "fieldName"), elt)
+        assertEquals(FieldElement(name = "fieldName", descriptor = "?"), elt)
     }
 
     @Test
-    fun testFieldWithDescriptorDoesNotExpire() {
-        val elt = FieldElement(name = "fieldName", descriptor = DESCRIPTOR)
+    fun testFieldWithAccessFlagsDoesNotExpire() {
+        val elt = FieldElement(name = "fieldName", descriptor = DESCRIPTOR, access = ACC_PUBLIC)
         assertFalse(elt.isExpired)
         assertFalse(elt.isExpired)
         assertFalse(elt.isExpired)
     }
 
     @Test
-    fun testFieldWithoutDescriptorDoesExpire() {
-        val elt = FieldElement(name = "fieldName")
+    fun testDummyFieldDoesExpire() {
+        val elt = FieldElement(name = "fieldName", descriptor = "?")
         assertFalse(elt.isExpired)
         assertTrue(elt.isExpired)
         assertTrue(elt.isExpired)

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/RequiresKotlin14.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/RequiresKotlin14.kt
@@ -1,0 +1,11 @@
+package net.corda.gradle.jarfilter
+
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.*
+
+@DisabledIfSystemProperty(named = "test.kotlin.api", matches = "1\\.[23]")
+@Target(CLASS, FUNCTION)
+@Retention(RUNTIME)
+@MustBeDocumented
+annotation class RequiresKotlin14

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/Utilities.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/Utilities.kt
@@ -3,7 +3,7 @@ package net.corda.gradle.jarfilter
 
 import org.opentest4j.TestAbortedException
 import java.io.IOException
-import java.lang.reflect.Field
+import java.lang.reflect.Member
 import java.net.MalformedURLException
 import java.net.URLClassLoader
 import java.nio.file.StandardCopyOption.*
@@ -64,8 +64,8 @@ fun arrayOfJunk(size: Int) = ByteArray(size).apply {
     }
 }
 
-fun Field.hasModifiers(flags: Int): Boolean {
-    return (modifiers and flags) != 0
+fun Member.hasModifiers(flags: Int): Boolean {
+    return (modifiers and flags) == flags
 }
 
 val KFunction<*>.hasAnyOptionalParameters: Boolean

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/Utilities.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/Utilities.kt
@@ -3,6 +3,7 @@ package net.corda.gradle.jarfilter
 
 import org.opentest4j.TestAbortedException
 import java.io.IOException
+import java.lang.reflect.Field
 import java.net.MalformedURLException
 import java.net.URLClassLoader
 import java.nio.file.StandardCopyOption.*
@@ -61,6 +62,10 @@ fun arrayOfJunk(size: Int) = ByteArray(size).apply {
     for (i in 0 until size) {
         this[i] = (i and 0xFF).toByte()
     }
+}
+
+fun Field.hasModifiers(flags: Int): Boolean {
+    return (modifiers and flags) != 0
 }
 
 val KFunction<*>.hasAnyOptionalParameters: Boolean

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/matcher/JavaMatchers.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/matcher/JavaMatchers.kt
@@ -65,7 +65,7 @@ private class MethodMatcher(
             return false
         }
 
-        val method: Method = obj as? Method ?: return false
+        val method = obj as? Method ?: return false
         mismatch.appendText("name is ").appendValue(method.name)
         if (!name.matches(method.name)) {
             return false
@@ -80,8 +80,8 @@ private class MethodMatcher(
         val parameterCount = method.parameterTypes.size
         if (parameterCount != parameters.size) {
             mismatch.appendText(" with ")
-                    .appendValue(parameterCount).appendText(" parameter").appendText(if (parameterCount == 1) " " else "s ")
-                    .appendValueList("(", ",", ")", method.parameterTypes.map(Class<*>::getName))
+                .appendValue(parameterCount).appendText(" parameter").appendText(if (parameterCount == 1) " " else "s ")
+                .appendValueList("(", ",", ")", method.parameterTypes.map(Class<*>::getName))
             return false
         }
 
@@ -123,7 +123,7 @@ private class ConstructorMatcher(
             return false
         }
 
-        val constructor: Constructor<*> = obj as? Constructor<*> ?: return false
+        val constructor = obj as? Constructor<*> ?: return false
         mismatch.appendText("class ").appendValue(constructor.name)
         if (!classType.matches(constructor.name)) {
             return false

--- a/jar-filter/src/test/resources/abstract-function/kotlin/net/corda/gradle/AbstractFunctions.kt
+++ b/jar-filter/src/test/resources/abstract-function/kotlin/net/corda/gradle/AbstractFunctions.kt
@@ -1,4 +1,4 @@
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/annotations/kotlin/net/corda/gradle/jarfilter/DecorateMe.kt
+++ b/jar-filter/src/test/resources/annotations/kotlin/net/corda/gradle/jarfilter/DecorateMe.kt
@@ -5,10 +5,15 @@ import kotlin.annotation.AnnotationRetention.*
 import kotlin.annotation.AnnotationTarget.*
 
 @Target(
+    FILE,
+    CLASS,
     CONSTRUCTOR,
     FUNCTION,
+    PROPERTY,
     PROPERTY_GETTER,
-    PROPERTY_SETTER
+    PROPERTY_SETTER,
+    FIELD,
+    TYPEALIAS
 )
-@Retention(RUNTIME)
-annotation class StubMeOut
+@Retention(BINARY)
+annotation class DecorateMe

--- a/jar-filter/src/test/resources/annotations/kotlin/net/corda/gradle/jarfilter/DeleteMe.kt
+++ b/jar-filter/src/test/resources/annotations/kotlin/net/corda/gradle/jarfilter/DeleteMe.kt
@@ -1,9 +1,8 @@
+@file:Suppress("PackageDirectoryMismatch")
 package net.corda.gradle.jarfilter
 
 import kotlin.annotation.AnnotationRetention.*
 import kotlin.annotation.AnnotationTarget.*
-import kotlin.annotation.Retention
-import kotlin.annotation.Target
 
 @Target(
     FILE,

--- a/jar-filter/src/test/resources/annotations/kotlin/net/corda/gradle/jarfilter/RemoveMe.kt
+++ b/jar-filter/src/test/resources/annotations/kotlin/net/corda/gradle/jarfilter/RemoveMe.kt
@@ -1,9 +1,8 @@
+@file:Suppress("PackageDirectoryMismatch")
 package net.corda.gradle.jarfilter
 
 import kotlin.annotation.AnnotationRetention.*
 import kotlin.annotation.AnnotationTarget.*
-import kotlin.annotation.Retention
-import kotlin.annotation.Target
 
 @Target(
     FILE,

--- a/jar-filter/src/test/resources/delete-ambiguous-property/build.gradle
+++ b/jar-filter/src/test/resources/delete-ambiguous-property/build.gradle
@@ -1,0 +1,35 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
+plugins {
+    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'net.corda.plugins.jar-filter' apply false
+}
+apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
+
+sourceSets {
+    main {
+        kotlin {
+            srcDir files(
+                '../resources/test/delete-ambiguous-property/kotlin',
+                '../resources/test/annotations/kotlin'
+            )
+        }
+    }
+}
+
+dependencies {
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
+}
+
+jar {
+    archiveBaseName = 'delete-ambiguous-property'
+}
+
+task jarFilter(type: JarFilterTask) {
+    jars jar
+    annotations {
+        forDelete = ["net.corda.gradle.jarfilter.DeleteMe"]
+    }
+}

--- a/jar-filter/src/test/resources/delete-ambiguous-property/kotlin/net/corda/gradle/DeleteAmbiguousValProperty.kt
+++ b/jar-filter/src/test/resources/delete-ambiguous-property/kotlin/net/corda/gradle/DeleteAmbiguousValProperty.kt
@@ -1,0 +1,23 @@
+@file:Suppress("unused", "PackageDirectoryMismatch")
+package net.corda.gradle
+
+import net.corda.gradle.jarfilter.DecorateMe
+import net.corda.gradle.jarfilter.DeleteMe
+
+class DeleteAmbiguousValProperty {
+    @DeleteMe
+    @get:JvmName("nameIntToInt")
+    val Map<Int, Int>.name: String get() = "int-to-int"
+
+    @DecorateMe
+    @get:JvmName("nameIntToByte")
+    val Map<Int, Byte>.name: String get() = "int-to-byte"
+
+    @DecorateMe
+    @get:JvmName("nameString")
+    val Collection<String>.name: String get() = "string"
+
+    @DeleteMe
+    @get:JvmName("nameLong")
+    val Collection<Long>.name: String get() = "long"
+}

--- a/jar-filter/src/test/resources/delete-and-stub/kotlin/net/corda/gradle/DeletePackageWithStubbed.kt
+++ b/jar-filter/src/test/resources/delete-and-stub/kotlin/net/corda/gradle/DeletePackageWithStubbed.kt
@@ -1,5 +1,5 @@
+@file:Suppress("unused", "PackageDirectoryMismatch")
 @file:JvmName("DeletePackageWithStubbed")
-@file:Suppress("UNUSED")
 @file:DeleteMe
 package net.corda.gradle
 

--- a/jar-filter/src/test/resources/delete-and-stub/kotlin/net/corda/gradle/HasDeletedInsideStubbed.kt
+++ b/jar-filter/src/test/resources/delete-and-stub/kotlin/net/corda/gradle/HasDeletedInsideStubbed.kt
@@ -1,5 +1,4 @@
-@file:JvmName("HasDeletedInsideStubbed")
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-and-stub/kotlin/net/corda/gradle/HasPropertyForDeleteAndStub.kt
+++ b/jar-filter/src/test/resources/delete-and-stub/kotlin/net/corda/gradle/HasPropertyForDeleteAndStub.kt
@@ -1,5 +1,4 @@
-@file:JvmName("HasPropertyForDeleteAndStub")
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-constructor/kotlin/net/corda/gradle/HasConstructorToDelete.kt
+++ b/jar-filter/src/test/resources/delete-constructor/kotlin/net/corda/gradle/HasConstructorToDelete.kt
@@ -1,4 +1,4 @@
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-constructor/kotlin/net/corda/gradle/PrimaryConstructorsToDelete.kt
+++ b/jar-filter/src/test/resources/delete-constructor/kotlin/net/corda/gradle/PrimaryConstructorsToDelete.kt
@@ -1,5 +1,4 @@
-@file:JvmName("PrimaryConstructorsToDelete")
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-constructor/kotlin/net/corda/gradle/SecondaryConstructorWithDefaultToDelete.kt
+++ b/jar-filter/src/test/resources/delete-constructor/kotlin/net/corda/gradle/SecondaryConstructorWithDefaultToDelete.kt
@@ -1,4 +1,4 @@
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-extension-val/kotlin/net/corda/gradle/HasValExtension.kt
+++ b/jar-filter/src/test/resources/delete-extension-val/kotlin/net/corda/gradle/HasValExtension.kt
@@ -1,4 +1,4 @@
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-field/kotlin/net/corda/gradle/HasFieldToDelete.kt
+++ b/jar-filter/src/test/resources/delete-field/kotlin/net/corda/gradle/HasFieldToDelete.kt
@@ -1,5 +1,4 @@
-@file:JvmName("HasFieldToDelete")
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-file-typealias/kotlin/net/corda/gradle/FileWithTypeAlias.kt
+++ b/jar-filter/src/test/resources/delete-file-typealias/kotlin/net/corda/gradle/FileWithTypeAlias.kt
@@ -1,5 +1,5 @@
+@file:Suppress("unused", "PackageDirectoryMismatch")
 @file:JvmName("FileWithTypeAlias")
-@file:Suppress("UNUSED")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-function/kotlin/net/corda/gradle/HasFunctionToDelete.kt
+++ b/jar-filter/src/test/resources/delete-function/kotlin/net/corda/gradle/HasFunctionToDelete.kt
@@ -1,4 +1,4 @@
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-function/kotlin/net/corda/gradle/HasFunctionWithDefaultParameter.kt
+++ b/jar-filter/src/test/resources/delete-function/kotlin/net/corda/gradle/HasFunctionWithDefaultParameter.kt
@@ -1,4 +1,4 @@
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-function/kotlin/net/corda/gradle/HasIndirectFunctionToDelete.kt
+++ b/jar-filter/src/test/resources/delete-function/kotlin/net/corda/gradle/HasIndirectFunctionToDelete.kt
@@ -1,4 +1,4 @@
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-inner-lambda/kotlin/net/corda/gradle/HasInnerLambda.kt
+++ b/jar-filter/src/test/resources/delete-inner-lambda/kotlin/net/corda/gradle/HasInnerLambda.kt
@@ -1,4 +1,4 @@
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-lazy/kotlin/net/corda/gradle/HasLazy.kt
+++ b/jar-filter/src/test/resources/delete-lazy/kotlin/net/corda/gradle/HasLazy.kt
@@ -1,5 +1,4 @@
-@file:JvmName("HasLazy")
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-multifile/kotlin/net/corda/gradle/HasInt.kt
+++ b/jar-filter/src/test/resources/delete-multifile/kotlin/net/corda/gradle/HasInt.kt
@@ -1,6 +1,6 @@
+@file:Suppress("unused", "PackageDirectoryMismatch")
 @file:JvmName("HasMultiData")
 @file:JvmMultifileClass
-@file:Suppress("UNUSED")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-multifile/kotlin/net/corda/gradle/HasLong.kt
+++ b/jar-filter/src/test/resources/delete-multifile/kotlin/net/corda/gradle/HasLong.kt
@@ -1,6 +1,6 @@
+@file:Suppress("unused", "PackageDirectoryMismatch")
 @file:JvmName("HasMultiData")
 @file:JvmMultifileClass
-@file:Suppress("UNUSED")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-multifile/kotlin/net/corda/gradle/HasString.kt
+++ b/jar-filter/src/test/resources/delete-multifile/kotlin/net/corda/gradle/HasString.kt
@@ -1,6 +1,6 @@
+@file:Suppress("unused", "PackageDirectoryMismatch")
 @file:JvmName("HasMultiData")
 @file:JvmMultifileClass
-@file:Suppress("UNUSED")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-nested-class/kotlin/net/corda/gradle/HasNestedClasses.kt
+++ b/jar-filter/src/test/resources/delete-nested-class/kotlin/net/corda/gradle/HasNestedClasses.kt
@@ -1,4 +1,4 @@
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-nested-class/kotlin/net/corda/gradle/SealedClass.kt
+++ b/jar-filter/src/test/resources/delete-nested-class/kotlin/net/corda/gradle/SealedClass.kt
@@ -1,4 +1,4 @@
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-object/kotlin/net/corda/gradle/HasObjects.kt
+++ b/jar-filter/src/test/resources/delete-object/kotlin/net/corda/gradle/HasObjects.kt
@@ -1,5 +1,5 @@
+@file:Suppress("unused", "PackageDirectoryMismatch")
 @file:JvmName("HasObjects")
-@file:Suppress("UNUSED")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe
@@ -8,6 +8,17 @@ import net.corda.gradle.unwanted.HasUnwantedVal
 
 @DeleteMe
 val unwantedObj = object : HasUnwantedFun {
+    override fun unwantedFun(str: String): String = str
+}
+
+@DeleteMe
+val unwantedGetObj get() = object : HasUnwantedFun {
+    override fun unwantedFun(str: String): String = str
+}
+
+@field:DeleteMe
+@JvmField
+val unwantedFieldObj = object : HasUnwantedFun {
     override fun unwantedFun(str: String): String = str
 }
 

--- a/jar-filter/src/test/resources/delete-overloaded-function/kotlin/net/corda/gradle/HasOverloadedFunction.kt
+++ b/jar-filter/src/test/resources/delete-overloaded-function/kotlin/net/corda/gradle/HasOverloadedFunction.kt
@@ -1,4 +1,4 @@
-@file:Suppress("unused")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-sealed-subclass/kotlin/net/corda/gradle/SealedWithSubclasses.kt
+++ b/jar-filter/src/test/resources/delete-sealed-subclass/kotlin/net/corda/gradle/SealedWithSubclasses.kt
@@ -1,5 +1,4 @@
-@file:JvmName("SealedWithSubclasses")
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-static-field/kotlin/net/corda/gradle/StaticFieldsToDelete.kt
+++ b/jar-filter/src/test/resources/delete-static-field/kotlin/net/corda/gradle/StaticFieldsToDelete.kt
@@ -1,5 +1,5 @@
+@file:Suppress("unused", "PackageDirectoryMismatch")
 @file:JvmName("StaticFieldsToDelete")
-@file:Suppress("UNUSED")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-static-function/kotlin/net/corda/gradle/StaticFunctionsToDelete.kt
+++ b/jar-filter/src/test/resources/delete-static-function/kotlin/net/corda/gradle/StaticFunctionsToDelete.kt
@@ -1,5 +1,5 @@
+@file:Suppress("unused", "PackageDirectoryMismatch")
 @file:JvmName("StaticFunctionsToDelete")
-@file:Suppress("UNUSED")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-static-val/kotlin/net/corda/gradle/StaticValToDelete.kt
+++ b/jar-filter/src/test/resources/delete-static-val/kotlin/net/corda/gradle/StaticValToDelete.kt
@@ -1,5 +1,5 @@
+@file:Suppress("unused", "PackageDirectoryMismatch")
 @file:JvmName("StaticValToDelete")
-@file:Suppress("UNUSED")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-static-var/kotlin/net/corda/gradle/StaticVarToDelete.kt
+++ b/jar-filter/src/test/resources/delete-static-var/kotlin/net/corda/gradle/StaticVarToDelete.kt
@@ -1,5 +1,5 @@
+@file:Suppress("unused", "PackageDirectoryMismatch")
 @file:JvmName("StaticVarToDelete")
-@file:Suppress("UNUSED")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-val-property/kotlin/net/corda/gradle/HasValPropertyForDelete.kt
+++ b/jar-filter/src/test/resources/delete-val-property/kotlin/net/corda/gradle/HasValPropertyForDelete.kt
@@ -1,4 +1,4 @@
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/delete-var-property/kotlin/net/corda/gradle/HasVarPropertyForDelete.kt
+++ b/jar-filter/src/test/resources/delete-var-property/kotlin/net/corda/gradle/HasVarPropertyForDelete.kt
@@ -1,5 +1,4 @@
-@file:JvmName("HasVarPropertyForDelete")
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/gradle.properties
+++ b/jar-filter/src/test/resources/gradle.properties
@@ -1,2 +1,5 @@
 org.gradle.jvmargs=-XX:+UseG1GC -Xmx512m -javaagent:"$jacocoAgent"=destfile="$buildDir/jacoco/test.exec",includes=net/corda/gradle/jarfilter/**
 org.gradle.caching=false
+kotlin.incremental=false
+
+kotlin_api_version=$kotlin_api_version

--- a/jar-filter/src/test/resources/interface-function/kotlin/net/corda/gradle/InterfaceFunctions.kt
+++ b/jar-filter/src/test/resources/interface-function/kotlin/net/corda/gradle/InterfaceFunctions.kt
@@ -1,4 +1,4 @@
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/kotlin.gradle
+++ b/jar-filter/src/test/resources/kotlin.gradle
@@ -3,9 +3,8 @@ import static org.gradle.api.JavaVersion.*
 tasks.named('compileKotlin', AbstractCompile) {
     kotlinOptions {
         jvmTarget = VERSION_1_8
-        apiVersion = '1.2'
-        languageVersion = '1.2'
+        apiVersion = kotlin_api_version
+        languageVersion = kotlin_api_version
         freeCompilerArgs = ['-Xjvm-default=enable']
     }
 }
-

--- a/jar-filter/src/test/resources/remove-annotations/kotlin/net/corda/gradle/HasUnwantedAnnotations.kt
+++ b/jar-filter/src/test/resources/remove-annotations/kotlin/net/corda/gradle/HasUnwantedAnnotations.kt
@@ -1,4 +1,4 @@
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.RemoveMe

--- a/jar-filter/src/test/resources/sanitise-delete-constructor/kotlin/net/corda/gradle/HasOverloadedConstructorsToDelete.kt
+++ b/jar-filter/src/test/resources/sanitise-delete-constructor/kotlin/net/corda/gradle/HasOverloadedConstructorsToDelete.kt
@@ -1,5 +1,5 @@
+@file:Suppress("unused", "PackageDirectoryMismatch")
 @file:JvmName("HasOverloadedConstructorsToDelete")
-@file:Suppress("UNUSED")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.DeleteMe

--- a/jar-filter/src/test/resources/sanitise-stub-constructor/kotlin/net/corda/gradle/HasOverloadedConstructorsToStub.kt
+++ b/jar-filter/src/test/resources/sanitise-stub-constructor/kotlin/net/corda/gradle/HasOverloadedConstructorsToStub.kt
@@ -1,5 +1,5 @@
+@file:Suppress("unused", "PackageDirectoryMismatch")
 @file:JvmName("HasOverloadedConstructorsToStub")
-@file:Suppress("UNUSED")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.StubMeOut

--- a/jar-filter/src/test/resources/stub-constructor/kotlin/net/corda/gradle/HasConstructorToStub.kt
+++ b/jar-filter/src/test/resources/stub-constructor/kotlin/net/corda/gradle/HasConstructorToStub.kt
@@ -1,4 +1,4 @@
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.StubMeOut

--- a/jar-filter/src/test/resources/stub-constructor/kotlin/net/corda/gradle/PrimaryConstructorsToStub.kt
+++ b/jar-filter/src/test/resources/stub-constructor/kotlin/net/corda/gradle/PrimaryConstructorsToStub.kt
@@ -1,5 +1,4 @@
-@file:JvmName("PrimaryConstructorsToStub")
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.StubMeOut

--- a/jar-filter/src/test/resources/stub-constructor/kotlin/net/corda/gradle/SecondaryConstructorWithDefaultToStub.kt
+++ b/jar-filter/src/test/resources/stub-constructor/kotlin/net/corda/gradle/SecondaryConstructorWithDefaultToStub.kt
@@ -1,4 +1,4 @@
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.StubMeOut

--- a/jar-filter/src/test/resources/stub-function/kotlin/net/corda/gradle/HasFunctionToStub.kt
+++ b/jar-filter/src/test/resources/stub-function/kotlin/net/corda/gradle/HasFunctionToStub.kt
@@ -1,4 +1,4 @@
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.StubMeOut

--- a/jar-filter/src/test/resources/stub-function/kotlin/net/corda/gradle/RuntimeAnnotations.kt
+++ b/jar-filter/src/test/resources/stub-function/kotlin/net/corda/gradle/RuntimeAnnotations.kt
@@ -1,10 +1,8 @@
-@file:JvmName("RuntimeAnnotations")
+@file:Suppress("PackageDirectoryMismatch")
 package net.corda.gradle
 
 import kotlin.annotation.AnnotationRetention.*
 import kotlin.annotation.AnnotationTarget.*
-import kotlin.annotation.Retention
-import kotlin.annotation.Target
 
 @Target(VALUE_PARAMETER)
 @Retention(RUNTIME)

--- a/jar-filter/src/test/resources/stub-static-function/kotlin/net/corda/gradle/StaticFunctionsToStub.kt
+++ b/jar-filter/src/test/resources/stub-static-function/kotlin/net/corda/gradle/StaticFunctionsToStub.kt
@@ -1,5 +1,5 @@
+@file:Suppress("unused", "PackageDirectoryMismatch")
 @file:JvmName("StaticFunctionsToStub")
-@file:Suppress("UNUSED")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.StubMeOut

--- a/jar-filter/src/test/resources/stub-val-property/kotlin/net/corda/gradle/HasValPropertyForStub.kt
+++ b/jar-filter/src/test/resources/stub-val-property/kotlin/net/corda/gradle/HasValPropertyForStub.kt
@@ -1,4 +1,4 @@
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.StubMeOut

--- a/jar-filter/src/test/resources/stub-var-property/kotlin/net/corda/gradle/HasVarPropertyForStub.kt
+++ b/jar-filter/src/test/resources/stub-var-property/kotlin/net/corda/gradle/HasVarPropertyForStub.kt
@@ -1,5 +1,4 @@
-@file:JvmName("HasVarPropertyForStub")
-@file:Suppress("UNUSED")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package net.corda.gradle
 
 import net.corda.gradle.jarfilter.StubMeOut


### PR DESCRIPTION
Kotlin 1.4 changes how it annotates properties inside the byte-code - see [KT-31352](https://youtrack.jetbrains.com/issue/KT-31352) and [KT-36926](https://youtrack.jetbrains.com/issue/KT-36926). Update JarFilter so that it will work with Kotlin 1.2, 1.3 and 1.4.