### PR TITLE
ENT-5364: Added ACCEPT_LICENSE environment variable

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 ### Version 5.0.10
 
+* `cordformation`: Add option to accept license agreements for Corda enterprise Docker images 
 * `cordformation`: Add properties `runSchemaMigration` and `allowHibernateToManageAppSchema` in order to run schema 
 migration/set-up as part of a cordform deployment (only supported in Corda 4.6 and later)
 * `cordformation`: Made Dockerform's dockerImage property mandatory to avoid using hardcoded default Docker images

--- a/cordformation/src/main/kotlin/net/corda/plugins/Dockerform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Dockerform.kt
@@ -99,6 +99,7 @@ open class Dockerform @Inject constructor(objects: ObjectFactory) : Baseform(obj
                             "$nodeBuildDir/additional-node-infos:/opt/corda/additional-node-infos",
                             "$nodeBuildDir/drivers:/opt/corda/drivers"
                     ),
+                    "environment" to listOf("ACCEPT_LICENSE=\${ACCEPT_LICENSE}"),
                     "ports" to listOf(it.rpcPort.get(), it.config.getInt("sshd.port")),
                     "image" to dockerImage.get()
             )


### PR DESCRIPTION
This change allows ACCEPT_LICENSE environment variable to be passed to the Corda Docker Image. This variable is important for the ENT version and has no effect on the OS version. 