### PR TITLE
NOTICK: Close input streams as JarFilter scans jar entries.

### DIFF
--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/JarFilterTask.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/JarFilterTask.kt
@@ -224,20 +224,21 @@ open class JarFilterTask @Inject constructor(objects: ObjectFactory, layouts: Pr
                 outJar.setComment(inJar.comment)
 
                 for (entry in inJar.entries()) {
-                    val entryData = inJar.getInputStream(entry)
-
-                    if (entry.isDirectory || !entry.name.endsWith(".class")) {
-                        // This entry's byte contents have not changed,
-                        // but may still need to be recompressed.
-                        outJar.putNextEntry(entry.copy().withFileTimestamps(preserveTimestamps.get()))
-                        entryData.copyTo(outJar)
-                    } else {
-                        val classData = transform(entryData.readBytes())
-                        if (classData.isNotEmpty()) {
-                            // This entry's byte contents have almost certainly
-                            // changed, and will be stored compressed.
-                            outJar.putNextEntry(entry.asCompressed().withFileTimestamps(preserveTimestamps.get()))
-                            outJar.write(classData)
+                    inJar.getInputStream(entry).use { entryData ->
+                        if (entry.isDirectory || !entry.name.endsWith(".class")) {
+                            // This entry's byte contents have not changed,
+                            // but may still need to be recompressed.
+                            outJar.putNextEntry(entry.copy().withFileTimestamps(preserveTimestamps.get()))
+                            entryData.copyTo(outJar)
+                        } else {
+                            val classData = transform(entryData.readBytes())
+                            if (classData.isNotEmpty()) {
+                                // This entry's byte contents have almost certainly
+                                // changed, and will be stored compressed.
+                                outJar.putNextEntry(entry.asCompressed().withFileTimestamps(preserveTimestamps.get()))
+                                outJar.write(classData)
+                            }
+                            Unit
                         }
                     }
                 }

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTask.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTask.kt
@@ -110,19 +110,19 @@ open class MetaFixerTask @Inject constructor(objects: ObjectFactory, layouts: Pr
 
             val classNames = inJar.entries().asSequence().namesEndingWith(".class")
             for (entry in inJar.entries()) {
-                val entryData = inJar.getInputStream(entry)
-
-                if (entry.isDirectory || !entry.name.endsWith(".class")) {
-                    // This entry's byte contents have not changed,
-                    // but may still need to be recompressed.
-                    outJar.putNextEntry(entry.copy().withFileTimestamps(preserveTimestamps.get()))
-                    entryData.copyTo(outJar)
-                } else {
-                    // This entry's byte contents have almost certainly
-                    // changed, and will be stored compressed.
-                    val classData = entryData.readBytes().fixMetadata(logger, classNames)
-                    outJar.putNextEntry(entry.asCompressed().withFileTimestamps(preserveTimestamps.get()))
-                    outJar.write(classData)
+                inJar.getInputStream(entry).use { entryData ->
+                    if (entry.isDirectory || !entry.name.endsWith(".class")) {
+                        // This entry's byte contents have not changed,
+                        // but may still need to be recompressed.
+                        outJar.putNextEntry(entry.copy().withFileTimestamps(preserveTimestamps.get()))
+                        entryData.copyTo(outJar)
+                    } else {
+                        // This entry's byte contents have almost certainly
+                        // changed, and will be stored compressed.
+                        val classData = entryData.readBytes().fixMetadata(logger, classNames)
+                        outJar.putNextEntry(entry.asCompressed().withFileTimestamps(preserveTimestamps.get()))
+                        outJar.write(classData)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Ensure that we close every `InputStream` created for the JAR file entries we are scanning. This is just good housekeeping, but otherwise we _could_ theoretically run out of file descriptors if required to scan a particularly large JAR.