### PR TITLE
CORDA-3860: Raise minimum Gradle version for cordapp plugin to v5.1.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ### Version 5.0.11
 
+* `cordapp`: Raise minimum Gradle version to 5.1.
+
 ### Version 5.0.10
 
 * `cordformation`: Add option to accept license agreements for Corda enterprise Docker images 

--- a/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
@@ -24,7 +24,7 @@ import javax.inject.Inject
 class CordappPlugin @Inject constructor(private val objects: ObjectFactory): Plugin<Project> {
     private companion object {
         private const val UNKNOWN = "Unknown"
-        private const val MIN_GRADLE_VERSION = "4.0"
+        private const val MIN_GRADLE_VERSION = "5.1"
 
         private val HARDCODED_EXCLUDES: Set<Pair<String, String>> = unmodifiableSet(setOf(
             "org.jetbrains.kotlin" to "kotlin-stdlib",

--- a/cordapp/src/main/kotlin/net/corda/plugins/CordappUtils.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/CordappUtils.kt
@@ -31,9 +31,9 @@ class CordappUtils {
         }
 
         fun compareVersions(v1: String, v2: String): Int {
-            fun parseVersionString(v: String) = v.split(".").flatMap { it.split("-") }.map {
+            fun parseVersionString(v: String) = v.split('.').flatMap { it.split('-') }.map {
                 try {
-                    Integer.valueOf(it)
+                    it.toInt()
                 } catch (e: NumberFormatException) {
                     -1
                 }


### PR DESCRIPTION
Bring the `cordapp` plugin's internal Gradle version check up-to-date for the 5.x release.
Also tidy up the Kotlin for the version-checking function.

The specific Gradle 5.1 API is:
```java
/**
 * Specifies the provider of the value to use as the convention for this property. The convention is used when no value has been set for this property.
 *
 * @param valueProvider The provider of the value.
 * @return this
 * @since 5.1
 */
Property<T> convention(Provider<? extends T> valueProvider);
```