### PR TITLE
CORDA-3893: Upgrade to Gradle 5.6.4.

### DIFF
--- a/api-scanner/build.gradle
+++ b/api-scanner/build.gradle
@@ -52,11 +52,9 @@ dependencies {
 }
 
 processTestResources {
-    filesMatching('**/kotlin-*/build.gradle') {
-        expand(['kotlin_version': kotlin_version])
-    }
     filesMatching('gradle.properties') {
         expand(['jacocoAgent': configurations.jacocoRuntime.asPath.replace('\\', '/'),
+                'kotlin_version': kotlin_version,
                 'buildDir': buildDir])
     }
 }

--- a/api-scanner/src/test/resources/gradle.properties
+++ b/api-scanner/src/test/resources/gradle.properties
@@ -1,2 +1,4 @@
 org.gradle.jvmargs=-XX:+UseG1GC -Xmx512m -javaagent:"$jacocoAgent"=destfile="$buildDir/jacoco/test.exec",includes=net/corda/plugins/**
 org.gradle.caching=false
+
+kotlin_version=$kotlin_version

--- a/api-scanner/src/test/resources/kotlin-annotations/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-annotations/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'net.corda.plugins.api-scanner'
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
 }
 apply from: 'repositories.gradle'
 

--- a/api-scanner/src/test/resources/kotlin-auto-generated-class/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-auto-generated-class/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'net.corda.plugins.api-scanner'
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
 }
 apply from: 'repositories.gradle'
 

--- a/api-scanner/src/test/resources/kotlin-constant/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-constant/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'net.corda.plugins.api-scanner'
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
 }
 apply from: 'repositories.gradle'
 

--- a/api-scanner/src/test/resources/kotlin-enum/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-enum/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'net.corda.plugins.api-scanner'
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
 }
 apply from: 'repositories.gradle'
 

--- a/api-scanner/src/test/resources/kotlin-exclude-method/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-exclude-method/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'net.corda.plugins.api-scanner'
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
 }
 apply from: 'repositories.gradle'
 

--- a/api-scanner/src/test/resources/kotlin-internal-annotation/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-internal-annotation/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'net.corda.plugins.api-scanner'
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
 }
 apply from: 'repositories.gradle'
 

--- a/api-scanner/src/test/resources/kotlin-lambdas/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-lambdas/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'net.corda.plugins.api-scanner'
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
 }
 apply from: 'repositories.gradle'
 

--- a/api-scanner/src/test/resources/kotlin-legacy/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-legacy/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
     id 'net.corda.plugins.api-scanner'
+    id 'org.jetbrains.kotlin.jvm'
 }
 apply from: 'repositories.gradle'
 

--- a/api-scanner/src/test/resources/kotlin-library/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-library/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-library'
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.api-scanner'
 }
 apply from: 'repositories.gradle'

--- a/api-scanner/src/test/resources/kotlin-vararg-method/build.gradle
+++ b/api-scanner/src/test/resources/kotlin-vararg-method/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'net.corda.plugins.api-scanner'
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
 }
 apply from: 'repositories.gradle'
 

--- a/api-scanner/src/test/resources/settings.gradle
+++ b/api-scanner/src/test/resources/settings.gradle
@@ -3,4 +3,8 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
     }
+
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version kotlin_version
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,33 +1,11 @@
 import static org.gradle.api.JavaVersion.*
 
-buildscript {
-    ext {
-        gradle_plugins_version = '5.0.11-SNAPSHOT'
-        typesafe_config_version = '1.3.1'
-        classgraph_version = '4.8.78'
-        kotlin_version = '1.3.21'
-        snake_yaml_version = '1.19'
-        commons_io_version = '2.6'
-        assertj_version = '3.12.1'
-        junit_jupiter_version = '5.6.2'
-        hamcrest_version = '2.1'
-        asm_version = '7.3.1'
-        docker_client_version = '8.15.1'
-    }
-
-    repositories {
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 plugins {
-    id 'com.gradle.plugin-publish' version '0.12.0' apply false
-    id 'com.jfrog.bintray' version '1.8.5' apply false
-    id 'com.jfrog.artifactory' version '4.16.0'
+    id 'org.jetbrains.kotlin.jvm' apply false
+    id 'com.gradle.plugin-publish' apply false
+    id 'com.jfrog.artifactory' apply false
+    id 'com.jfrog.bintray' apply false
+    id 'com.gradle.build-scan'
 }
 
 ext {
@@ -226,6 +204,13 @@ artifactory {
 }
 
 wrapper {
-    gradleVersion = '5.4.1'
+    gradleVersion = '5.6.4'
     distributionType = Wrapper.DistributionType.ALL
+}
+
+gradleEnterprise {
+    buildScan {
+        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+        termsOfServiceAgree = 'yes'
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,16 @@
 kotlin.incremental=true
 org.gradle.jvmargs=-XX:+UseG1GC -Xmx1g
 org.gradle.caching=false
+
+gradle_plugins_version=5.0.11-SNAPSHOT
+typesafe_config_version=1.3.1
+classgraph_version=4.8.78
+kotlin_version=1.3.41
+snake_yaml_version=1.19
+commons_io_version=2.6
+assertj_version=3.12.1
+junit_jupiter_version=5.6.2
+hamcrest_version=2.1
+asm_version=7.3.1
+docker_client_version=8.15.1
+

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://gradleproxy:gradleproxy@software.r3.com/artifactory/gradle-proxy/gradle-5.4.1-all.zip
+distributionUrl=https\://gradleproxy:gradleproxy@software.r3.com/artifactory/gradle-proxy/gradle-5.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jar-filter/build.gradle
+++ b/jar-filter/build.gradle
@@ -64,17 +64,16 @@ dependencies {
 }
 
 processTestResources {
-    filesMatching('**/build.gradle') {
-        expand(['kotlin_version': kotlin_version])
-    }
     filesMatching('gradle.properties') {
         expand(['jacocoAgent': configurations.jacocoRuntime.asPath.replace('\\', '/'),
                 'kotlin_api_version': test_kotlin_api_version,
+                'kotlin_version': kotlin_version,
                 'buildDir': buildDir])
     }
 }
 
 tasks.withType(Test).configureEach {
+    // Configures the @RequiresKotlin14 annotation.
     systemProperty 'test.kotlin.api', test_kotlin_api_version
 }
 

