### PR TITLE
CORDA-3876: Update publish-utils to use lazy task configuration where possible.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * `cordapp`: Raise minimum Gradle version to 5.1.
 * `cordapp`: Refresh the certificate for the development CorDapp signing key.
 * `api-scanner`: Refactor this plugin into its own package.
+* `publish-utils`: Configure publication tasks lazily.
 
 ### Version 5.0.10
 


### PR DESCRIPTION
Update `publish-utils` to create the following tasks lazily:
- `sourceJar`
- `javadocJar`
- `install`

This means that Gradle will not configure them unless it also intends to execute them.
Also tweak the logging to use SLF4J place-holders rather than string concatenation.