### PR TITLE
CORDA-3838: Make cordapp plugin properties lazy.

### DIFF
--- a/cordapp/src/main/kotlin/net/corda/plugins/CordappData.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/CordappData.kt
@@ -1,16 +1,42 @@
 package net.corda.plugins
 
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import javax.inject.Inject
 
-open class CordappData {
+@Suppress("UnstableApiUsage", "Unused")
+open class CordappData @Inject constructor(objects: ObjectFactory) {
     @get:Input
-    var name: String? = null
+    val name: Property<String> = objects.property(String::class.java)
+
     /** relaxed type so users can specify Integer or String identifiers */
     @get:Input
-    var versionId: Int? = null
+    val versionId: Property<Int> = objects.property(Int::class.java)
+
     @get:Input
-    var vendor: String? = null
+    val vendor: Property<String> = objects.property(String::class.java)
+
     @get:Input
-    var licence: String? = null
-    internal fun isEmpty(): Boolean = (name == null && versionId == null && vendor == null && licence == null)
+    val licence: Property<String> = objects.property(String::class.java)
+
+    @Internal
+    internal fun isEmpty(): Boolean = (!name.isPresent && !versionId.isPresent && !vendor.isPresent && !licence.isPresent)
+
+    fun name(value: String?) {
+        name.set(value)
+    }
+
+    fun versionId(value: Int?) {
+        versionId.set(value)
+    }
+
+    fun vendor(value: String?) {
+        vendor.set(value)
+    }
+
+    fun licence(value: String?) {
+        licence.set(value)
+    }
 }

--- a/cordapp/src/main/kotlin/net/corda/plugins/CordappExtension.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/CordappExtension.kt
@@ -2,20 +2,13 @@ package net.corda.plugins
 
 import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
 import javax.inject.Inject
 
+@Suppress("UnstableApiUsage", "Unused", "Deprecation")
 open class CordappExtension @Inject constructor(objectFactory: ObjectFactory)  {
-
-    /**
-     * Top-level CorDapp attributes
-     */
-    @get:Input
-    var targetPlatformVersion: Int? = null
-
-    @get:Input
-    var minimumPlatformVersion: Int? = null
 
     /**
      * CorDapp distribution information (deprecated)
@@ -23,6 +16,15 @@ open class CordappExtension @Inject constructor(objectFactory: ObjectFactory)  {
     @Deprecated("Use top-level attributes and specific Contract and Workflow info objects")
     @get:Nested
     val info: Info = objectFactory.newInstance(Info::class.java)
+
+    /**
+     * Top-level CorDapp attributes
+     */
+    @get:Input
+    val targetPlatformVersion: Property<Int> = objectFactory.property(Int::class.java).convention(info.targetPlatformVersion)
+
+    @get:Input
+    val minimumPlatformVersion: Property<Int> = objectFactory.property(Int::class.java).convention(info.minimumPlatformVersion)
 
     /**
      * CorDapp Contract distribution information.
@@ -66,5 +68,13 @@ open class CordappExtension @Inject constructor(objectFactory: ObjectFactory)  {
 
     fun sealing(action: Action<in Sealing>) {
         action.execute(sealing)
+    }
+
+    fun targetPlatformVersion(value: Int?) {
+        targetPlatformVersion.set(value)
+    }
+
+    fun minimumPlatformVersion(value: Int?) {
+        minimumPlatformVersion.set(value)
     }
 }

--- a/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
@@ -8,27 +8,38 @@ import org.gradle.api.artifacts.Dependency
 import org.gradle.api.java.archives.Attributes
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.provider.Property
 import org.gradle.api.publish.maven.tasks.GenerateMavenPom
 import org.gradle.api.tasks.bundling.ZipEntryCompression.DEFLATED
 import org.gradle.jvm.tasks.Jar
 import java.io.File
+import java.util.Collections.unmodifiableSet
 import javax.inject.Inject
 
 /**
  * The Cordapp plugin will turn a project into a cordapp project which builds cordapp JARs with the correct format
  * and with the information needed to run on Corda.
  */
-@Suppress("UNUSED")
+@Suppress("UNUSED", "UnstableApiUsage", "Deprecation")
 class CordappPlugin @Inject constructor(private val objects: ObjectFactory): Plugin<Project> {
     private companion object {
         private const val UNKNOWN = "Unknown"
         private const val MIN_GRADLE_VERSION = "4.0"
+
+        private val HARDCODED_EXCLUDES: Set<Pair<String, String>> = unmodifiableSet(setOf(
+            "org.jetbrains.kotlin" to "kotlin-stdlib",
+            "org.jetbrains.kotlin" to "kotlin-stdlib-jre8",
+            "org.jetbrains.kotlin" to "kotlin-stdlib-jdk8",
+            "org.jetbrains.kotlin" to "kotlin-reflect",
+            "co.paralleluniverse" to "quasar-core"
+        ))
     }
 
     /**
      * CorDapp's information.
      */
-    lateinit var cordapp: CordappExtension
+    internal lateinit var cordapp: CordappExtension
+        private set
 
     override fun apply(project: Project) {
         project.logger.info("Configuring ${project.name} as a cordapp")
@@ -55,7 +66,6 @@ class CordappPlugin @Inject constructor(private val objects: ObjectFactory): Plu
      */
     private fun configureCordappJar(project: Project) {
         // Note: project.afterEvaluate did not have full dependency resolution completed, hence a task is used instead
-        val cordappTask = project.task("configureCordappFatJar")
         val jarTask = project.tasks.getByName("jar") as Jar
         jarTask.fileMode = Integer.parseInt("444", 8)
         jarTask.dirMode = Integer.parseInt("555", 8)
@@ -75,9 +85,10 @@ class CordappPlugin @Inject constructor(private val objects: ObjectFactory): Plu
                 configureCordappAttributes(project, jarTask, attributes)
             }
         }.doLast {
-            sign(project, cordapp.signing, it.outputs.files.singleFile)
+            sign(project, cordapp.signing, it.outputs.files.singleFile, cordapp.signing.enabled.get())
         }
 
+        val cordappTask = project.task("configureCordappFatJar")
         cordappTask.doLast {
             jarTask.from(getDirectNonCordaDependencies(project).map { file ->
                 it.logger.info("CorDapp dependency: ${file.name}")
@@ -97,20 +108,21 @@ class CordappPlugin @Inject constructor(private val objects: ObjectFactory): Plu
     }
 
     private fun configureCordappAttributes(project: Project, jarTask: Jar, attributes: Attributes) {
+        val defaultName = "${project.group}.${jarTask.archiveBaseName.get()}"
         var skip = false
         // Corda 4 attributes support
         if (!cordapp.contract.isEmpty()) {
-            attributes["Cordapp-Contract-Name"] = cordapp.contract.name ?: "${project.group}.${jarTask.baseName}"
+            attributes["Cordapp-Contract-Name"] = cordapp.contract.name.getOrElse(defaultName)
             attributes["Cordapp-Contract-Version"] = checkCorDappVersionId(cordapp.contract.versionId)
-            attributes["Cordapp-Contract-Vendor"] = cordapp.contract.vendor ?: UNKNOWN
-            attributes["Cordapp-Contract-Licence"] = cordapp.contract.licence ?: UNKNOWN
+            attributes["Cordapp-Contract-Vendor"] = cordapp.contract.vendor.getOrElse(UNKNOWN)
+            attributes["Cordapp-Contract-Licence"] = cordapp.contract.licence.getOrElse(UNKNOWN)
             skip = true
         }
         if (!cordapp.workflow.isEmpty()) {
-            attributes["Cordapp-Workflow-Name"] = cordapp.workflow.name ?: "${project.group}.${jarTask.baseName}"
+            attributes["Cordapp-Workflow-Name"] = cordapp.workflow.name.getOrElse(defaultName)
             attributes["Cordapp-Workflow-Version"] = checkCorDappVersionId(cordapp.workflow.versionId)
-            attributes["Cordapp-Workflow-Vendor"] = cordapp.workflow.vendor ?: UNKNOWN
-            attributes["Cordapp-Workflow-Licence"] = cordapp.workflow.licence ?: UNKNOWN
+            attributes["Cordapp-Workflow-Vendor"] = cordapp.workflow.vendor.getOrElse(UNKNOWN)
+            attributes["Cordapp-Workflow-Licence"] = cordapp.workflow.licence.getOrElse(UNKNOWN)
             skip = true
         }
         // Deprecated support (Corda 3)
@@ -118,15 +130,15 @@ class CordappPlugin @Inject constructor(private val objects: ObjectFactory): Plu
             if (skip) {
                 project.logger.warn("Ignoring deprecated 'info' attributes. Using 'contract' and 'workflow' attributes.")
             } else {
-                attributes["Name"] = cordapp.info.name ?: "${project.group}.${jarTask.baseName}"
-                attributes["Implementation-Version"] = cordapp.info.version ?: project.version
-                attributes["Implementation-Vendor"] = cordapp.info.vendor ?: UNKNOWN
+                attributes["Name"] = cordapp.info.name.getOrElse(defaultName)
+                attributes["Implementation-Version"] = cordapp.info.version.getOrElse(project.version.toString())
+                attributes["Implementation-Vendor"] = cordapp.info.vendor.getOrElse(UNKNOWN)
             }
         }
         val (targetPlatformVersion, minimumPlatformVersion) = checkPlatformVersionInfo()
         attributes["Target-Platform-Version"] = targetPlatformVersion
         attributes["Min-Platform-Version"] = minimumPlatformVersion
-        if (cordapp.sealing.enabled) {
+        if (cordapp.sealing.enabled.get()) {
             attributes["Sealed"] = "true"
         }
     }
@@ -152,20 +164,8 @@ class CordappPlugin @Inject constructor(private val objects: ObjectFactory): Plu
                 project.configuration("cordaRuntime").allDependencies
     }
 
-    private fun hardCodedExcludes(): Set<Pair<String, String>>{
-        val excludes = setOf(
-            ("org.jetbrains.kotlin"  to "kotlin-stdlib"),
-            ("org.jetbrains.kotlin" to "kotlin-stdlib-jre8"),
-            ("org.jetbrains.kotlin" to "kotlin-stdlib-jdk8"),
-            ("org.jetbrains.kotlin" to "kotlin-reflect"),
-            ("co.paralleluniverse" to "quasar-core")
-        )
-        return excludes
-    }
-
     private fun getDirectNonCordaDependencies(project: Project): Set<File> {
         project.logger.info("Finding direct non-corda dependencies for inclusion in CorDapp JAR")
-        val excludes = hardCodedExcludes()
 
         val runtimeConfiguration = project.configuration("runtime")
         // The direct dependencies of this project
@@ -173,7 +173,7 @@ class CordappPlugin @Inject constructor(private val objects: ObjectFactory): Plu
         val directDeps = runtimeConfiguration.allDependencies - excludeDeps
         // We want to filter out anything Corda related or provided by Corda, like kotlin-stdlib and quasar
         val filteredDeps = directDeps.filter { dep ->
-            excludes.none { exclude -> (exclude.first == dep.group) && (exclude.second == dep.name) }
+            HARDCODED_EXCLUDES.none { exclude -> (exclude.first == dep.group) && (exclude.second == dep.name) }
         }
         filteredDeps.forEach {
             // net.corda or com.r3.corda.enterprise may be a core dependency which shouldn't be included in this cordapp so give a warning
@@ -193,9 +193,9 @@ class CordappPlugin @Inject constructor(private val objects: ObjectFactory): Plu
 
     private fun checkPlatformVersionInfo(): Pair<Int, Int> {
         // If the minimum platform version is not set, default to 1.
-        val minimumPlatformVersion: Int = cordapp.minimumPlatformVersion ?: cordapp.info.minimumPlatformVersion ?: 1
-        val targetPlatformVersion = cordapp.targetPlatformVersion ?: cordapp.info.targetPlatformVersion
-        ?: throw InvalidUserDataException("CorDapp `targetPlatformVersion` was not specified in the `cordapp` metadata section.")
+        val minimumPlatformVersion: Int = cordapp.minimumPlatformVersion.getOrElse(1)
+        val targetPlatformVersion = cordapp.targetPlatformVersion.orNull
+            ?: throw InvalidUserDataException("CorDapp `targetPlatformVersion` was not specified in the `cordapp` metadata section.")
         if (targetPlatformVersion < 1) {
             throw InvalidUserDataException("CorDapp `targetPlatformVersion` must not be smaller than 1.")
         }
@@ -205,16 +205,17 @@ class CordappPlugin @Inject constructor(private val objects: ObjectFactory): Plu
         return Pair(targetPlatformVersion, minimumPlatformVersion)
     }
 
-    private fun checkCorDappVersionId(versionId: Int?): Int {
-        if (versionId == null)
+    private fun checkCorDappVersionId(versionId: Property<Int>): Int {
+        if (!versionId.isPresent)
             throw InvalidUserDataException("CorDapp `versionId` was not specified in the associated `contract` or `workflow` metadata section. Please specify a whole number starting from 1.")
-        else if (versionId < 1) {
+        val value = versionId.get()
+        if (value < 1) {
             throw InvalidUserDataException("CorDapp `versionId` must not be smaller than 1.")
         }
-        return versionId
+        return value
     }
 
     private fun Iterable<Dependency>.toUniqueFiles(configuration: Configuration): Set<File> {
-        return map { configuration.files(it) }.flatten().toSet()
+        return flatMapTo(LinkedHashSet()) { configuration.files(it) }
     }
 }

--- a/cordapp/src/main/kotlin/net/corda/plugins/Info.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/Info.kt
@@ -1,18 +1,57 @@
 package net.corda.plugins
 
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import javax.inject.Inject
 
 @Deprecated("Use top-level attributes and specific Contract and Workflow info objects")
-open class Info {
+@Suppress("UnstableApiUsage", "Unused")
+open class Info @Inject constructor(objects: ObjectFactory) {
+    @get:Optional
     @get:Input
-    var name: String? = null
+    val name: Property<String> = objects.property(String::class.java)
+
+    @get:Optional
     @get:Input
-    var version: String? = null
+    val version: Property<String> = objects.property(String::class.java)
+
+    @get:Optional
     @get:Input
-    var vendor: String? = null
+    val vendor: Property<String> = objects.property(String::class.java)
+
+    @get:Optional
     @get:Input
-    var targetPlatformVersion: Int? = null
+    val targetPlatformVersion: Property<Int> = objects.property(Int::class.java)
+
+    @get:Optional
     @get:Input
-    var minimumPlatformVersion: Int? = null
-    internal fun isEmpty() : Boolean = (name == null && version == null && vendor == null && targetPlatformVersion == null && minimumPlatformVersion == null)
+    val minimumPlatformVersion: Property<Int> = objects.property(Int::class.java)
+
+    @Internal
+    internal fun isEmpty() : Boolean = (!name.isPresent && !version.isPresent && !vendor.isPresent
+            && !targetPlatformVersion.isPresent
+            && !minimumPlatformVersion.isPresent)
+
+    fun name(value: String?) {
+        name.set(value)
+    }
+
+    fun version(value: String?) {
+        version.set(value)
+    }
+
+    fun vendor(value: String?) {
+        vendor.set(value)
+    }
+
+    fun targetPlatformVersion(value: Int?) {
+        targetPlatformVersion.set(value)
+    }
+
+    fun minimumPlatformVersion(value: Int?) {
+        minimumPlatformVersion.set(value)
+    }
 }

--- a/cordapp/src/main/kotlin/net/corda/plugins/Sealing.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/Sealing.kt
@@ -1,17 +1,22 @@
 package net.corda.plugins
 
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import javax.inject.Inject
 
-open class Sealing {
+@Suppress("UnstableApiUsage", "Unused")
+open class Sealing @Inject constructor(objects: ObjectFactory) {
 
     @get:Input
-    var enabled: Boolean = System.getProperty( "sealing.enabled", "true").toBoolean()
+    val enabled: Property<Boolean> = objects.property(Boolean::class.javaObjectType)
+            .convention(System.getProperty( "sealing.enabled", "true").toBoolean())
 
     fun enabled(value: Boolean) {
-        enabled = value
+        enabled.set(value)
     }
 
     fun enabled(value: String) {
-        enabled = value.toBoolean()
+        enabled.set(value.toBoolean())
     }
 }

--- a/cordapp/src/main/kotlin/net/corda/plugins/SignJar.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/SignJar.kt
@@ -6,6 +6,7 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileCollection
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFiles
@@ -18,9 +19,10 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
 
+@Suppress("UnstableApiUsage")
 open class SignJar : DefaultTask() {
     companion object {
-        fun sign(project: Project, signing: Signing, file: File, enabled: Boolean = signing.enabled) {
+        fun sign(project: Project, signing: Signing, file: File, enabled: Boolean) {
             if (!enabled) {
                 project.logger.info("CorDapp JAR signing is disabled, the CorDapp's contracts will not use signature constraints.")
                 return
@@ -53,10 +55,15 @@ open class SignJar : DefaultTask() {
         }
     }
 
+    init {
+        description = "Signs the given jars using the configuration from cordapp.signing.options."
+        group = "Cordapp"
+    }
+
     private val signing: Signing = (project.extensions.findByName("cordapp") as CordappExtension).signing
 
     @get:Input
-    var postfix: String = "-signed"
+    val postfix: Property<String> = project.objects.property(String::class.java).convention("-signed")
 
     private val _inputJars: ConfigurableFileCollection = project.files()
 

--- a/cordapp/src/main/kotlin/net/corda/plugins/Signing.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/Signing.kt
@@ -4,21 +4,24 @@ import net.corda.plugins.cordapp.signing.SigningOptions
 import net.corda.plugins.cordapp.signing.SigningOptions.Companion.SYSTEM_PROPERTY_PREFIX
 import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
 import javax.inject.Inject
 
+@Suppress("UnstableApiUsage", "Unused")
 open class Signing @Inject constructor(objectFactory: ObjectFactory) {
 
     @get:Input
-    var enabled: Boolean = System.getProperty(SYSTEM_PROPERTY_PREFIX + "enabled", "true").toBoolean()
+    val enabled: Property<Boolean> = objectFactory.property(Boolean::class.javaObjectType)
+            .convention(System.getProperty(SYSTEM_PROPERTY_PREFIX + "enabled", "true").toBoolean())
 
     fun enabled(value: Boolean) {
-        enabled = value
+        enabled.set(value)
     }
 
     fun enabled(value: String) {
-        enabled = value.toBoolean()
+        enabled.set(value.toBoolean())
     }
 
     @get:Nested

--- a/cordapp/src/test/kotlin/net/corda/plugins/CordappTest.kt
+++ b/cordapp/src/test/kotlin/net/corda/plugins/CordappTest.kt
@@ -26,6 +26,7 @@ class CordappTest {
     fun setup() {
         buildFile = testProjectDir.resolve("build.gradle")
         installResource(testProjectDir, "settings.gradle")
+        installResource(testProjectDir, "gradle.properties")
         installResource(testProjectDir, "repositories.gradle")
     }
 
@@ -47,6 +48,7 @@ class CordappTest {
         val jarTaskRunner = jarTaskRunner("CorDappWithInfo.gradle", extraArgs)
 
         val result = jarTaskRunner.build()
+        println(result.output)
 
         assertThat(result.task(":jar")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
@@ -83,6 +85,7 @@ class CordappTest {
         val jarTaskRunner = jarTaskRunner("CorDappWithContractInfo.gradle", extraArgs)
 
         val result = jarTaskRunner.build()
+        println(result.output)
 
         assertThat(result.task(":jar")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
@@ -119,6 +122,7 @@ class CordappTest {
         val jarTaskRunner = jarTaskRunner("CorDappWithWorkflowInfo.gradle", extraArgs)
 
         val result = jarTaskRunner.build()
+        println(result.output)
 
         assertThat(result.task(":jar")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
@@ -163,6 +167,7 @@ class CordappTest {
         val jarTaskRunner = jarTaskRunner("CorDappWithContractAndWorflowInfo.gradle", extraArgs)
 
         val result = jarTaskRunner.build()
+        println(result.output)
 
         assertThat(result.task(":jar")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
@@ -212,6 +217,7 @@ class CordappTest {
         val jarTaskRunner = jarTaskRunner("CorDappWithInfoAll.gradle", extraArgs)
 
         val result = jarTaskRunner.build()
+        println(result.output)
 
         assertThat(result.task(":jar")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
@@ -246,6 +252,7 @@ class CordappTest {
         val jarTaskRunner = jarTaskRunner("CorDappWithoutMetadata.gradle")
 
         val result = jarTaskRunner.build()
+        println(result.output)
 
         assertThat(result.task(":jar")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
 

--- a/cordapp/src/test/resources/net/corda/plugins/CorDappWithContractAndWorflowInfo.gradle
+++ b/cordapp/src/test/resources/net/corda/plugins/CorDappWithContractAndWorflowInfo.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id 'java'
     id 'net.corda.plugins.cordapp'
 }
 

--- a/cordapp/src/test/resources/net/corda/plugins/CorDappWithContractInfo.gradle
+++ b/cordapp/src/test/resources/net/corda/plugins/CorDappWithContractInfo.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id 'java'
     id 'net.corda.plugins.cordapp'
 }
 

--- a/cordapp/src/test/resources/net/corda/plugins/CorDappWithInfo.gradle
+++ b/cordapp/src/test/resources/net/corda/plugins/CorDappWithInfo.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id 'java'
     id 'net.corda.plugins.cordapp'
 }
 

--- a/cordapp/src/test/resources/net/corda/plugins/CorDappWithInfoAll.gradle
+++ b/cordapp/src/test/resources/net/corda/plugins/CorDappWithInfoAll.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id 'java'
     id 'net.corda.plugins.cordapp'
 }
 

--- a/cordapp/src/test/resources/net/corda/plugins/CorDappWithWorkflowInfo.gradle
+++ b/cordapp/src/test/resources/net/corda/plugins/CorDappWithWorkflowInfo.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id 'java'
     id 'net.corda.plugins.cordapp'
 }
 

--- a/cordapp/src/test/resources/net/corda/plugins/CorDappWithoutMetadata.gradle
+++ b/cordapp/src/test/resources/net/corda/plugins/CorDappWithoutMetadata.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id 'java'
     id 'net.corda.plugins.cordapp'
 }
 


### PR DESCRIPTION
Update the `cordapp` plugin to use Gradle's "lazy" property APIs. This fixes some technical debt, and should have no functional impact.

Note: Gradle considers a `Property` to be "present" if `get()` will return a value, _and this includes having a value set by `convention()`_. This doesn't include setting a `Provider` as a `convention()` if that `Provider` also has no value.