### PR TITLE
CORDA-3884: Address some technical debt in the API Scanner plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The plugins themselves fall into two categories: those intended for developing C
 
 ### Plugins for CorDapp development.
 
-- [`net.corda.plugins.cordapp`](cordapp/README.md):
+- [`net.corda.plugins.cordapp`](cordapp/README.md)\
 This plugin packages your CorDapp classes into a single jar file, along with
 the contents of all of the jar's dependent jars. Dependencies which are added
 to Gradle's `cordaCompile`, `cordaRuntime` and `cordapp` configurations are
@@ -44,13 +44,17 @@ excluded from this packaging. The final jar is then signed. It also provides
 a `cordapp` Gradle extension so that you can configure your CorDapp's metadata.
 This metadata is currently optional, but you are _strongly_ advised to provide it.
 
-- [`net.corda.plugins.cordformation`](cordformation/README.rst):
+    <sup>Requires Gradle 5.1</sup>
+
+- [`net.corda.plugins.cordformation`](cordformation/README.rst)\
 This plugin provides `Cordform` and `Dockerform` Gradle tasks for creating
 test deployments of multiple Corda nodes and their CorDapps. It also invokes
 the Network Bootstrapper over the deployment for you, and provides you with a
 `runnodes` script to boot it all up afterwards.
 
-- [`net.corda.plugins.quasar-utils`](quasar-utils/README.rst):
+    <sup>Requires Gradle 5.1</sup>
+
+- [`net.corda.plugins.quasar-utils`](quasar-utils/README.rst)\
 This plugin configures a Gradle module to use Quasar. Specifically:
     - It allows you to specify the Maven group, version and classifier of
 the `quasar-core` artifact to use.
@@ -65,10 +69,12 @@ configuration without any of its transitive dependencies.
     - Provides a `quasar` Gradle extension so that you can configure
 which classes the Quasar java agent should not instrument at runtime.
 
+    <sup>Requires Gradle 5.1</sup>
+
 ### Internal Corda plugins.
 These plugins are unlikely to be useful to CorDapp developers outside of R3.
 
-- [`net.corda.plugins.api-scanner`](api-scanner/README.md):
+- [`net.corda.plugins.api-scanner`](api-scanner/README.md)\
 This plugin scans the `public` and `protected` classes inside a Gradle
 module's "primary" jar artifact and writes a summary of their `public`
 and `protected` methods and fields into an output file. The "primary"
@@ -77,18 +83,25 @@ although this is configurable. Its goal is to alert Corda developers to
 accidental breaks in our public ABI for those Corda modules we have
 declared to be "stable", and is used by the Continuous Integration builds.
 
-- [`net.corda.plugins.jar-filter`](jar-filter/README.md):
+    <sup>Requires Gradle 5.6</sup>
+
+- [`net.corda.plugins.jar-filter`](jar-filter/README.md)\
 This plugin allows us to delete certain annotated classes, methods and
 fields from the compiled byte-code inside a jar file. It can also rewrite
 Kotlin classes' `@kotlin.Metadata` annotations to make them consistent 
 again with their revised byte-code. It is currently used in Corda's
 `core-deterministic` and `serialization-deterministic` modules, and has
-been successfully tested with Kotlin 1.2.x - 1.3.71.
+been successfully tested with Kotlin 1.2.x - 1.3.72.
 
-- [`net.corda.plugins.publish-utils`](publish-utils/README.rst): **_Here
-be Dragons!_** This plugin helps configure Gradle's `maven-publish` plugin
-to publish Corda modules to Bintray and to R3's Artifactory. However, its
-workings probably shouldn't be allowed and they should _most definitely_
-**never** be copied. Unfortunately, it is heavily constrained by how JFrog's
-Bintray and Artifactory plugins themselves work, and so we're currently stuck
-with it "as is". It _is_ useful though - just shut your eyes and hold your nose.
+    <sup>Requires Gradle 5.6</sup>
+
+- [`net.corda.plugins.publish-utils`](publish-utils/README.rst)\
+**_Here be Dragons!_**
+This plugin helps configure Gradle's `maven-publish` plugin to publish Corda
+modules to Bintray and to R3's Artifactory. However, its workings probably
+shouldn't be allowed and they should _most definitely_ **never** be copied.
+Unfortunately, it is heavily constrained by how JFrog's Bintray and Artifactory
+plugins themselves work, and so we're currently stuck with it "as is". It _is_
+useful though - just shut your eyes and hold your nose.
+
+    <sup>Requires Gradle 5.1</sup>