--- a/jar-filter/src/test/resources/abstract-function/build.gradle
+++ b/jar-filter/src/test/resources/abstract-function/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/delete-ambiguous-property/build.gradle
+++ b/jar-filter/src/test/resources/delete-ambiguous-property/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/delete-and-stub/build.gradle
+++ b/jar-filter/src/test/resources/delete-and-stub/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/delete-constructor/build.gradle
+++ b/jar-filter/src/test/resources/delete-constructor/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/delete-extension-val/build.gradle
+++ b/jar-filter/src/test/resources/delete-extension-val/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/delete-field/build.gradle
+++ b/jar-filter/src/test/resources/delete-field/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/delete-file-typealias/build.gradle
+++ b/jar-filter/src/test/resources/delete-file-typealias/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/delete-function/build.gradle
+++ b/jar-filter/src/test/resources/delete-function/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/delete-inner-lambda/build.gradle
+++ b/jar-filter/src/test/resources/delete-inner-lambda/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/delete-lazy/build.gradle
+++ b/jar-filter/src/test/resources/delete-lazy/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/delete-multifile/build.gradle
+++ b/jar-filter/src/test/resources/delete-multifile/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/delete-nested-class/build.gradle
+++ b/jar-filter/src/test/resources/delete-nested-class/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/delete-object/build.gradle
+++ b/jar-filter/src/test/resources/delete-object/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/delete-overloaded-function/build.gradle
+++ b/jar-filter/src/test/resources/delete-overloaded-function/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/delete-sealed-subclass/build.gradle
+++ b/jar-filter/src/test/resources/delete-sealed-subclass/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/delete-static-field/build.gradle
+++ b/jar-filter/src/test/resources/delete-static-field/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/delete-static-function/build.gradle
+++ b/jar-filter/src/test/resources/delete-static-function/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/delete-static-val/build.gradle
+++ b/jar-filter/src/test/resources/delete-static-val/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/delete-static-var/build.gradle
+++ b/jar-filter/src/test/resources/delete-static-var/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/delete-val-property/build.gradle
+++ b/jar-filter/src/test/resources/delete-val-property/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/delete-var-property/build.gradle
+++ b/jar-filter/src/test/resources/delete-var-property/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/gradle.properties
+++ b/jar-filter/src/test/resources/gradle.properties
@@ -3,3 +3,4 @@ org.gradle.caching=false
 kotlin.incremental=false
 
 kotlin_api_version=$kotlin_api_version
+kotlin_version=$kotlin_version

--- a/jar-filter/src/test/resources/interface-function/build.gradle
+++ b/jar-filter/src/test/resources/interface-function/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/remove-annotations/build.gradle
+++ b/jar-filter/src/test/resources/remove-annotations/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/sanitise-delete-constructor/build.gradle
+++ b/jar-filter/src/test/resources/sanitise-delete-constructor/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/sanitise-stub-constructor/build.gradle
+++ b/jar-filter/src/test/resources/sanitise-stub-constructor/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/settings.gradle
+++ b/jar-filter/src/test/resources/settings.gradle
@@ -3,4 +3,8 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
     }
+
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version kotlin_version
+    }
 }

--- a/jar-filter/src/test/resources/stub-constructor/build.gradle
+++ b/jar-filter/src/test/resources/stub-constructor/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/stub-function/build.gradle
+++ b/jar-filter/src/test/resources/stub-function/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/stub-static-function/build.gradle
+++ b/jar-filter/src/test/resources/stub-static-function/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/stub-val-property/build.gradle
+++ b/jar-filter/src/test/resources/stub-val-property/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/jar-filter/src/test/resources/stub-var-property/build.gradle
+++ b/jar-filter/src/test/resources/stub-var-property/build.gradle
@@ -1,7 +1,7 @@
 import net.corda.gradle.jarfilter.JarFilterTask
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '$kotlin_version'
+    id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.jar-filter' apply false
 }
 apply from: 'repositories.gradle'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,18 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+    }
+
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version kotlin_version
+        id 'com.gradle.plugin-publish' version '0.12.0'
+        id 'com.jfrog.artifactory' version '4.16.0'
+        id 'com.jfrog.bintray' version '1.8.5'
+        id 'org.owasp.dependencycheck' version '5.3.2.1'
+        id 'com.gradle.build-scan' version '3.3.4'
+    }
+}
+
 rootProject.name = 'corda-gradle-plugins'
 include 'publish-utils'
 include 'quasar-utils'


### PR DESCRIPTION
Upgrade Gradle 5.4.1 -> 5.6.4. This is the same version of Gradle used by Corda 4.6.

The `cordapp`, `cordformation` and `quasar-utils` plugins must remain compatible with Gradle 5.4.1, for the sake of Corda 4.3 -> Corda 4.5.