### PR TITLE
CORDA-3838: Fix generated name of signed CorDapp jar.

### DIFF
--- a/cordapp/src/main/kotlin/net/corda/plugins/SignJar.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/SignJar.kt
@@ -86,7 +86,7 @@ open class SignJar : DefaultTask() {
     private fun toSigned(file: File): File {
         val path = file.absolutePath
         val lastDot = path.lastIndexOf('.')
-        return File(path.substring(0, lastDot) + postfix + path.substring(lastDot))
+        return File(path.substring(0, lastDot) + postfix.get() + path.substring(lastDot))
     }
 
     @TaskAction


### PR DESCRIPTION
We must "get" the value of the `SignJar` task's `postfix` property before using it.