### PR TITLE
CORDA-3884: Refactor publish-utils to use a single root project listener.

### DIFF
--- a/publish-utils/src/main/groovy/net/corda/plugins/publish/MavenMapper.groovy
+++ b/publish-utils/src/main/groovy/net/corda/plugins/publish/MavenMapper.groovy
@@ -1,6 +1,7 @@
 package net.corda.plugins.publish
 
 import groovy.transform.CompileStatic
+import groovy.transform.PackageScope
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.Dependency
@@ -9,6 +10,7 @@ import org.gradle.api.artifacts.ResolvedConfiguration
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 
 @CompileStatic
+@PackageScope
 class MavenMapper {
     private final Map<ModuleVersionIdentifier, String> publishedAliases
     private final Set<ModuleVersionIdentifier> apiElements
@@ -16,6 +18,7 @@ class MavenMapper {
     private final Set<ModuleVersionIdentifier> compile
     private final Set<ModuleVersionIdentifier> runtime
 
+    @PackageScope
     MavenMapper(ConfigurationContainer configurations, ResolvedConfiguration resolvedConfiguration) {
         // Ensure that we use these artifacts' published names, because
         // these aren't necessarily the same as their internal names.
@@ -29,6 +32,7 @@ class MavenMapper {
         runtime = resolveArtifactsFor(configurations, "runtimeClasspath")
     }
 
+    @PackageScope
     String getScopeFor(ModuleVersionIdentifier id, String defaultScope) {
         if (compile.contains(id) && (!compileOnly.contains(id) || apiElements.contains(id))) {
             // This dependency is on the compile classpath. Also, it has
@@ -45,6 +49,7 @@ class MavenMapper {
         }
     }
 
+    @PackageScope
     String getModuleNameFor(ModuleVersionIdentifier id) {
         return publishedAliases[id]
     }

--- a/publish-utils/src/main/groovy/net/corda/plugins/publish/PublishPlugin.groovy
+++ b/publish-utils/src/main/groovy/net/corda/plugins/publish/PublishPlugin.groovy
@@ -32,10 +32,11 @@ class PublishPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
+        publishConfig = project.extensions.create(PUBLISH_EXTENSION_NAME, PublishExtension, project.name)
         if (project == project.rootProject) {
             project.extensions.create(BINTRAY_CONFIG_EXTENSION_NAME, BintrayConfigExtension)
+            createRootProjectListener(project)
         }
-        publishConfig = project.extensions.create(PUBLISH_EXTENSION_NAME, PublishExtension, project.name)
 
         // We cannot register new tasks inside the project's afterEvaluate handler,
         // which means we cannot risk registering plugins there either.
@@ -44,11 +45,10 @@ class PublishPlugin implements Plugin<Project> {
 
         createTasks(project)
         createConfigurations(project)
-        createProjectListener(project)
     }
 
-    private void createProjectListener(Project project) {
-        project.gradle.addListener(new PublishConfigurationProjectListener(publishConfig, project))
+    private void createRootProjectListener(Project rootProject) {
+        rootProject.gradle.addListener(new PublishConfigurationProjectListener(rootProject))
     }
 
     private void createTasks(Project project) {


### PR DESCRIPTION
Only install `PublishConfigurationProjectListener` for the root project, and allow it to listen for all other projects.