--- a/api-scanner/README.md
+++ b/api-scanner/README.md
@@ -18,7 +18,9 @@ scope for classes or fields yet as these are currently `public` inside the `.cla
 Include this line in the `build.gradle` file of every Corda module that exports public API:
 
 ```gradle
-apply plugin: 'net.corda.plugins.api-scanner'
+plugins {
+    id 'net.corda.plugins.api-scanner'
+}
 ```
 
 This will create a Gradle task called `scanApi` which will analyse that module's Jar artifacts. More precisely,

--- a/api-scanner/annotations/build.gradle
+++ b/api-scanner/annotations/build.gradle
@@ -1,7 +1,7 @@
-apply plugin: 'java'
+apply plugin: 'java-library'
 
 description 'A library of annotations for testing API Scanner.'
 
-jar {
+tasks.named('jar', Jar) {
     archiveFileName = 'annotations.jar'
 }

--- a/api-scanner/src/main/java/net/corda/plugins/apiscanner/ApiPrintWriter.java
+++ b/api-scanner/src/main/java/net/corda/plugins/apiscanner/ApiPrintWriter.java
@@ -11,14 +11,15 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toCollection;
 import static nonapi.io.github.classgraph.types.TypeUtils.ModifierType.METHOD;
 
-public class ApiPrintWriter extends PrintWriter {
+@SuppressWarnings("SameParameterValue")
+class ApiPrintWriter extends PrintWriter {
     private static final int METHOD_MASK = Modifier.methodModifiers() | Modifier.TRANSIENT;
 
     ApiPrintWriter(File file, String encoding) throws FileNotFoundException, UnsupportedEncodingException {
         super(file, encoding);
     }
 
-    public void println(ClassInfo classInfo, int modifierMask, List<String> filteredAnnotations) {
+    void println(ClassInfo classInfo, int modifierMask, List<String> filteredAnnotations) {
         append(asAnnotations(filteredAnnotations, ""));
         append(Modifier.toString(classInfo.loadClass().getModifiers() & modifierMask));
         if (classInfo.isAnnotation()) {
@@ -51,7 +52,7 @@ public class ApiPrintWriter extends PrintWriter {
         println();
     }
 
-    public void println(MethodInfo method, AnnotationInfoList visibleAnnotations, String indentation) {
+    void println(MethodInfo method, AnnotationInfoList visibleAnnotations, String indentation) {
         append(asAnnotations(visibleAnnotations.getNames(), indentation));
         append(indentation).append(pureModifiersFor(method)).append(' ');
         if (!method.isConstructor()) {
@@ -71,7 +72,7 @@ public class ApiPrintWriter extends PrintWriter {
         println(')');
     }
 
-    public void println(FieldInfo field, AnnotationInfoList visibleAnnotations, String indentation) {
+    void println(FieldInfo field, AnnotationInfoList visibleAnnotations, String indentation) {
         append(asAnnotations(visibleAnnotations.getNames(), indentation))
             .append(indentation)
             .append(field.getModifierStr())

--- a/api-scanner/src/main/java/net/corda/plugins/apiscanner/ScannerExtension.java
+++ b/api-scanner/src/main/java/net/corda/plugins/apiscanner/ScannerExtension.java
@@ -1,38 +1,35 @@
 package net.corda.plugins.apiscanner;
 
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 
+import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import java.util.List;
-import java.util.Map;
-
-import static java.util.Collections.emptyMap;
 
 @SuppressWarnings({"unused", "WeakerAccess", "UnstableApiUsage"})
 public class ScannerExtension {
 
-    private boolean verbose;
     private boolean enabled = true;
+    private final Property<Boolean> verbose;
     private final SetProperty<String> excludeClasses;
-    private Map<String, List<String>> excludeMethods = emptyMap();
+    private final MapProperty<String, List> excludeMethods;
     private final SetProperty<String> excludePackages;
     private final Property<String> targetClassifier;
 
     @Inject
-    public ScannerExtension(ObjectFactory objectFactory, String defaultClassifier) {
+    public ScannerExtension(@Nonnull ObjectFactory objectFactory, String defaultClassifier) {
+        verbose = objectFactory.property(Boolean.class).convention(false);
         excludeClasses = objectFactory.setProperty(String.class);
         excludePackages = objectFactory.setProperty(String.class);
+        excludeMethods = objectFactory.mapProperty(String.class, List.class);
         targetClassifier = objectFactory.property(String.class).convention(defaultClassifier);
     }
 
-    public boolean isVerbose() {
+    public Property<Boolean> getVerbose() {
         return verbose;
-    }
-
-    public void setVerbose(boolean verbose) {
-        this.verbose = verbose;
     }
 
     public boolean isEnabled() {
@@ -47,12 +44,8 @@ public class ScannerExtension {
         return excludeClasses;
     }
 
-    public Map<String, List<String>> getExcludeMethods() {
+    public MapProperty<String, ? extends List> getExcludeMethods() {
         return excludeMethods;
-    }
-
-    public void setExcludeMethods(Map<String, List<String>> excludeMethods) {
-        this.excludeMethods = excludeMethods;
     }
 
     public SetProperty<String> getExcludePackages() {

--- a/api-scanner/src/test/java/net/corda/plugins/apiscanner/CopyUtils.java
+++ b/api-scanner/src/test/java/net/corda/plugins/apiscanner/CopyUtils.java
@@ -14,13 +14,16 @@ public final class CopyUtils {
     private CopyUtils() {
     }
 
-    public static long installResource(@Nonnull Path folder, @Nonnull String resourceName) throws IOException {
+    public static boolean installResource(@Nonnull Path folder, @Nonnull String resourceName) throws IOException {
         Path buildFile = folder.resolve(resourceName.substring(1 + resourceName.lastIndexOf('/')));
-        return copyResourceTo(resourceName, buildFile);
+        return copyResourceTo(resourceName, buildFile) >= 0;
     }
 
     public static long copyResourceTo(String resourceName, Path target) throws IOException {
         try (InputStream input = CopyUtils.class.getClassLoader().getResourceAsStream(resourceName)) {
+            if (input == null) {
+                return -1;
+            }
             return Files.copy(input, target, REPLACE_EXISTING);
         }
     }

--- a/api-scanner/src/test/java/net/corda/plugins/apiscanner/GenerateChildProjectTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/apiscanner/GenerateChildProjectTest.java
@@ -1,0 +1,37 @@
+package net.corda.plugins.apiscanner;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+
+class GenerateChildProjectTest {
+    private GradleProject testProject;
+
+    @BeforeEach
+    void setup(@TempDir Path testProjectDir) throws IOException {
+        testProject = new GradleProject(testProjectDir, "generate-child-project")
+            .withSubResource("child-project/build.gradle")
+            .withTaskName("generateApi")
+            .build();
+    }
+
+    @Test
+    void testGenerateChildProject() throws IOException {
+        assertThat(testProject.getOutcomeOf("child-project:jar")).isEqualTo(SUCCESS);
+        assertThat(testProject.getOutcomeOf("child-project:scanApi")).isEqualTo(SUCCESS);
+        assertThat(testProject.getOutcomeOf("scanApi")).isNull();
+        assertThat(testProject.getOutcomeOf("generateApi")).isEqualTo(SUCCESS);
+        assertThat(testProject.getApiLines())
+            .contains(
+                "public class net.corda.example.ChildClass extends java.lang.Object",
+                "  public <init>()",
+                "##"
+            );
+    }
+}

--- a/api-scanner/src/test/java/net/corda/plugins/apiscanner/GenerateNoScanTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/apiscanner/GenerateNoScanTest.java
@@ -1,0 +1,31 @@
+package net.corda.plugins.apiscanner;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.gradle.testkit.runner.TaskOutcome.NO_SOURCE;
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+
+class GenerateNoScanTest {
+    private GradleProject testProject;
+
+    @BeforeEach
+    void setup(@TempDir Path testProjectDir) throws IOException {
+        testProject = new GradleProject(testProjectDir, "generate-no-scan")
+            .withTaskName("generateApi")
+            .build();
+    }
+
+    @Test
+    void testGenerateNoScan() throws IOException {
+        assertThat(testProject.getOutcomeOf("jar")).isNull();
+        assertThat(testProject.getOutcomeOf("scanApi")).isNull();
+        assertThat(testProject.getOutcomeOf("generateApi")).isEqualTo(SUCCESS);
+        assertThat(testProject.getApiLines()).isEmpty();
+    }
+}

--- a/api-scanner/src/test/java/net/corda/plugins/apiscanner/KotlinExcludeMethodTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/apiscanner/KotlinExcludeMethodTest.java
@@ -22,8 +22,8 @@ class KotlinExcludeMethodTest {
     @Test
     void testFilteredMethodsAreExcluded() throws IOException {
         assertThat(testProject.getApiText())
-                .contains("net.corda.example.ClassWithExtraConstructorGenerated")
-                .doesNotContain("<init>(String, String, kotlin.jvm.internal.DefaultConstructorMarker)");
+            .contains("net.corda.example.ClassWithExtraConstructorGenerated")
+            .doesNotContain("<init>(String, String, kotlin.jvm.internal.DefaultConstructorMarker)");
     }
 
 }

--- a/api-scanner/src/test/resources/generate-child-project/build.gradle
+++ b/api-scanner/src/test/resources/generate-child-project/build.gradle
@@ -1,0 +1,13 @@
+import net.corda.plugins.apiscanner.GenerateApi
+
+plugins {
+    id 'net.corda.plugins.api-scanner' apply false
+}
+apply from: 'repositories.gradle'
+
+description 'Test generating API file for child project'
+version = ''
+
+tasks.register('generateApi', GenerateApi) {
+    baseName = 'generate-child-project'
+}

--- a/api-scanner/src/test/resources/generate-child-project/child-project/build.gradle
+++ b/api-scanner/src/test/resources/generate-child-project/child-project/build.gradle
@@ -1,0 +1,17 @@
+plugins {
+    id 'java'
+    id 'net.corda.plugins.api-scanner'
+}
+apply from: '../repositories.gradle'
+
+sourceSets {
+    main {
+        java {
+            srcDir file("../../resources/test/generate-child-project/child-project/java")
+        }
+    }
+}
+
+scanApi {
+    verbose = true
+}

--- a/api-scanner/src/test/resources/generate-child-project/child-project/java/net/corda/example/ChildClass.java
+++ b/api-scanner/src/test/resources/generate-child-project/child-project/java/net/corda/example/ChildClass.java
@@ -1,0 +1,4 @@
+package net.corda.example;
+
+public class ChildClass {
+}

--- a/api-scanner/src/test/resources/generate-child-project/settings.gradle
+++ b/api-scanner/src/test/resources/generate-child-project/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'generate-child-project'
+include 'child-project'

--- a/api-scanner/src/test/resources/generate-no-scan/build.gradle
+++ b/api-scanner/src/test/resources/generate-no-scan/build.gradle
@@ -1,0 +1,13 @@
+import net.corda.plugins.apiscanner.GenerateApi
+
+plugins {
+    id 'net.corda.plugins.api-scanner' apply false
+}
+apply from: 'repositories.gradle'
+
+description 'Test generating overall API file when there are no scanApi tasks'
+
+tasks.register('generateApi', GenerateApi) {
+    baseName = 'generate-no-scan'
+    version = ''
+}

--- a/api-scanner/src/test/resources/kotlin-annotations/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-annotations/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 description 'Test appearance of Kotlin-specific annotations'
 
@@ -18,8 +19,6 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
 }
-
-apply from: 'kotlin.gradle'
 
 jar {
     archiveBaseName = "kotlin-annotations"

--- a/api-scanner/src/test/resources/kotlin-auto-generated-class/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-auto-generated-class/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 description 'Test appearance of Kotlin lambdas'
 
@@ -18,8 +19,6 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
 }
-
-apply from: 'kotlin.gradle'
 
 jar {
     archiveBaseName = "kotlin-auto-generated-class"

--- a/api-scanner/src/test/resources/kotlin-constant/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-constant/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 description 'Test appearance of Kotlin const field'
 
@@ -18,8 +19,6 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
 }
-
-apply from: 'kotlin.gradle'
 
 jar {
     archiveBaseName = "kotlin-constant"

--- a/api-scanner/src/test/resources/kotlin-enum/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-enum/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 description 'Test appearance of Kotlin enum class'
 
@@ -18,8 +19,6 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
 }
-
-apply from: 'kotlin.gradle'
 
 jar {
     archiveBaseName = "kotlin-enum"

--- a/api-scanner/src/test/resources/kotlin-exclude-method/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-exclude-method/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 description 'Test behaviour of filtering'
 
@@ -19,8 +20,6 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
 }
 
-apply from: 'kotlin.gradle'
-
 jar {
     archiveBaseName = "kotlin-exclude-method"
 }
@@ -28,8 +27,8 @@ jar {
 scanApi {
     verbose = true
     excludeMethods = [
-            "net.corda.example.ClassWithExtraConstructorGenerated": [
-                    "<init>(Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V"
-            ]
+        "net.corda.example.ClassWithExtraConstructorGenerated": [
+            "<init>(Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V"
+        ]
     ]
 }

--- a/api-scanner/src/test/resources/kotlin-internal-annotation/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-internal-annotation/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 description 'Test appearance of internal Corda annotations in Kotlin'
 
@@ -18,8 +19,6 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
 }
-
-apply from: 'kotlin.gradle'
 
 jar {
     archiveBaseName = "kotlin-internal-annotation"

--- a/api-scanner/src/test/resources/kotlin-lambdas/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-lambdas/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 description 'Test appearance of Kotlin lambdas'
 
@@ -18,8 +19,6 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
 }
-
-apply from: 'kotlin.gradle'
 
 jar {
     archiveBaseName = "kotlin-lambdas"

--- a/api-scanner/src/test/resources/kotlin-legacy/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-legacy/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 description 'Test Legacy Gradle API'
 
@@ -18,8 +19,6 @@ dependencies {
     compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly files('../../annotations/build/libs/annotations.jar')
 }
-
-apply from: 'kotlin.gradle'
 
 jar {
     archiveBaseName = "kotlin-legacy"

--- a/api-scanner/src/test/resources/kotlin-library/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-library/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'net.corda.plugins.api-scanner'
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 description 'Test API for a library'
 
@@ -20,8 +21,6 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:1.7.26'
     compileOnly files('../../annotations/build/libs/annotations.jar')
 }
-
-apply from: 'kotlin.gradle'
 
 jar {
     archiveBaseName = "kotlin-library"

--- a/api-scanner/src/test/resources/kotlin-vararg-method/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-vararg-method/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
 }
 apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
 
 description 'Test appearance of Kotlin vararg functions'
 
@@ -18,8 +19,6 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
 }
-
-apply from: 'kotlin.gradle'
 
 jar {
     archiveBaseName = "kotlin-vararg-method"


### PR DESCRIPTION
- Migrate task properties to be "lazy".
- Avoid configuring tasks that will not be executed.
- Implicitly apply the `java` plugin up front.
- Increase unit test coverage for `GenerateApi` task.
- This plugin now requires Gradle 5.6+.