### PR TITLE
 EG-153/jmacmahon/dockerfileplugin

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -62,6 +62,7 @@ changes to this list.
 * Ivan Schasny (R3)
 * James Brown (R3)
 * James Carlyle (R3)
+* James Mac Mahon (R3)
 * Jared Harwayne-Gidansky (BNY Mellon)
 * Joel Dudley (R3)
 * Johan Hörmark (SEB)

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import static org.gradle.api.JavaVersion.*
 
 buildscript {
     ext {
-        gradle_plugins_version = '5.0.9-SNAPSHOT'
+        gradle_plugins_version = '5.0.10-SNAPSHOT'
         typesafe_config_version = '1.3.1'
         classgraph_version = '4.8.53'
         kotlin_version = '1.3.21'
@@ -12,6 +12,7 @@ buildscript {
         junit_jupiter_version = '5.6.0'
         hamcrest_version = '2.1'
         asm_version = '7.3.1'
+        docker_client_version = '8.15.1'
     }
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import static org.gradle.api.JavaVersion.*
 
 buildscript {
     ext {
-        gradle_plugins_version = '5.0.10-SNAPSHOT'
+        gradle_plugins_version = '5.0.9-SNAPSHOT'
         typesafe_config_version = '1.3.1'
         classgraph_version = '4.8.53'
         kotlin_version = '1.3.21'

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@
 
 * `jar-filter`: Initial support for byte-code compiled by Kotlin >= 1.4.0 (See [KT-31352](https://youtrack.jetbrains.com/issue/KT-31352)).
 
+* `cordformation` Dockerfile generation for Cordapp to create bundled cordapp/corda node image  
+
 ### Version 5.0.8
 
 * `cordformation`: Allow `dataSource.url` to be overridden in `Dockerform` task.

--- a/cordformation/build.gradle
+++ b/cordformation/build.gradle
@@ -75,6 +75,10 @@ dependencies {
     testRuntimeOnly "net.corda:corda-node-api:$corda_release_version"
     // Docker-compose file generation
     implementation "org.yaml:snakeyaml:$snake_yaml_version"
+    //DockerFile Generation
+    implementation "com.spotify:docker-client:$docker_client_version"
+
+
 }
 
 /**

--- a/cordformation/src/main/kotlin/net/corda/plugins/DockerImage.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/DockerImage.kt
@@ -66,9 +66,10 @@ open class DockerImage  @Inject constructor(objects: ObjectFactory, layouts: Pro
         val files = inputs ?: return
         _jars.from(files)
     }
+
     fun cordaJars(inputs: Any?) = setCordaJars(inputs)
 
-    @get:Internal
+    @get:OutputDirectory
     val outputDir: DirectoryProperty = objects.directoryProperty().convention(layouts.buildDirectory.dir("docker"))
 
     @TaskAction

--- a/cordformation/src/main/kotlin/net/corda/plugins/DockerImage.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/DockerImage.kt
@@ -1,0 +1,86 @@
+package net.corda.plugins
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+open class DockerImage : DefaultTask() {
+
+    private companion object{
+        private const val DOCKER_FILE_NAME = "dockerfile"
+        private const val CORDA_VERSION_PROP = "corda_release_version"
+    }
+
+    private enum class Images(val label: String,val enterpriseLabel: String) {
+        ZULU("zulu","alpine-zulu"),
+        CORRETTO("corretto", "" );
+
+        fun getAddress(cordaVersion:String, isEnterprise:Boolean): String{
+            if(isEnterprise){
+                return "entdocker/corda-enterprise-${enterpriseLabel}-java1.8-${cordaVersion.toLowerCase()}:latest"
+            }
+            return "corda/corda-${label}-java1.8-${cordaVersion.toLowerCase()}:latest"
+        }
+    }
+
+
+    init {
+        description = "Creates a docker file and immediately builds that image to the local repository."
+    }
+
+    @get:Optional
+    @get:Input
+    internal var baseImage: String = Images.ZULU.label
+
+    fun baseImage(baseImage: String) {
+        this.baseImage = baseImage
+    }
+
+    @get:Optional
+    @get:Input
+    internal var enterprise: Boolean = false
+
+    fun enterpriseEdition(editionInput: Boolean) {
+        this.enterprise = editionInput
+    }
+
+
+    @TaskAction
+    fun build() {
+
+        project.logger.lifecycle("Running DockerImage task")
+        project.copy {
+            it.apply {
+                from("${project.buildDir}/libs", "*.jar")
+                into("${project.buildDir}/docker")
+            }
+        }
+
+        val imageAddress = getImageTag()
+        File("${project.buildDir}/docker/$DOCKER_FILE_NAME").writeText("""
+            FROM $imageAddress
+            COPY build/docker/*.jar /opt/corda/cordapps/
+        """.trimIndent())
+
+        project.exec{
+            it.commandLine("docker", "build", ".", "-t", "${project.name}:${project.version}","-f", "${project.buildDir}/docker/$DOCKER_FILE_NAME" )
+        }
+    }
+
+
+    fun getImageTag(): String{
+        val cordaVersion = project.properties[CORDA_VERSION_PROP] as String
+        if(baseImage.equals(Images.CORRETTO.label)) {
+            return Images.CORRETTO.getAddress(cordaVersion,enterprise)
+        }else if(baseImage.equals(Images.ZULU.label)){
+            return Images.ZULU.getAddress(cordaVersion,enterprise)
+        }else if (baseImage.isNotEmpty()){
+            project.logger.lifecycle("Using custom image $baseImage")
+            return baseImage
+        }
+        return Images.ZULU.getAddress(cordaVersion,enterprise)
+    }
+
+}

--- a/cordformation/src/main/kotlin/net/corda/plugins/DockerImage.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/DockerImage.kt
@@ -68,9 +68,6 @@ open class DockerImage  @Inject constructor(objects: ObjectFactory, layouts: Pro
     }
     fun cordaJars(inputs: Any?) = setCordaJars(inputs)
 
-
-    private fun transferToDockerDir(source: File) = outputDir.file(source.name)
-
     @get:Internal
     val outputDir: DirectoryProperty = objects.directoryProperty().convention(layouts.buildDirectory.dir("docker"))
 
@@ -112,7 +109,6 @@ open class DockerImage  @Inject constructor(objects: ObjectFactory, layouts: Pro
         }
     }
 
-
     private fun buildDockerFile(docker:DefaultDockerClient):  String{
         val path: Path = Paths.get(outputDir.get().toString())
         return docker.build(path,null, DOCKER_FILE_NAME, LoggingBuildHandler())
@@ -133,6 +129,4 @@ open class DockerImage  @Inject constructor(objects: ObjectFactory, layouts: Pro
         }
         return ""
     }
-
-
 }

--- a/cordformation/src/main/kotlin/net/corda/plugins/DockerImage.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/DockerImage.kt
@@ -33,10 +33,10 @@ open class DockerImage  @Inject constructor(objects: ObjectFactory, layouts: Pro
 
     @get:Optional
     @get:InputFile
-    internal var trustRootStoreName: File? = null
+    internal var trustRootStoreFile: File? = null
 
-    fun trustRootStoreName(trustRoot: File) {
-        this.trustRootStoreName = trustRoot
+    fun trustRootStoreFile(trustRootStoreFile: File) {
+        this.trustRootStoreFile = trustRootStoreFile
     }
 
     @get:Optional
@@ -94,10 +94,8 @@ open class DockerImage  @Inject constructor(objects: ObjectFactory, layouts: Pro
             |COPY *.jar /opt/corda/cordapps/
             |$copyTrustRootStore""".trimMargin()
 
-        val dockerFilePath = "${project.buildDir}/docker/$DOCKER_FILE_NAME"
-
-        logger.lifecycle("Writing Dockerfile to $dockerFilePath")
-        project.file(dockerFilePath).writeText(dockerFileContents)
+        logger.lifecycle("Writing Dockerfile to ${outputDir.get()}")
+        project.file(outputDir.file(DOCKER_FILE_NAME)).writeText(dockerFileContents)
 
         if(buildImage){
             val docker = DefaultDockerClient.fromEnv().build()
@@ -116,17 +114,17 @@ open class DockerImage  @Inject constructor(objects: ObjectFactory, layouts: Pro
     }
 
     private fun getAdditionalTrustRootCommandIfNeeded(): String {
-        if (trustRootStoreName != null) {
-            logger.lifecycle("Copying Trust Store: ${trustRootStoreName}")
+        if (trustRootStoreFile != null) {
+            logger.lifecycle("Copying Trust Store: ${trustRootStoreFile}")
             logger.lifecycle("Copying From: ${project.projectDir}")
 
             project.copy {
                 it.apply {
-                    from(trustRootStoreName)
+                    from(trustRootStoreFile)
                     into(outputDir)
                 }
             }
-            return "COPY ${trustRootStoreName!!.name} /opt/corda/tmp-certificates/"
+            return "COPY ${trustRootStoreFile!!.name} /opt/corda/tmp-certificates/"
         }
         return ""
     }

--- a/cordformation/src/main/kotlin/net/corda/plugins/DockerImage.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/DockerImage.kt
@@ -1,16 +1,17 @@
 package net.corda.plugins
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.TaskAction
 import com.spotify.docker.client.DefaultDockerClient
-import org.apache.commons.lang.StringUtils
+import org.gradle.api.file.*
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.*
+import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
+import javax.inject.Inject
 
 
-open class DockerImage : DefaultTask() {
+open class DockerImage  @Inject constructor(objects: ObjectFactory, layouts: ProjectLayout) : DefaultTask() {
 
     private companion object{
         //Currently a bug in gradle's projectFile that writes the file with a lower case 'd'
@@ -23,7 +24,6 @@ open class DockerImage : DefaultTask() {
         group = "CordaDockerDeployment"
     }
 
-    @get:Optional
     @get:Input
     internal var baseImage: String? = null
 
@@ -32,51 +32,86 @@ open class DockerImage : DefaultTask() {
     }
 
     @get:Optional
-    @get:Input
-    internal var trustRootStoreName: String? = null
+    @get:InputFile
+    internal var trustRootStoreName: File? = null
 
-    fun trustRootStoreName(trustRoot: String) {
+    fun trustRootStoreName(trustRoot: File) {
         this.trustRootStoreName = trustRoot
     }
 
+    @get:Optional
+    @get:Input
+    internal var buildImage: Boolean = true
+
+    fun buildImage(doBuild: Boolean) {
+        this.buildImage = doBuild
+    }
+
+    @get:Optional
+    @get:Input
+    internal var dockerImageTag: String? = null
+
+    fun dockerImageTag(tag: String) {
+        dockerImageTag = tag
+    }
+
+    private val _jars: ConfigurableFileCollection = project.files()
+
+    @get:InputFiles
+    @get:SkipWhenEmpty
+    val cordaJars: FileCollection get() = _jars
+
+    @Suppress("MemberVisibilityCanBePrivate")
+    fun setCordaJars(inputs: Any?) {
+        val files = inputs ?: return
+        _jars.setFrom(files)
+    }
+    fun cordaJars(inputs: Any?) = setCordaJars(inputs)
+
+    @get:OutputFiles
+    val dockerJars: FileCollection get() = project.files(cordaJars.map(::transferToDockerDir))
+
+    private fun transferToDockerDir(source: File) = outputDir.file(source.name)
+
+    @get:Internal
+    val outputDir: DirectoryProperty = objects.directoryProperty().convention(layouts.buildDirectory.dir("docker"))
 
     @TaskAction
     fun build() {
 
-        logger.lifecycle("Running DockerImage task")
-        project.copy {
+        project.copy{
             it.apply {
-                from("${project.buildDir}/libs", "*.jar")
-                into("${project.buildDir}/docker")
+                from(project.configuration("cordapp"))
+                into(outputDir)
             }
         }
 
         logger.lifecycle("Using Image: ${baseImage}")
         val copyTrustRootStore:String = getAdditionalTrustRootCommandIfNeeded()
 
-        val dockerFileContents= """
-            FROM $baseImage
-            COPY *.jar /opt/corda/cordapps/
-            $copyTrustRootStore""".trimIndent()
+        val dockerFileContents= """\
+            |FROM $baseImage
+            |COPY *.jar /opt/corda/cordapps/
+            |$copyTrustRootStore""".trimMargin()
 
         val dockerFilePath = "${project.buildDir}/docker/$DOCKER_FILE_NAME"
 
         logger.lifecycle("Writing Dockerfile to $dockerFilePath")
         project.file(dockerFilePath).writeText(dockerFileContents)
-        val docker = DefaultDockerClient.fromEnv().build()
 
-        val builtImageId = buildDockerFile(docker)
+        if(buildImage){
+            val docker = DefaultDockerClient.fromEnv().build()
+            val builtImageId = buildDockerFile(docker)
+            val tag = dockerImageTag?:"${project.name}:${project.version}"
 
-        val tag = "${project.name}:${project.version}"
-
-        logger.lifecycle("Tagging $builtImageId as: $tag")
-        docker.tag(builtImageId, tag)
+            logger.lifecycle("Tagging $builtImageId as: $tag")
+            docker.tag(builtImageId, tag)
+        }
 
     }
 
     private fun buildDockerFile(docker:DefaultDockerClient):  String{
-        val path: Path = Paths.get(project.buildDir.absolutePath, "docker")
-
+        val path: Path = Paths.get(outputDir.get().toString())
         return docker.build(path, DOCKER_FILE_NAME)
     }
 
@@ -87,13 +122,13 @@ open class DockerImage : DefaultTask() {
 
             project.copy {
                 it.apply {
-                    from("${project.projectDir}/${trustRootStoreName}")
-                    into("${project.buildDir}/docker/")
+                    from(trustRootStoreName)
+                    into(outputDir)
                 }
             }
-            return "COPY ${trustRootStoreName} /opt/corda/certificates/"
+            return "COPY ${trustRootStoreName!!.name} /opt/corda/tmp-certificates/"
         }
-        return StringUtils.EMPTY
+        return ""
     }
 
 

--- a/cordformation/src/test/kotlin/net/corda/plugins/DockerImageTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/DockerImageTest.kt
@@ -1,4 +1,31 @@
 package net.corda.plugins
 
-class DockerImageTest {
+import org.assertj.core.api.Assertions
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Test
+import java.nio.file.Paths
+
+class DockerImageTest :BaseformTest() {
+    @Test
+    fun testThatImageBuildsDockerFileAsExpected() {
+        val runner = getStandardGradleRunnerFor("DeployDockerImage.gradle", "dockerImage")
+
+        val result = runner.build()
+        Assertions.assertThat(result.task(":dockerImage")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        Assertions.assertThat(Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker", "dockerfile")).isRegularFile()
+
+        val dockerfile = Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker", "dockerfile").toFile()
+        val text = dockerfile.readText()
+        Assertions.assertThat(text.contains("From corda/entImage")).isEqualTo(true)
+        Assertions.assertThat(text.contains("COPY *.jar /opt/corda/cordapps/")).isEqualTo(true)
+    }
+
+    @Test
+    fun testThatCordappDependenciesArePulledDownIntoTheBuildDockerDir() {
+        val runner = getStandardGradleRunnerFor("DeployDockerImage.gradle", "dockerImage")
+
+        val result = runner.build()
+        Assertions.assertThat(Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker","corda-finance-contracts-4.0.jar")).isRegularFile()
+        Assertions.assertThat(Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker","corda-finance-workflows-4.0.jar")).isRegularFile()
+    }
 }

--- a/cordformation/src/test/kotlin/net/corda/plugins/DockerImageTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/DockerImageTest.kt
@@ -12,9 +12,9 @@ class DockerImageTest :BaseformTest() {
 
         val result = runner.build()
         Assertions.assertThat(result.task(":dockerImage")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        Assertions.assertThat(Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker", "dockerfile")).isRegularFile()
+        Assertions.assertThat(Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker", "Dockerfile")).isRegularFile()
 
-        val dockerfile = Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker", "dockerfile").toFile()
+        val dockerfile = Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker", "Dockerfile").toFile()
         val text = dockerfile.readText()
         Assertions.assertThat(text.contains("FROM corda/entImage")).isEqualTo(true)
         Assertions.assertThat(text.contains("COPY *.jar /opt/corda/cordapps/")).isEqualTo(true)
@@ -23,9 +23,12 @@ class DockerImageTest :BaseformTest() {
     @Test
     fun testThatCordappDependenciesArePulledDownIntoTheBuildDockerDir() {
         val runner = getStandardGradleRunnerFor("DeployDockerImage.gradle", "dockerImage")
-
+        installResource("dummyJar.jar")
         val result = runner.build()
+
+        Assertions.assertThat(result.task(":dockerImage")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
         Assertions.assertThat(Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker","corda-finance-contracts-4.0.jar")).isRegularFile()
         Assertions.assertThat(Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker","corda-finance-workflows-4.0.jar")).isRegularFile()
+        Assertions.assertThat(Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker","dummyJar.jar")).isRegularFile()
     }
 }

--- a/cordformation/src/test/kotlin/net/corda/plugins/DockerImageTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/DockerImageTest.kt
@@ -1,0 +1,4 @@
+package net.corda.plugins
+
+class DockerImageTest {
+}

--- a/cordformation/src/test/kotlin/net/corda/plugins/DockerImageTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/DockerImageTest.kt
@@ -16,7 +16,7 @@ class DockerImageTest :BaseformTest() {
 
         val dockerfile = Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker", "dockerfile").toFile()
         val text = dockerfile.readText()
-        Assertions.assertThat(text.contains("From corda/entImage")).isEqualTo(true)
+        Assertions.assertThat(text.contains("FROM corda/entImage")).isEqualTo(true)
         Assertions.assertThat(text.contains("COPY *.jar /opt/corda/cordapps/")).isEqualTo(true)
     }
 

--- a/cordformation/src/test/resources/net/corda/plugins/DeployDockerImage.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeployDockerImage.gradle
@@ -1,0 +1,31 @@
+buildscript {
+    ext {
+        corda_group = 'net.corda'
+        corda_release_version = '4.0'
+    }
+}
+
+plugins {
+    id 'net.corda.plugins.cordformation'
+}
+
+
+
+repositories {
+    mavenCentral()
+    maven { url 'https://software.r3.com/artifactory/corda-releases' }
+
+}
+
+dependencies {
+    runtime "$corda_group:corda:$corda_release_version"
+    runtime "$corda_group:corda-node-api:$corda_release_version"
+    cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
+    cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
+}
+
+def dockerImage = tasks.register('dockerImage', net.corda.plugins.DockerImage) {
+    baseImage "corda/entImage"
+    cordaJars project.files(project.file("./dummyJar.jar"))
+    buildImage false
+}

--- a/cordformation/src/test/resources/net/corda/plugins/DeployDockerImage.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeployDockerImage.gradle
@@ -26,6 +26,6 @@ dependencies {
 
 def dockerImage = tasks.register('dockerImage', net.corda.plugins.DockerImage) {
     baseImage "corda/entImage"
-    cordaJars project.files(project.file("./dummyJar.jar"))
+    cordaJars files('dummyJar.jar')
     buildImage false
 }

--- a/cordformation/src/test/resources/net/corda/plugins/DeployDockerImage.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeployDockerImage.gradle
@@ -18,8 +18,8 @@ repositories {
 }
 
 dependencies {
-    runtime "$corda_group:corda:$corda_release_version"
-    runtime "$corda_group:corda-node-api:$corda_release_version"
+    runtimeOnly "$corda_group:corda:$corda_release_version"
+    runtimeOnly "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
 }


### PR DESCRIPTION
This task has been added to allow users to quickly create a docker image based on their cordapp. 

The inputs are BaseImage & trustRootStoreName

BaseImage is the the image you wish to use as the base Corda image for your docker image.
This has three enum values to make life easier for end user : zulu, corretto and enterprise. 
This value defaults to Zulu

The TrustRootStoreName is to allow users to embed a trust root into their corda docker image so they can join an external network. 

The expectation is it will be in the project directory. 