### PR TITLE
EG-1856: Allow users to specify Dockerform ports

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Version 5.0.9
 
 * `cordformation`: Added option to deploy external databases using docker compose task    
+* `cordformation`: Allow users to specify ports in Dockerform
 * `cordformation`: Use GNU Screen in `runnodes` on macOS to start nodes in different Screen windows. Activated when the user is already running `screen`.
 
 * `jar-filter`: Initial support for byte-code compiled by Kotlin >= 1.4.0 (See [KT-31352](https://youtrack.jetbrains.com/issue/KT-31352)).

--- a/cordformation/src/main/kotlin/net/corda/plugins/ConfigurationUtils.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/ConfigurationUtils.kt
@@ -1,0 +1,19 @@
+package net.corda.plugins
+
+import org.gradle.api.InvalidUserDataException
+import java.net.URI
+import java.net.URISyntaxException
+
+class ConfigurationUtils {
+
+    companion object {
+
+        fun parsePort(address: String): Int {
+            return try {
+                URI(null, address, null, null, null).port
+            } catch (ex: URISyntaxException) {
+                throw InvalidUserDataException("Invalid host and port syntax for RPC address, expected host:port. Using default value")
+            }
+        }
+    }
+}

--- a/cordformation/src/main/kotlin/net/corda/plugins/ConfigurationUtils.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/ConfigurationUtils.kt
@@ -12,7 +12,7 @@ class ConfigurationUtils {
             return try {
                 URI(null, address, null, null, null).port
             } catch (ex: URISyntaxException) {
-                throw InvalidUserDataException("Invalid host and port syntax for RPC address, expected host:port. Using default value")
+                throw InvalidUserDataException("Invalid host and port syntax for RPC address, expected host:port")
             }
         }
     }

--- a/cordformation/src/main/kotlin/net/corda/plugins/Dockerform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Dockerform.kt
@@ -99,7 +99,7 @@ open class Dockerform @Inject constructor(objects: ObjectFactory) : Baseform(obj
                             "$nodeBuildDir/additional-node-infos:/opt/corda/additional-node-infos",
                             "$nodeBuildDir/drivers:/opt/corda/drivers"
                     ),
-                    "ports" to listOf(it.rpcPort(), it.config.getInt("sshd.port")),
+                    "ports" to listOf(it.rpcPort.get(), it.config.getInt("sshd.port")),
                     "image" to (dockerImage ?: "corda/corda-zulu-${it.runtimeVersion().toLowerCase()}")
             )
 

--- a/cordformation/src/main/kotlin/net/corda/plugins/Dockerform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Dockerform.kt
@@ -99,7 +99,7 @@ open class Dockerform @Inject constructor(objects: ObjectFactory) : Baseform(obj
                             "$nodeBuildDir/additional-node-infos:/opt/corda/additional-node-infos",
                             "$nodeBuildDir/drivers:/opt/corda/drivers"
                     ),
-                    "ports" to listOf(it.rpcPort, it.config.getInt("sshd.port")),
+                    "ports" to listOf(it.rpcPort(), it.config.getInt("sshd.port")),
                     "image" to (dockerImage ?: "corda/corda-zulu-${it.runtimeVersion().toLowerCase()}")
             )
 

