### PR TITLE
CORDA-3884: Update JarFilter's usage of FileCollection for Gradle 5.6.

### DIFF
--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/FilterAnnotations.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/FilterAnnotations.kt
@@ -1,6 +1,7 @@
 package net.corda.gradle.jarfilter
 
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Provider
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
@@ -21,12 +22,15 @@ open class FilterAnnotations @Inject constructor(objects: ObjectFactory) {
     val forSanitise: SetProperty<String> = objects.setProperty(String::class.java)
 
     @get:Internal
-    val values get() = Values(
-        forDelete.get(),
-        forStub.get(),
-        forRemove.get(),
-        forSanitise.get()
-    )
+    val values: Provider<Values> = forDelete.flatMap { delete ->
+        forStub.flatMap { stub ->
+            forRemove.flatMap { remove ->
+                forSanitise.map { sanitise ->
+                    Values(delete, stub, remove, sanitise)
+                }
+            }
+        }
+    }
 
     class Values(
         val forDelete: Set<String>,


### PR DESCRIPTION
Prevent JarFilter tasks from recalculating the names of their output files every single time.