### PR TITLE
NOTICK: Ensure that ZipFiles used for testing are always closed afterwards.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ This metadata is currently optional, but you are _strongly_ advised to provide i
     <sup>Requires Gradle 5.1</sup>
 
 - [`net.corda.plugins.cordformation`](cordformation/README.rst)\
-This plugin provides `Cordform` and `Dockerform` Gradle tasks for creating
-test deployments of multiple Corda nodes and their CorDapps. It also invokes
-the Network Bootstrapper over the deployment for you, and provides you with a
-`runnodes` script to boot it all up afterwards.
+This plugin provides `Cordform`, `Dockerform` and `DockerImage` Gradle tasks
+for creating test deployments of multiple Corda nodes and their CorDapps. It
+also invokes the Network Bootstrapper over the deployment for you, and provides
+you with a `runnodes` script to boot it all up afterwards.
 
     <sup>Requires Gradle 5.1</sup>
 

--- a/cordapp/src/test/kotlin/net/corda/plugins/CordappGradleConfigurationsTest.kt
+++ b/cordapp/src/test/kotlin/net/corda/plugins/CordappGradleConfigurationsTest.kt
@@ -16,6 +16,7 @@ class CordappGradleConfigurationsTest {
         private lateinit var testProject: GradleProject
         private lateinit var poms: List<ZipEntry>
 
+        @Suppress("unused")
         @BeforeAll
         @JvmStatic
         fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
@@ -55,9 +56,10 @@ class CordappGradleConfigurationsTest {
             val cordapp = testProject.pathOf("build", "libs", "configurations.jar")
             assertThat(cordapp).isRegularFile()
 
-            poms = ZipFile(cordapp.toFile()).stream()
-                .filter { entry -> entry.name.endsWith("/pom.xml") }
-                .collect(toList())
+            poms = ZipFile(cordapp.toFile()).use { zip ->
+                zip.stream().filter { entry -> entry.name.endsWith("/pom.xml") }
+                   .collect(toList())
+            }
         }
     }
 

--- a/cordapp/src/test/kotlin/net/corda/plugins/CordappLibraryGradleConfigurationsTest.kt
+++ b/cordapp/src/test/kotlin/net/corda/plugins/CordappLibraryGradleConfigurationsTest.kt
@@ -16,6 +16,7 @@ class CordappLibraryGradleConfigurationsTest {
         private lateinit var testProject: GradleProject
         private lateinit var poms: List<ZipEntry>
 
+        @Suppress("unused")
         @BeforeAll
         @JvmStatic
         fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
@@ -57,9 +58,10 @@ class CordappLibraryGradleConfigurationsTest {
             val cordapp = testProject.pathOf("build", "libs", "configurations.jar")
             assertThat(cordapp).isRegularFile()
 
-            poms = ZipFile(cordapp.toFile()).stream()
-                .filter { entry -> entry.name.endsWith("/pom.xml") }
-                .collect(toList())
+            poms = ZipFile(cordapp.toFile()).use { zip ->
+                zip.stream().filter { entry -> entry.name.endsWith("/pom.xml") }
+                   .collect(toList())
+            }
         }
     }
 

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/Utilities.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/Utilities.kt
@@ -90,8 +90,9 @@ fun <T> ClassLoader.load(className: String)
 
 fun Path.getClassNames(prefix: String): List<String> {
     val resourcePrefix = prefix.toPathFormat
-    return ZipFile(toFile()).stream()
-        .filter { it.name.startsWith(resourcePrefix) && it.name.endsWith(".class") }
-        .map { it.name.removeSuffix(".class").toPackageFormat }
-        .collect(toList<String>())
+    return ZipFile(toFile()).use { zip ->
+        zip.stream().filter { it.name.startsWith(resourcePrefix) && it.name.endsWith(".class") }
+           .map { it.name.removeSuffix(".class").toPackageFormat }
+           .collect(toList<String>())
+    }
 }


### PR DESCRIPTION
Windows cannot delete an open file, so ensure that instances of `ZipFile` used in the tests are always closed.

And mention the `DockerImage` task in the README too - it can't hurt :wink:.