### PR TITLE
NOTICK: Close input streams as JarFilter scans jar entries. (#318)

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,0 +1,90 @@
+#!groovy
+/**
+ * Jenkins pipeline to build Corda Gradle Plugins
+ */
+
+/**
+ * Kill already started job.
+ * Assume new commit takes precedence and results from previousunfinished builds are not required.
+ * This feature doesn't play well with disableConcurrentBuilds() option
+ */
+@Library('corda-shared-build-pipeline-steps')
+import static com.r3.build.BuildControl.killAllExistingBuildsForJob
+killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
+
+/**
+ * Sense environment
+ */
+boolean isReleaseBranch = (env.BRANCH_NAME =~ /^release\/.*/)
+boolean isRelease = (env.TAG_NAME =~ /^release\/.*/)
+
+pipeline {
+    agent {
+        label 'eight-cores'
+    }
+    parameters {
+        booleanParam name: 'DO_PUBLISH',
+                     defaultValue: (isReleaseBranch || isRelease),
+                     description: 'Publish artifacts to Artifactory?'
+    }
+    options {
+        ansiColor('xterm')
+        timestamps()
+        timeout(3*60) // 3 hours
+        buildDiscarder(logRotator(daysToKeepStr: '7', artifactDaysToKeepStr: '7'))
+    }
+    environment {
+        // Replace / with :: as links from Jenkins to Artifactory are broken if we use slashes
+        // in the name
+        ARTIFACTORY_BUILD_NAME = "Corda Gradle Plugins / Publish To Artifactory"
+            .replaceAll("/", " :: ")
+        ARTIFACTORY_REPO = "${isRelease ? "corda-releases" : "corda-dev"}"
+    }
+    stages {
+        stage('Build') {
+            steps {
+                sh './gradlew --no-daemon -s --no-build-cache clean build'
+            }
+        }
+        stage('Publish to Artifactory') {
+            when {
+                expression { params.DO_PUBLISH }
+                beforeAgent true
+            }
+            steps {
+                rtServer (
+                        id: 'R3-Artifactory',
+                        url: 'https://software.r3.com/artifactory',
+                        credentialsId: 'artifactory-credentials'
+                )
+                rtGradleDeployer (
+                        id: 'deployer',
+                        serverId: 'R3-Artifactory',
+                        repo: env.ARTIFACTORY_REPO,
+                )
+                withCredentials([
+                        usernamePassword(credentialsId: 'artifactory-credentials',
+                                usernameVariable: 'CORDA_ARTIFACTORY_USERNAME',
+                                passwordVariable: 'CORDA_ARTIFACTORY_PASSWORD')]) {
+                    rtGradleRun (
+                            usesPlugin: true,
+                            useWrapper: true,
+                            switches: "--no-daemon -s",
+                            tasks: 'artifactoryPublish',
+                            deployerId: 'deployer',
+                            buildName: env.ARTIFACTORY_BUILD_NAME
+                    )
+                }
+                rtPublishBuildInfo (
+                        serverId: 'R3-Artifactory',
+                        buildName: env.ARTIFACTORY_BUILD_NAME
+                )
+            }
+        }
+    }
+    post {
+        cleanup {
+            deleteDir()
+        }
+    }
+}

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTask.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTask.kt
@@ -115,19 +115,19 @@ open class MetaFixerTask @Inject constructor(objects: ObjectFactory, layouts: Pr
 
             val classNames = inJar.entries().asSequence().namesEndingWith(".class")
             for (entry in inJar.entries()) {
-                val entryData = inJar.getInputStream(entry)
-
-                if (entry.isDirectory || !entry.name.endsWith(".class")) {
-                    // This entry's byte contents have not changed,
-                    // but may still need to be recompressed.
-                    outJar.putNextEntry(entry.copy().withFileTimestamps(preserveTimestamps.get()))
-                    entryData.copyTo(outJar)
-                } else {
-                    // This entry's byte contents have almost certainly
-                    // changed, and will be stored compressed.
-                    val classData = entryData.readBytes().fixMetadata(logger, classNames)
-                    outJar.putNextEntry(entry.asCompressed().withFileTimestamps(preserveTimestamps.get()))
-                    outJar.write(classData)
+                inJar.getInputStream(entry).use { entryData ->
+                    if (entry.isDirectory || !entry.name.endsWith(".class")) {
+                        // This entry's byte contents have not changed,
+                        // but may still need to be recompressed.
+                        outJar.putNextEntry(entry.copy().withFileTimestamps(preserveTimestamps.get()))
+                        entryData.copyTo(outJar)
+                    } else {
+                        // This entry's byte contents have almost certainly
+                        // changed, and will be stored compressed.
+                        val classData = entryData.readBytes().fixMetadata(logger, classNames)
+                        outJar.putNextEntry(entry.asCompressed().withFileTimestamps(preserveTimestamps.get()))
+                        outJar.write(classData)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Ensure that we close every `InputStream` created for the JAR file entries we are scanning. This is just good housekeeping, but otherwise we could theoretically run out of file descriptors if required to scan a particularly large JAR.