--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -5,6 +5,7 @@ import groovy.lang.Closure
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
@@ -57,9 +58,11 @@ open class Node @Inject constructor(private val project: Project) {
     private var rpcSettings: RpcSettings = RpcSettings()
     private var webserverJar: String? = null
     private var p2pPort = 10002
-    internal var rpcPort = 10003
-        @Input get
-        private set
+    @get:Input
+    val rpcPort: Provider<Int> = project.objects.property(Int::class.javaObjectType).apply {
+        set(project.provider { rpcSettings.port })
+    }
+
     internal var config = ConfigFactory.empty()
         @Internal get
         private set
@@ -186,14 +189,6 @@ open class Node @Inject constructor(private val project: Project) {
     @Deprecated("Use {@link CordformNode#rpcSettings(RpcSettings)} instead. Will be removed by Corda V5.0.")
     fun rpcPort(rpcPort: Int) {
         rpcAddress(DEFAULT_HOST + ':'.toString() + rpcPort)
-        this.rpcPort = rpcPort
-    }
-
-    /**
-     * Retrieves the RPC port associated with this node
-     */
-    fun rpcPort(): Int {
-        return rpcSettings.port
     }
 
     /**

--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -190,6 +190,13 @@ open class Node @Inject constructor(private val project: Project) {
     }
 
     /**
+     * Retrieves the RPC port associated with this node
+     */
+    fun rpcPort(): Int {
+        return rpcSettings.port
+    }
+
+    /**
      * Set the Artemis RPC address for this node.
      *
      * @param rpcAddress The Artemis RPC queue host and port.

--- a/cordformation/src/main/kotlin/net/corda/plugins/RpcSettings.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/RpcSettings.kt
@@ -22,8 +22,11 @@ class RpcSettings {
      * RPC address for the node.
      */
     fun address(value: String) {
-        val portNumber = parsePort(value)
-        port = when (portNumber) { -1 -> port else -> portNumber }
+        val parsedValue = ConfigurationUtils.parsePort(value)
+        port = when (parsedValue) {
+            -1 -> port
+            else -> parsedValue
+        }
         setValue("address", value)
     }
 
@@ -39,8 +42,11 @@ class RpcSettings {
      * RPC admin address for the node (necessary if [useSsl] is false or unset).
      */
     fun adminAddress(value: String) {
-        val portNumber = parsePort(value)
-        adminPort = when (portNumber) { -1 -> adminPort else -> portNumber }
+        val parsedValue = ConfigurationUtils.parsePort(value)
+        adminPort = when (parsedValue) {
+            -1 -> adminPort
+            else -> parsedValue
+        }
         setValue("adminAddress", value)
     }
 
@@ -78,13 +84,5 @@ class RpcSettings {
 
     private fun setValue(path: String, value: Any?) {
         config = config.withValue(path, ConfigValueFactory.fromAnyRef(value))
-    }
-
-    private fun parsePort(address: String): Int {
-        return try {
-            URI(null, address, null, null, null).port
-        } catch (ex: URISyntaxException) {
-            throw InvalidUserDataException("Invalid host and port syntax for RPC address, expected host:port. Using default value")
-        }
     }
 }

--- a/cordformation/src/main/kotlin/net/corda/plugins/RpcSettings.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/RpcSettings.kt
@@ -4,6 +4,8 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigValueFactory
 import org.gradle.api.tasks.Input
+import java.net.URI
+import java.net.URISyntaxException
 
 class RpcSettings {
     private var config = ConfigFactory.empty()
@@ -19,6 +21,9 @@ class RpcSettings {
      * RPC address for the node.
      */
     fun address(value: String) {
+        try {
+            port = URI(null, value, null, null, null).port
+        } catch (ex: URISyntaxException) { }
         setValue("address", value)
     }
 
@@ -34,6 +39,9 @@ class RpcSettings {
      * RPC admin address for the node (necessary if [useSsl] is false or unset).
      */
     fun adminAddress(value: String) {
+        try {
+            adminPort = URI(null, value, null, null, null).port
+        } catch (ex: URISyntaxException) { }
         setValue("adminAddress", value)
     }
 

--- a/cordformation/src/test/kotlin/net/corda/plugins/BaseformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/BaseformTest.kt
@@ -57,6 +57,7 @@ open class BaseformTest {
     fun getNodeCordappJar(nodeName: String, cordappJarName: String) = Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "nodes", nodeName, "cordapps", "$cordappJarName.jar")
     fun getNodeCordappConfig(nodeName: String, cordappJarName: String) = Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "nodes", nodeName, "cordapps", "config", "$cordappJarName.conf")
     fun getNetworkParameterOverrides(nodeName: String) = Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "nodes", nodeName, "network-parameters")
+    fun getNodeConfig(nodeName: String) = Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "nodes", nodeName, "node.conf")
 
     class AMQPParametersSerializationScheme : AbstractAMQPSerializationScheme(emptyList()) {
         override fun rpcClientSerializerFactory(context: SerializationContext) = throw UnsupportedOperationException()
@@ -66,5 +67,4 @@ open class BaseformTest {
             return magic == amqpMagic && target == SerializationContext.UseCase.P2P
         }
     }
-
 }

--- a/cordformation/src/test/kotlin/net/corda/plugins/ConfigurationUtilsTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/ConfigurationUtilsTest.kt
@@ -8,16 +8,16 @@ class ConfigurationUtilsTest {
 
     @Test
     fun `check correct port value parsing`() {
-        assertEquals(ConfigurationUtils.parsePort("localhost:10000"), 10000)
+        assertEquals(10000, ConfigurationUtils.parsePort("localhost:10000"))
     }
 
     @Test
     fun `missing port value correctly identified in valid address`() {
-        assertEquals(ConfigurationUtils.parsePort("localhost"), -1)
+        assertEquals(-1, ConfigurationUtils.parsePort("localhost"))
     }
 
     @Test
     fun `missing port value correctly identified in invalid address`() {
-        assertEquals(ConfigurationUtils.parsePort("localhost!"), -1)
+        assertEquals(-1, ConfigurationUtils.parsePort("localhost!"))
     }
 }

--- a/cordformation/src/test/kotlin/net/corda/plugins/ConfigurationUtilsTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/ConfigurationUtilsTest.kt
@@ -1,0 +1,23 @@
+package net.corda.plugins
+
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class ConfigurationUtilsTest {
+
+    @Test
+    fun `check correct port value parsing`() {
+        assertEquals(ConfigurationUtils.parsePort("localhost:10000"), 10000)
+    }
+
+    @Test
+    fun `missing port value correctly identified in valid address`() {
+        assertEquals(ConfigurationUtils.parsePort("localhost"), -1)
+    }
+
+    @Test
+    fun `missing port value correctly identified in invalid address`() {
+        assertEquals(ConfigurationUtils.parsePort("localhost!"), -1)
+    }
+}

--- a/cordformation/src/test/kotlin/net/corda/plugins/DockerformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/DockerformTest.kt
@@ -1,8 +1,11 @@
 package net.corda.plugins
 
+import com.typesafe.config.ConfigFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class DockerformTest : BaseformTest() {
 
@@ -111,5 +114,23 @@ class DockerformTest : BaseformTest() {
         assertThat(getNodeCordappJar(bankOfCordaNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
         assertThat(getNodeCordappJar(bankOfCordaNodeName, cordaFinanceContractsJarName)).isRegularFile()
         assertThat(getNetworkParameterOverrides(bankOfCordaNodeName)).isRegularFile()
+
+        val notaryConfigPath = getNodeConfig(notaryNodeName)
+        assertThat(notaryConfigPath).isRegularFile()
+
+        val notaryConfig = ConfigFactory.parseFile(notaryConfigPath.toFile())
+        assertTrue(notaryConfig.hasPath("rpcSettings.address"))
+        assertTrue(notaryConfig.hasPath("rpcSettings.adminAddress"))
+        assertEquals(ConfigurationUtils.parsePort(notaryConfig.getString("rpcSettings.address")), 10003)
+        assertEquals(ConfigurationUtils.parsePort(notaryConfig.getString("rpcSettings.adminAddress")), 10043)
+
+        val bankOfCordaConfigPath = getNodeConfig(bankOfCordaNodeName)
+        assertThat(bankOfCordaConfigPath).isRegularFile()
+
+        val bankOfCordaConfig = ConfigFactory.parseFile(bankOfCordaConfigPath.toFile())
+        assertTrue(bankOfCordaConfig.hasPath("rpcSettings.address"))
+        assertTrue(bankOfCordaConfig.hasPath("rpcSettings.adminAddress"))
+        assertEquals(ConfigurationUtils.parsePort(bankOfCordaConfig.getString("rpcSettings.address")), 10006)
+        assertEquals(ConfigurationUtils.parsePort(bankOfCordaConfig.getString("rpcSettings.adminAddress")), 10046)
     }
 }

--- a/cordformation/src/test/kotlin/net/corda/plugins/DockerformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/DockerformTest.kt
@@ -121,8 +121,8 @@ class DockerformTest : BaseformTest() {
         val notaryConfig = ConfigFactory.parseFile(notaryConfigPath.toFile())
         assertTrue(notaryConfig.hasPath("rpcSettings.address"))
         assertTrue(notaryConfig.hasPath("rpcSettings.adminAddress"))
-        assertEquals(ConfigurationUtils.parsePort(notaryConfig.getString("rpcSettings.address")), 10003)
-        assertEquals(ConfigurationUtils.parsePort(notaryConfig.getString("rpcSettings.adminAddress")), 10043)
+        assertEquals(10003, ConfigurationUtils.parsePort(notaryConfig.getString("rpcSettings.address")))
+        assertEquals(10043, ConfigurationUtils.parsePort(notaryConfig.getString("rpcSettings.adminAddress")))
 
         val bankOfCordaConfigPath = getNodeConfig(bankOfCordaNodeName)
         assertThat(bankOfCordaConfigPath).isRegularFile()
@@ -130,7 +130,7 @@ class DockerformTest : BaseformTest() {
         val bankOfCordaConfig = ConfigFactory.parseFile(bankOfCordaConfigPath.toFile())
         assertTrue(bankOfCordaConfig.hasPath("rpcSettings.address"))
         assertTrue(bankOfCordaConfig.hasPath("rpcSettings.adminAddress"))
-        assertEquals(ConfigurationUtils.parsePort(bankOfCordaConfig.getString("rpcSettings.address")), 10006)
-        assertEquals(ConfigurationUtils.parsePort(bankOfCordaConfig.getString("rpcSettings.adminAddress")), 10046)
+        assertEquals(10006, ConfigurationUtils.parsePort(bankOfCordaConfig.getString("rpcSettings.address")))
+        assertEquals(10046, ConfigurationUtils.parsePort(bankOfCordaConfig.getString("rpcSettings.adminAddress")))
     }
 }

--- a/cordformation/src/test/kotlin/net/corda/plugins/DockerformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/DockerformTest.kt
@@ -93,4 +93,18 @@ class DockerformTest : BaseformTest() {
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile()
         assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile()
     }
+
+    @Test
+    fun `deploy two nodes with cordapp dependencies`() {
+        val runner = getStandardGradleRunnerFor(
+                "DeployTwoNodeCordappWithDocker.gradle",
+                "prepareDockerNodes")
+
+        val result = runner.build()
+
+        assertThat(result.task(":prepareDockerNodes")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile()
+        assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile()
+    }
 }

--- a/cordformation/src/test/kotlin/net/corda/plugins/DockerformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/DockerformTest.kt
@@ -102,9 +102,14 @@ class DockerformTest : BaseformTest() {
 
         val result = runner.build()
 
+        val bankOfCordaNodeName = "BankOfCorda"
+
         assertThat(result.task(":prepareDockerNodes")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile()
         assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile()
+        assertThat(getNodeCordappJar(bankOfCordaNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
+        assertThat(getNodeCordappJar(bankOfCordaNodeName, cordaFinanceContractsJarName)).isRegularFile()
+        assertThat(getNetworkParameterOverrides(bankOfCordaNodeName)).isRegularFile()
     }
 }

--- a/cordformation/src/test/resources/net/corda/plugins/DeployTwoNodeCordappWithDocker.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeployTwoNodeCordappWithDocker.gradle
@@ -1,0 +1,42 @@
+plugins {
+    id 'net.corda.plugins.cordformation'
+}
+
+apply from: 'repositories.gradle'
+
+dependencies {
+    cordaRuntime "$corda_group:corda:$corda_release_version"
+    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
+    cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
+    cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
+}
+
+task prepareDockerNodes(type: net.corda.plugins.Dockerform, dependsOn: ['jar']) {
+    nodeDefaults {
+
+        cordapps = ["$corda_group:corda-finance-contracts:$corda_release_version",
+                    "$corda_group:corda-finance-workflows:$corda_release_version"]
+
+        projectCordapp {
+            deploy false
+        }
+    }
+    node {
+        name "O=Notary,L=London,C=GB"
+        notary = [validating : false]
+        p2pPort 10002
+        rpcSettings {
+            address("localhost:10003")
+            adminAddress("localhost:10043")
+        }
+    }
+    node {
+        name "O=Users,L=London,C=GB"
+        p2pPort 10005
+        rpcSettings {
+            address("localhost:10006")
+            adminAddress("localhost:10046")
+        }
+        rpcUsers = [[ user: "user1", "password": "test", "permissions": ["ALL"]]]
+    }
+}

--- a/cordformation/src/test/resources/net/corda/plugins/DeployTwoNodeCordappWithDocker.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeployTwoNodeCordappWithDocker.gradle
@@ -22,7 +22,7 @@ task prepareDockerNodes(type: net.corda.plugins.Dockerform, dependsOn: ['jar']) 
         }
     }
     node {
-        name "O=Notary,L=London,C=GB"
+        name "O=Notary Service,L=London,C=GB"
         notary = [validating : false]
         p2pPort 10002
         rpcSettings {
@@ -31,7 +31,7 @@ task prepareDockerNodes(type: net.corda.plugins.Dockerform, dependsOn: ['jar']) 
         }
     }
     node {
-        name "O=Users,L=London,C=GB"
+        name "O=BankOfCorda,L=London,C=GB"
         p2pPort 10005
         rpcSettings {
             address("localhost:10006")


### PR DESCRIPTION
Dockerform allocates predefined port numbers instead of using the ones specified in the `node.conf`. Users should be allowed to specify those ports