### PR TITLE
CORDA-3902: Allow publish.name to be set using Gradle provider.

### DIFF
--- a/publish-utils/src/main/groovy/net/corda/plugins/publish/PublishExtension.groovy
+++ b/publish-utils/src/main/groovy/net/corda/plugins/publish/PublishExtension.groovy
@@ -5,6 +5,7 @@ import org.gradle.api.Action
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.util.ConfigureUtil
 
 import javax.inject.Inject
@@ -34,6 +35,10 @@ class PublishExtension {
      */
     Property<String> getName() {
         return name
+    }
+
+    void name(Provider<String> provider) {
+        name.set(provider)
     }
 
     void name(String value) {


### PR DESCRIPTION
This will allow us to use Gradle's task configuration avoidance by writing:
```groovy
def jar = tasks.named('jar', Jar)

publish {
    name jar.flatMap { it.archiveBaseName }
}
```
instead of
```groovy
publish {
    name jar.baseName
}
```