### PR TITLE
[CORDA-3829] extended NetworkParameterOverrides object

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * `cordformation`: Add properties `runSchemaMigration` and `allowHibernateToManageAppSchema` in order to run schema 
 migration/set-up as part of a cordform deployment (only supported in Corda 4.6 and later)
 * `cordformation`: Made Dockerform's dockerImage property mandatory to avoid using hardcoded default Docker images
+* `cordformation`: Added `minimumPlatformVersion`, `maxMessageSize`, `maxTransactionSize` and `eventHorizon` to `NetworkParameterOverrides`
 
 ### Version 5.0.9
 

--- a/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
@@ -283,7 +283,7 @@ open class Baseform(objects: ObjectFactory) : DefaultTask() {
 
     private fun invokeBootstrap(networkBootstrapperClass: Class<*>, rootDir: Path, allCordapps: List<Path>) {
         try {
-            if (networkParameterOverrides.packageOwnership.isEmpty()) {
+            if (networkParameterOverrides.isEmpty()) {
                 val bootstrapMethod = networkBootstrapperClass.getMethod("bootstrapCordform", Path::class.java, List::class.java).apply { isAccessible = true }
                 bootstrapMethod.invoke(networkBootstrapperClass.newInstance(), rootDir, allCordapps)
             } else {

--- a/cordformation/src/main/kotlin/net/corda/plugins/NetworkParameterOverrides.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/NetworkParameterOverrides.kt
@@ -1,16 +1,29 @@
 package net.corda.plugins
 
-import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
-import com.typesafe.config.ConfigObject
-import com.typesafe.config.ConfigValueFactory
+import com.typesafe.config.*
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
+import java.time.Duration
 import javax.inject.Inject
 
 open class NetworkParameterOverrides @Inject constructor(project: Project) {
+
+    @get:Optional
+    @get:Input
+    val minimumPlatformVersion: Property<Int> = project.objects.property(Int::class.java)
+
+    @get:Optional
+    @get:Input
+    val maxMessageSize: Property<Int> = project.objects.property(Int::class.java)
+
+    @get:Optional
+    @get:Input
+    val maxTransactionSize: Property<Int> = project.objects.property(Int::class.java)
 
     @get:Nested
     val packageOwnership: NamedDomainObjectContainer<PackageOwnership> = project.container(PackageOwnership::class.java)
@@ -19,11 +32,29 @@ open class NetworkParameterOverrides @Inject constructor(project: Project) {
         action.execute(packageOwnership)
     }
 
-    fun toConfig(): Config {
-        val packageOwnershipsList = mutableListOf<ConfigObject>()
-        packageOwnership.forEach { packageOwnershipsList.add(it.toConfigObject()) }
-        val packageOwnershipsConfigObjectList = ConfigValueFactory.fromIterable(packageOwnershipsList)
+    @get:Optional
+    @get:Input
+    val eventHorizon: Property<Duration> = project.objects.property(Duration::class.java)
 
-        return ConfigFactory.empty().withValue("networkParameterOverrides", ConfigValueFactory.fromMap(mapOf("packageOwnership" to packageOwnershipsConfigObjectList)))
+    fun isEmpty() = !minimumPlatformVersion.isPresent &&
+            !maxMessageSize.isPresent &&
+            !maxTransactionSize.isPresent &&
+            packageOwnership.isEmpty() &&
+            !eventHorizon.isPresent
+
+    fun toConfig(): Config {
+        val map = sequenceOf(
+            "eventHorizon" to eventHorizon.orNull,
+            "packageOwnership" to packageOwnership
+                    .takeIf (NamedDomainObjectContainer<PackageOwnership>::isNotEmpty)
+                    ?.let { po -> ConfigValueFactory.fromIterable(po.map { it.toConfigObject() }) },
+            "minimumPlatformVersion" to minimumPlatformVersion.orNull,
+            "maxMessageSize" to maxMessageSize.orNull,
+            "maxTransactionSize" to maxTransactionSize.orNull
+        ).filter { it.second != null }.toMap()
+
+        return ConfigFactory.empty().withValue("networkParameterOverrides",
+                ConfigValueFactory.fromMap(map)
+        )
     }
 }

--- a/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
@@ -11,7 +11,9 @@ import net.corda.serialization.internal.AMQP_P2P_CONTEXT
 import net.corda.serialization.internal.SerializationFactoryImpl
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import java.time.Duration
 
 class CordformTest : BaseformTest() {
     @Test
@@ -34,8 +36,13 @@ class CordformTest : BaseformTest() {
                 AMQP_P2P_CONTEXT)
         )
         val serializedBytes = SerializedBytes<SignedDataWithCert<NetworkParameters>>(getNetworkParameterOverrides(notaryNodeName).toFile().readBytes())
-        val deserialized = serializedBytes.deserialize(SerializationDefaults.SERIALIZATION_FACTORY).raw.deserialize().packageOwnership
-        assertThat(deserialized.containsKey("com.mypackagename")).isTrue()
+        val deserializedNetworkParameterOverrides = serializedBytes.deserialize(SerializationDefaults.SERIALIZATION_FACTORY).raw.deserialize()
+        val deserializedPackageOwnership = deserializedNetworkParameterOverrides.packageOwnership
+        assertThat(deserializedPackageOwnership.containsKey("com.mypackagename")).isTrue()
+        Assertions.assertEquals(Duration.ofDays(2), deserializedNetworkParameterOverrides.eventHorizon)
+        Assertions.assertEquals(123456, deserializedNetworkParameterOverrides.maxMessageSize)
+        Assertions.assertEquals(2468, deserializedNetworkParameterOverrides.maxTransactionSize)
+        Assertions.assertEquals(3, deserializedNetworkParameterOverrides.minimumPlatformVersion)
     }
 
     @Test

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithNetworkParameterOverrides.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithNetworkParameterOverrides.gradle
@@ -1,3 +1,5 @@
+import java.time.Duration
+
 buildscript {
     ext {
         corda_release_version = '4.3'
@@ -28,6 +30,10 @@ task deployNodes(type: net.corda.plugins.Cordform) {
                 keystoreAlias = "MyKeyAlias"
             }
         }
+        minimumPlatformVersion = 3
+        eventHorizon = Duration.ofDays(2)
+        maxMessageSize = 123456
+        maxTransactionSize = 2468
     }
     node {
         projectCordapp {


### PR DESCRIPTION
extended `NetworkParameterOverrides` object to support `minimumPlatformVersion`, `maxMessageSize`, `maxTransactionSize` and `eventHorizon`
