### PR TITLE
NOTICK: Make Gradle scripts for cordformation tests consistent.

### DIFF
--- a/cordformation/src/test/resources/gradle.properties
+++ b/cordformation/src/test/resources/gradle.properties
@@ -5,3 +5,5 @@ corda_group=net.corda
 corda_release_version=4.0
 jolokia_version=1.6.0
 docker_image_name=corda/corda-zulu-4.0
+
+slf4j_version=1.7.26

--- a/cordformation/src/test/resources/net/corda/plugins/DeployDockerImage.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeployDockerImage.gradle
@@ -1,10 +1,3 @@
-buildscript {
-    ext {
-        corda_group = 'net.corda'
-        corda_release_version = '4.0'
-    }
-}
-
 plugins {
     id 'net.corda.plugins.cordformation'
 }
@@ -18,10 +11,11 @@ repositories {
 }
 
 dependencies {
-    runtimeOnly "$corda_group:corda:$corda_release_version"
-    runtimeOnly "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntime "$corda_group:corda:$corda_release_version"
+    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
+    runtimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 def dockerImage = tasks.register('dockerImage', net.corda.plugins.DockerImage) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordapp.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordapp.gradle
@@ -1,11 +1,3 @@
-buildscript {
-    ext {
-        corda_group = 'net.corda'
-        corda_release_version = '4.0'
-        jolokia_version = '1.6.0'
-    }
-}
-
 plugins {
     id 'net.corda.plugins.cordformation'
 }
@@ -13,10 +5,11 @@ plugins {
 apply from: 'repositories.gradle'
 
 dependencies {
-    runtime "$corda_group:corda:$corda_release_version"
-    runtime "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntime "$corda_group:corda:$corda_release_version"
+    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
+    runtimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappBackwardsCompatibility.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappBackwardsCompatibility.gradle
@@ -1,11 +1,3 @@
-buildscript {
-    ext {
-        corda_group = 'net.corda'
-        corda_release_version = '4.0'
-        jolokia_version = '1.6.0'
-    }
-}
-
 plugins {
     id 'net.corda.plugins.cordformation'
 }
@@ -13,10 +5,11 @@ plugins {
 apply from: 'repositories.gradle'
 
 dependencies {
-    runtime "$corda_group:corda:$corda_release_version"
-    runtime "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntime "$corda_group:corda:$corda_release_version"
+    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
+    runtimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappConfig.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappConfig.gradle
@@ -1,11 +1,3 @@
-buildscript {
-    ext {
-        corda_group = 'net.corda'
-        corda_release_version = '4.0'
-        jolokia_version = '1.6.0'
-    }
-}
-
 plugins {
     id 'net.corda.plugins.cordformation'
 }
@@ -13,10 +5,11 @@ plugins {
 apply from: 'repositories.gradle'
 
 dependencies {
-    runtime "$corda_group:corda:$corda_release_version"
-    runtime "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntime "$corda_group:corda:$corda_release_version"
+    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
+    runtimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappWithOU.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappWithOU.gradle
@@ -1,11 +1,3 @@
-buildscript {
-    ext {
-        corda_group = 'net.corda'
-        corda_release_version = '4.0'
-        jolokia_version = '1.6.0'
-    }
-}
-
 plugins {
     id 'net.corda.plugins.cordformation'
 }
@@ -13,10 +5,11 @@ plugins {
 apply from: 'repositories.gradle'
 
 dependencies {
-    runtime "$corda_group:corda:$corda_release_version"
-    runtime "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntime "$corda_group:corda:$corda_release_version"
+    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
+    runtimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
@@ -1,11 +1,3 @@
-buildscript {
-    ext {
-        corda_group = 'net.corda'
-        corda_release_version = '4.0'
-        jolokia_version = '1.6.0'
-    }
-}
-
 plugins {
     id 'net.corda.plugins.cordformation'
 }
@@ -13,8 +5,9 @@ plugins {
 apply from: 'repositories.gradle'
 
 dependencies {
-    runtime "$corda_group:corda:$corda_release_version"
-    runtime "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntime "$corda_group:corda:$corda_release_version"
+    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
+    runtimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 jar {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithNetworkParameterOverrides.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithNetworkParameterOverrides.gradle
@@ -1,12 +1,7 @@
-import java.nio.file.Paths
-
 buildscript {
     ext {
-        corda_group = 'net.corda'
         corda_release_version = '4.3'
         finance_release_version = '4.0'
-        jolokia_version = '1.6.0'
-        slf4j_version = '1.7.26'
     }
 }
 
@@ -17,8 +12,8 @@ plugins {
 apply from: 'repositories.gradle'
 
 dependencies {
-    runtime "$corda_group:corda:$corda_release_version"
-    runtime "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntime "$corda_group:corda:$corda_release_version"
+    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$finance_release_version"
     cordapp "$corda_group:corda-finance-workflows:$finance_release_version"
     runtimeOnly "org.slf4j:slf4j-simple:$slf4j_version"


### PR DESCRIPTION
- Use common `gradle.properties` instead of `buildscript` wherever possible.
- Replace deprecated `runtime` configuration with `cordaRuntime`
- Provide simple SLF4J implementation for Network Bootstrapper.