### PR TITLE
NOTICK: Close open files to prevent test failures on Windows.

### DIFF
--- a/cordapp/src/test/kotlin/net/corda/plugins/CordappTest.kt
+++ b/cordapp/src/test/kotlin/net/corda/plugins/CordappTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
+import java.nio.file.NoSuchFileException
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.jar.JarInputStream
@@ -268,6 +269,8 @@ class CordappTest {
                 .withPluginClasspath()
     }
 
-    private fun createBuildFile(buildFileResourceName: String) = Files.copy(javaClass.getResourceAsStream(buildFileResourceName), buildFile)
+    private fun createBuildFile(buildFileResourceName: String): Long = javaClass.getResourceAsStream(buildFileResourceName)?.use { s ->
+        Files.copy(s, buildFile)
+    } ?: throw NoSuchFileException(buildFileResourceName)
     private fun getCordappJar(cordappJarName: String): Path = Paths.get(testProjectDir.toFile().absolutePath, "build", "libs", "$cordappJarName.jar")
 }

--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
@@ -24,8 +24,10 @@ class Cordformation : Plugin<Project> {
             val tmpDir = File(project.buildDir, "tmp")
             val outputFile = File(tmpDir, filePathInJar)
             tmpDir.mkdir()
-            outputFile.outputStream().use {
-                Cordformation::class.java.getResourceAsStream(filePathInJar).copyTo(it)
+            outputFile.outputStream().use { output ->
+                Cordformation::class.java.getResourceAsStream(filePathInJar)?.use { input ->
+                    input.copyTo(output)
+                }
             }
             return outputFile
         }

--- a/cordformation/src/test/kotlin/net/corda/plugins/DockerformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/DockerformTest.kt
@@ -138,7 +138,9 @@ class DockerformTest : BaseformTest() {
 
         val dockerComposePath = getDockerCompose()
 
-        val yaml = Yaml().load(dockerComposePath.toFile().bufferedReader()) as Map<String, Any>
+        val yaml = dockerComposePath.toFile().bufferedReader().use { reader ->
+            Yaml().load(reader) as Map<String, Any>
+        }
         assertThat(yaml).containsKey("services")
 
         val services = yaml["services"] as Map<String, Any>

--- a/cordformation/src/test/resources/net/corda/plugins/DeployDockerImage.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeployDockerImage.gradle
@@ -15,7 +15,7 @@ dependencies {
     cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
-    runtimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 def dockerImage = tasks.register('dockerImage', net.corda.plugins.DockerImage) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordapp.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordapp.gradle
@@ -9,7 +9,7 @@ dependencies {
     cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
-    runtimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappBackwardsCompatibility.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappBackwardsCompatibility.gradle
@@ -9,7 +9,7 @@ dependencies {
     cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
-    runtimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappConfig.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappConfig.gradle
@@ -9,7 +9,7 @@ dependencies {
     cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
-    runtimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappWithDocker.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappWithDocker.gradle
@@ -9,6 +9,7 @@ dependencies {
     cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
+    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task prepareDockerNodes(type: net.corda.plugins.Dockerform) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappWithNetworkConfigWithDocker.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappWithNetworkConfigWithDocker.gradle
@@ -9,6 +9,7 @@ dependencies {
     cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
+    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task prepareDockerNodes(type: net.corda.plugins.Dockerform) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappWithOU.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappWithOU.gradle
@@ -9,7 +9,7 @@ dependencies {
     cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
-    runtimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithExternalDBSettingsWithDocker.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithExternalDBSettingsWithDocker.gradle
@@ -10,6 +10,7 @@ dependencies {
     cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
+    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task prepareDockerNodes(type: net.corda.plugins.Dockerform, dependsOn: 'generateInitScripts') {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithExtraCommandForDbSchema.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithExtraCommandForDbSchema.gradle
@@ -19,6 +19,7 @@ dependencies {
     cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
+    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
@@ -7,7 +7,7 @@ apply from: 'repositories.gradle'
 dependencies {
     cordaRuntime "$corda_group:corda:$corda_release_version"
     cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
-    runtimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 jar {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithNetworkParameterOverrides.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithNetworkParameterOverrides.gradle
@@ -18,7 +18,7 @@ dependencies {
     cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$finance_release_version"
     cordapp "$corda_group:corda-finance-workflows:$finance_release_version"
-    runtimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeployThreeNodeCordappWithExternalDBSettingsWithDocker.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeployThreeNodeCordappWithExternalDBSettingsWithDocker.gradle
@@ -10,6 +10,7 @@ dependencies {
     cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
+    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task prepareDockerNodes(type: net.corda.plugins.Dockerform, dependsOn: ['generateInitScripts', 'jar']) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeployThreeNodeCordappWithExternalDBSettingsWithNetworkConfigWithDocker.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeployThreeNodeCordappWithExternalDBSettingsWithNetworkConfigWithDocker.gradle
@@ -10,6 +10,7 @@ dependencies {
     cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
+    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task prepareDockerNodes(type: net.corda.plugins.Dockerform, dependsOn: ['generateInitScripts', 'jar']) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeployTwoNodeCordappWithDocker.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeployTwoNodeCordappWithDocker.gradle
@@ -9,6 +9,7 @@ dependencies {
     cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
+    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task prepareDockerNodes(type: net.corda.plugins.Dockerform, dependsOn: ['jar']) {


### PR DESCRIPTION
Windows cannot delete open files, so ensure that streams and reader objects created during the tests are closed afterwards.
Also fix some trivial compiler warnings, and ensure that Network Bootstrapper has a simple SLF4J back-end available for the `cordformation` tests.