### PR TITLE
ENT-5258 Handle db migration in Cordform

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ### Version 5.0.10
 
+* `cordformation`: Add properties `runSchemaMigration` and `allowHibernateToManageAppSchema` in order to run schema 
+migration/set-up as part of a cordform deployment (only supported in Corda 4.6 and later)
 * `cordformation`: Made Dockerform's dockerImage property mandatory to avoid using hardcoded default Docker images
 
 ### Version 5.0.9

--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -145,10 +145,11 @@ open class Node @Inject constructor(private val project: Project) {
         @Optional @Input get
         private set
 
-    // Should the cordform set up run data base migration scripts after installation
+    // Should the cordform set up run data base migration scripts after installation - defaults to false for compatibility
+    // with current and previous Corda versions
     @get:Optional
     @get:Input
-    var runSchemaMigration: Boolean = true
+    var runSchemaMigration: Boolean = false
 
     // If generating schemas, should app schema be generated using hibernate if missing migration scripts
     @get:Optional

--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -5,7 +5,6 @@ import groovy.lang.Closure
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
-import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
@@ -505,7 +504,7 @@ open class Node @Inject constructor(private val project: Project) {
         runNodeJob(createSchemasCmd(), "node-schema-cordform.log")
     }
 
-    val LOGS_DIR_NAME: String = "logs"
+    private val LOGS_DIR_NAME: String = "logs"
 
     private fun runNodeJob(command: List<String>, logfileName: String) {
         val logsDir = Files.createDirectories(nodeDir.toPath().resolve(LOGS_DIR_NAME))

--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -150,17 +150,17 @@ open class Node @Inject constructor(private val project: Project) {
     // with current and previous Corda versions
     @get:Optional
     @get:Input
-    var runSchemaMigration: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType).convention(false)
+    val runSchemaMigration: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType).convention(false)
 
     // If generating schemas, should app schema be generated using hibernate if missing migration scripts
     @get:Optional
     @get:Input
-    var allowHibernateToManageAppSchema: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType).convention(false)
+    val allowHibernateToManageAppSchema: Property<Boolean> = project.objects.property(Boolean::class.javaObjectType).convention(false)
 
     //Configure the timeout for schema generation runtime
     @get:Optional
-    @get:Input
-    var nodeJobTimeOut: Property<Long> = project.objects.property(Long::class.javaObjectType).convention(3)
+    @get:Internal
+    val nodeJobTimeOut: Property<Long> = project.objects.property(Long::class.javaObjectType).convention(3)
 
     /**
      * Set the name of the node.
@@ -529,7 +529,7 @@ open class Node @Inject constructor(private val project: Project) {
         }
     }
 
-    private fun printNodeOutputAndThrow(stdoutFile: File) {
+    private fun printNodeOutputAndThrow(stdoutFile: File): Nothing {
         project.logger.error("#### Error while generating node info file $name ####")
         project.logger.error(stdoutFile.readText())
         throw IllegalStateException("Error while generating node info file. Please check the logs in ${stdoutFile.parent}.")

--- a/cordformation/src/test/kotlin/net/corda/plugins/BaseformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/BaseformTest.kt
@@ -54,6 +54,7 @@ open class BaseformTest {
         } ?: throw FileNotFoundException(resourceName)
     }
 
+    fun getNodeLogFile( nodeName: String, fileName: String ) = Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "nodes", nodeName, "logs", "$fileName")
     fun getNodeCordappJar(nodeName: String, cordappJarName: String) = Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "nodes", nodeName, "cordapps", "$cordappJarName.jar")
     fun getNodeCordappConfig(nodeName: String, cordappJarName: String) = Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "nodes", nodeName, "cordapps", "config", "$cordappJarName.conf")
     fun getNetworkParameterOverrides(nodeName: String) = Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "nodes", nodeName, "network-parameters")

--- a/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
@@ -51,6 +51,18 @@ class CordformTest : BaseformTest() {
     }
 
     @Test
+    fun `a node that requires an extra command to create schema`(){
+        val runner = getStandardGradleRunnerFor("DeploySingleNodeWithExtraCommandForDbSchema.gradle")
+
+        val result = runner.build()
+
+        assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(getNodeLogFile(notaryNodeName, "node-run-migration.log")).isRegularFile()
+        assertThat(getNodeLogFile(notaryNodeName, "node-schema-cordform.log")).isRegularFile()
+        assertThat(getNodeLogFile(notaryNodeName, "node-info-gen.log")).isRegularFile()
+    }
+
+    @Test
     fun `a node with cordapp dependency`() {
         val runner = getStandardGradleRunnerFor("DeploySingleNodeWithCordapp.gradle")
 

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithExtraCommandForDbSchema.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithExtraCommandForDbSchema.gradle
@@ -1,0 +1,41 @@
+buildscript {
+    ext {
+        corda_group = 'net.corda'
+        corda_release_version = '4.6-20200519_115923-a2be3e8'
+        jolokia_version = '1.6.0'
+    }
+}
+
+plugins {
+    id 'net.corda.plugins.cordformation'
+}
+
+repositories {
+    mavenCentral()
+    maven { url 'https://software.r3.com/artifactory/corda-dev' }
+    maven { url 'https://software.r3.com/artifactory/corda-dependencies' }
+}
+
+dependencies {
+    runtime "$corda_group:corda:$corda_release_version"
+    runtime "$corda_group:corda-node-api:$corda_release_version"
+    cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
+    cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
+}
+
+task deployNodes(type: net.corda.plugins.Cordform) {
+    node {
+        projectCordapp {
+            deploy false
+        }
+        name 'O=Notary Service,L=Zurich,C=CH'
+        notary = [validating : true]
+        p2pPort 10002
+        rpcPort 10003
+        rpcSettings {
+            adminAddress "localhost:10004"
+        }
+        runSchemaMigration = true
+        allowHibernateToManageAppSchema = true
+    }
+}

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithExtraCommandForDbSchema.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithExtraCommandForDbSchema.gradle
@@ -1,8 +1,6 @@
 buildscript {
     ext {
-        corda_group = 'net.corda'
         corda_release_version = '4.6-20200519_115923-a2be3e8'
-        jolokia_version = '1.6.0'
     }
 }
 
@@ -17,8 +15,8 @@ repositories {
 }
 
 dependencies {
-    runtime "$corda_group:corda:$corda_release_version"
-    runtime "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntime "$corda_group:corda:$corda_release_version"
+    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
 }


### PR DESCRIPTION
In Corda 4.6, database schema migration/set-up will have to be run explicitly via a new subcommand - this change brings in the code to do this during cordformation, currently guarded behind a property that defaults to off.