### PR TITLE
ENT-5316 Add extra parameters for app and core schema

### DIFF
--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -496,6 +496,8 @@ open class Node @Inject constructor(private val project: Project) {
             "-jar",
             "corda.jar",
             "run-migration-scripts",
+            "--core-schemas",
+            "--app-schemas",
             if (allowHibernateToManageAppSchema) "--allow-hibernate-to-manage-app-schema" else null)
 
     private fun runSchemaMigration(){

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithExtraCommandForDbSchema.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithExtraCommandForDbSchema.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        corda_release_version = '4.6-20200519_115923-a2be3e8'
+        corda_release_version = '4.6-20200608_123659-1da174c'
     }
 }
 


### PR DESCRIPTION
Add cmd line paramters to the runMigrationScripts job so that the node creates all the app and core schemas as part of the bootstrapping in CordFormation.