### PR TITLE
NOTICK: Fix basic warnings and errors when building on JDK11.

### DIFF
--- a/cordformation/build.gradle
+++ b/cordformation/build.gradle
@@ -8,7 +8,7 @@ plugins {
 description 'Cordformation allows you to build your own local Corda networks for development.'
 
 ext {
-    corda_release_version = '4.0'
+    corda_release_version = '4.3'
 }
 
 repositories {

--- a/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
@@ -285,10 +285,10 @@ open class Baseform(objects: ObjectFactory) : DefaultTask() {
         try {
             if (networkParameterOverrides.isEmpty()) {
                 val bootstrapMethod = networkBootstrapperClass.getMethod("bootstrapCordform", Path::class.java, List::class.java).apply { isAccessible = true }
-                bootstrapMethod.invoke(networkBootstrapperClass.newInstance(), rootDir, allCordapps)
+                bootstrapMethod.invoke(networkBootstrapperClass.getDeclaredConstructor().newInstance(), rootDir, allCordapps)
             } else {
                 val bootstrapMethod = networkBootstrapperClass.getMethod("bootstrapCordform", Path::class.java, List::class.java, String::class.java).apply { isAccessible = true }
-                bootstrapMethod.invoke(networkBootstrapperClass.newInstance(), rootDir, allCordapps, networkParameterOverrides.toConfig().root().render(ConfigRenderOptions.concise()))
+                bootstrapMethod.invoke(networkBootstrapperClass.getDeclaredConstructor().newInstance(), rootDir, allCordapps, networkParameterOverrides.toConfig().root().render(ConfigRenderOptions.concise()))
             }
         } catch (e: NoSuchMethodException) {
             throw InvalidUserDataException("Unrecognised configuration options passed. Please ensure you're using the correct 'corda-node-api' version on Gradle's runtime classpath.", e)

--- a/cordformation/src/test/kotlin/net/corda/plugins/BaseformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/BaseformTest.kt
@@ -18,8 +18,8 @@ open class BaseformTest {
     lateinit var buildFile: Path
 
     companion object {
-        const val cordaFinanceWorkflowsJarName = "corda-finance-workflows-4.0"
-        const val cordaFinanceContractsJarName = "corda-finance-contracts-4.0"
+        const val cordaFinanceWorkflowsJarName = "corda-finance-workflows-4.3"
+        const val cordaFinanceContractsJarName = "corda-finance-contracts-4.3"
         const val localCordappJarName = "locally-built-cordapp"
         const val notaryNodeName = "NotaryService"
         const val notaryNodeUnitName = "OrgUnit"
@@ -33,7 +33,11 @@ open class BaseformTest {
     }
 
 
-    fun getStandardGradleRunnerFor(buildFileResourceName: String, taskName: String = "deployNodes"): GradleRunner {
+    fun getStandardGradleRunnerFor(
+            buildFileResourceName: String,
+            taskName: String = "deployNodes",
+            vararg extraArgs: String
+    ): GradleRunner {
         createBuildFile(buildFileResourceName)
         installResource("settings.gradle")
         installResource("repositories.gradle")
@@ -42,7 +46,7 @@ open class BaseformTest {
         return GradleRunner.create()
                 .withDebug(true)
                 .withProjectDir(testProjectDir.toFile())
-                .withArguments(taskName, "-s", "--info", "-g", testGradleUserHome)
+                .withArguments(taskName, "-s", "--info", "-g", testGradleUserHome, *extraArgs)
                 .withPluginClasspath()
     }
 

--- a/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
@@ -18,14 +18,21 @@ import java.time.Duration
 class CordformTest : BaseformTest() {
     @Test
     fun `network parameter overrides`() {
-        val runner = getStandardGradleRunnerFor("DeploySingleNodeWithNetworkParameterOverrides.gradle")
+        val financeReleaseVersion = "4.0"
+        val cordaReleaseVersion = "4.3"
+
+        val runner = getStandardGradleRunnerFor(
+            "DeploySingleNodeWithNetworkParameterOverrides.gradle",
+            "deployNodes",
+            "-Pcorda_release_version=$cordaReleaseVersion", "-Pfinance_release_version=$financeReleaseVersion"
+        )
         installResource("testkeystore")
 
         val result = runner.build()
 
         assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
-        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile()
+        assertThat(getNodeCordappJar(notaryNodeName, "corda-finance-workflows-$financeReleaseVersion")).isRegularFile()
+        assertThat(getNodeCordappJar(notaryNodeName, "corda-finance-contracts-$financeReleaseVersion")).isRegularFile()
         assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile()
 
         ThreadLocalToggleField<SerializationEnvironment>("contextSerializationEnv")
@@ -58,8 +65,14 @@ class CordformTest : BaseformTest() {
     }
 
     @Test
-    fun `a node that requires an extra command to create schema`(){
-        val runner = getStandardGradleRunnerFor("DeploySingleNodeWithExtraCommandForDbSchema.gradle")
+    fun `a node that requires an extra command to create schema`() {
+        val cordaReleaseVersion = "4.6-20200608_123659-1da174c"
+
+        val runner = getStandardGradleRunnerFor(
+            "DeploySingleNodeWithExtraCommandForDbSchema.gradle",
+            "deployNodes",
+            "-Pcorda_release_version=$cordaReleaseVersion"
+        )
 
         val result = runner.build()
 
@@ -123,25 +136,25 @@ class CordformTest : BaseformTest() {
         val jarName = "corda"
 
         var releaseVersion = "4.3"
-        var pattern = "\\Q$jarName\\E(-enterprise)?-\\Q$releaseVersion\\E(-.+)?\\.jar\$".toRegex()
-        assertThat("corda-4.3.jar".contains(pattern)).isTrue()
-        assertThat("corda-4.3.jar".contains(pattern)).isTrue()
-        assertThat("corda-4.3.jarBla".contains(pattern)).isFalse()
-        assertThat("bla\\bla\\bla\\corda-4.3.jar".contains(pattern)).isTrue()
-        assertThat("corda-4.3-jdk11.jar".contains(pattern)).isTrue()
-        assertThat("corda-4.3jdk11.jar".contains(pattern)).isFalse()
-        assertThat("bla\\bla\\bla\\corda-enterprise-4.3.jar".contains(pattern)).isTrue()
-        assertThat("corda-enterprise-4.3.jar".contains(pattern)).isTrue()
-        assertThat("corda-enterprise-4.3-jdk11.jar".contains(pattern)).isTrue()
+        var pattern = "\\Q$jarName\\E(-enterprise)?-\\Q$releaseVersion\\E(-.+)?\\.jar\$".toRegex().pattern
+        assertThat("corda-4.3.jar").containsPattern(pattern)
+        assertThat("corda-4.3.jar").containsPattern(pattern)
+        assertThat("corda-4.3.jarBla").doesNotContainPattern(pattern)
+        assertThat("bla\\bla\\bla\\corda-4.3.jar").containsPattern(pattern)
+        assertThat("corda-4.3-jdk11.jar").containsPattern(pattern)
+        assertThat("corda-4.3jdk11.jar").doesNotContainPattern(pattern)
+        assertThat("bla\\bla\\bla\\corda-enterprise-4.3.jar").containsPattern(pattern)
+        assertThat("corda-enterprise-4.3.jar").containsPattern(pattern)
+        assertThat("corda-enterprise-4.3-jdk11.jar").containsPattern(pattern)
 
         releaseVersion = "4.3-RC01"
-        pattern = "\\Q$jarName\\E(-enterprise)?-\\Q$releaseVersion\\E(-.+)?\\.jar\$".toRegex()
-        assertThat("corda-4.3-RC01.jar".contains(pattern)).isTrue()
-        assertThat("corda-4.3RC01.jar".contains(pattern)).isFalse()
+        pattern = "\\Q$jarName\\E(-enterprise)?-\\Q$releaseVersion\\E(-.+)?\\.jar\$".toRegex().pattern
+        assertThat("corda-4.3-RC01.jar").containsPattern(pattern)
+        assertThat("corda-4.3RC01.jar").doesNotContainPattern(pattern)
 
         releaseVersion = "4.3.20190925"
-        pattern = "\\Q$jarName\\E(-enterprise)?-\\Q$releaseVersion\\E(-.+)?\\.jar\$".toRegex()
-        assertThat("corda-4.3.20190925.jar".contains(pattern)).isTrue()
-        assertThat("corda-4.3.20190925-TEST.jar".contains(pattern)).isTrue()
+        pattern = "\\Q$jarName\\E(-enterprise)?-\\Q$releaseVersion\\E(-.+)?\\.jar\$".toRegex().pattern
+        assertThat("corda-4.3.20190925.jar").containsPattern(pattern)
+        assertThat("corda-4.3.20190925-TEST.jar").containsPattern(pattern)
     }
 }

--- a/cordformation/src/test/kotlin/net/corda/plugins/DockerImageTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/DockerImageTest.kt
@@ -27,8 +27,8 @@ class DockerImageTest :BaseformTest() {
         val result = runner.build()
 
         Assertions.assertThat(result.task(":dockerImage")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        Assertions.assertThat(Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker","corda-finance-contracts-4.0.jar")).isRegularFile()
-        Assertions.assertThat(Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker","corda-finance-workflows-4.0.jar")).isRegularFile()
+        Assertions.assertThat(Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker","corda-finance-contracts-4.3.jar")).isRegularFile()
+        Assertions.assertThat(Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker","corda-finance-workflows-4.3.jar")).isRegularFile()
         Assertions.assertThat(Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker","dummyJar.jar")).isRegularFile()
     }
 }

--- a/cordformation/src/test/resources/gradle.properties
+++ b/cordformation/src/test/resources/gradle.properties
@@ -2,8 +2,8 @@
 org.gradle.jvmargs=-XX:+UseG1GC -Xmx512m
 org.gradle.caching=false
 corda_group=net.corda
-corda_release_version=4.0
+corda_release_version=4.3
 jolokia_version=1.6.0
-docker_image_name=corda/corda-zulu-4.0
+docker_image_name=corda/corda-zulu-4.3
 
 slf4j_version=1.7.26

--- a/cordformation/src/test/resources/net/corda/plugins/DeployDockerImage.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeployDockerImage.gradle
@@ -2,13 +2,7 @@ plugins {
     id 'net.corda.plugins.cordformation'
 }
 
-
-
-repositories {
-    mavenCentral()
-    maven { url 'https://software.r3.com/artifactory/corda-releases' }
-
-}
+apply from: 'repositories.gradle'
 
 dependencies {
     cordaRuntime "$corda_group:corda:$corda_release_version"

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithExtraCommandForDbSchema.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithExtraCommandForDbSchema.gradle
@@ -1,9 +1,3 @@
-buildscript {
-    ext {
-        corda_release_version = '4.6-20200608_123659-1da174c'
-    }
-}
-
 plugins {
     id 'net.corda.plugins.cordformation'
 }

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithNetworkParameterOverrides.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithNetworkParameterOverrides.gradle
@@ -1,12 +1,5 @@
 import java.time.Duration
 
-buildscript {
-    ext {
-        corda_release_version = '4.3'
-        finance_release_version = '4.0'
-    }
-}
-
 plugins {
     id 'net.corda.plugins.cordformation'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,5 +16,5 @@ docker_client_version=8.15.1
 javax_annotations_version=1.3.2
 
 bintray_version=1.8.5
-artifactory_version=4.16.0
+artifactory_version=4.16.1
 gradle_publish_version=0.12.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,7 @@ junit_jupiter_version=5.6.2
 hamcrest_version=2.1
 asm_version=7.3.1
 docker_client_version=8.15.1
+javax_annotations_version=1.3.2
 
 bintray_version=1.8.5
 artifactory_version=4.16.0

--- a/jar-filter/build.gradle
+++ b/jar-filter/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     testImplementation "org.assertj:assertj-core:$assertj_version"
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_jupiter_version"
+    testImplementation "javax.annotation:javax.annotation-api:$javax_annotations_version"
     testImplementation project(':jar-filter:unwanteds')
 
     jacocoRuntime "org.jacoco:org.jacoco.agent:${jacoco.toolVersion}:runtime"
@@ -66,6 +67,7 @@ dependencies {
 processTestResources {
     filesMatching('gradle.properties') {
         expand(['jacocoAgent': configurations.jacocoRuntime.asPath.replace('\\', '/'),
+                'javax_annotations_version': javax_annotations_version,
                 'kotlin_api_version': test_kotlin_api_version,
                 'kotlin_version': kotlin_version,
                 'buildDir': buildDir])

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteFunctionTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteFunctionTest.kt
@@ -36,7 +36,7 @@ class DeleteFunctionTest {
     fun deleteFunction() {
         classLoaderFor(testProject.sourceJar).use { cl ->
             with(cl.load<HasUnwantedFun>(FUNCTION_CLASS)) {
-                newInstance().also {
+                getDeclaredConstructor().newInstance().also {
                     assertEquals(MESSAGE, it.unwantedFun(MESSAGE))
                 }
                 assertThat("unwantedFun(String) not found", kotlin.declaredFunctions, hasItem(unwantedFun))
@@ -45,7 +45,7 @@ class DeleteFunctionTest {
 
         classLoaderFor(testProject.filteredJar).use { cl ->
             with(cl.load<HasUnwantedFun>(FUNCTION_CLASS)) {
-                newInstance().also {
+                getDeclaredConstructor().newInstance().also {
                     assertFailsWith<AbstractMethodError> { it.unwantedFun(MESSAGE) }
                 }
                 assertThat("unwantedFun(String) still exists", kotlin.declaredFunctions, not(hasItem(unwantedFun)))
@@ -91,7 +91,7 @@ class DeleteFunctionTest {
                 assertThat("Java unwantedFun\$default(String) is missing", declaredMethods.toList(), hasItem(javaDefaultUnwantedFun))
 
                 val function = kotlin.declaredFunctions.single { it.name == "unwantedFun" }
-                newInstance().also {
+                getDeclaredConstructor().newInstance().also {
                     assertEquals(MESSAGE, function.call(it, MESSAGE))
                     assertEquals(DEFAULT_MESSAGE, function.callBy(mapOf(function.parameters[0] to it)))
                 }
@@ -106,7 +106,7 @@ class DeleteFunctionTest {
                 val javaDefaultUnwantedFun = isMethod("unwantedFun\$default", String::class.java, this, String::class.java, Integer.TYPE, Any::class.java)
                 assertThat("Java unwantedFun\$default(String) still exists", declaredMethods.toList(), not(hasItem(javaDefaultUnwantedFun)))
 
-                assertNotNull(newInstance())
+                assertNotNull(getDeclaredConstructor().newInstance())
             }
         }
     }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteOverloadedFunctionTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteOverloadedFunctionTest.kt
@@ -33,7 +33,7 @@ class DeleteOverloadedFunctionTest {
     fun deleteFunction() {
         classLoaderFor(testProject.sourceJar).use { cl ->
             with(cl.load<Any>(FUNCTION_CLASS)) {
-                newInstance().also {
+                getDeclaredConstructor().newInstance().also {
                     assertEquals(MESSAGE, getDeclaredMethod("stringData", String::class.java).invoke(it, MESSAGE))
                     assertEquals("$NUMBER: $MESSAGE",
                         getDeclaredMethod("stringData", Int::class.java, String::class.java).invoke(it, NUMBER, MESSAGE))
@@ -45,7 +45,7 @@ class DeleteOverloadedFunctionTest {
 
         classLoaderFor(testProject.filteredJar).use { cl ->
             with(cl.load<Any>(FUNCTION_CLASS)) {
-                newInstance().also {
+                getDeclaredConstructor().newInstance().also {
                     assertFailsWith<NoSuchMethodException> { getDeclaredMethod("stringData", String::class.java) }
                     assertEquals("$NUMBER: $MESSAGE",
                         getDeclaredMethod("stringData", Int::class.java, String::class.java).invoke(it, NUMBER, MESSAGE))
@@ -60,7 +60,7 @@ class DeleteOverloadedFunctionTest {
     fun deleteFunctionWithLambda() {
         classLoaderFor(testProject.sourceJar).use { cl ->
             with(cl.load<Any>(LAMBDA_CLASS)) {
-                newInstance().also {
+                getDeclaredConstructor().newInstance().also {
                     assertEquals("[$MESSAGE]", getDeclaredMethod("lambdaData", String::class.java).invoke(it, MESSAGE))
                     assertEquals("($NUMBER)", getDeclaredMethod("lambdaData", Int::class.java).invoke(it, NUMBER))
                 }
@@ -70,7 +70,7 @@ class DeleteOverloadedFunctionTest {
 
         classLoaderFor(testProject.filteredJar).use { cl ->
             with(cl.load<Any>(LAMBDA_CLASS)) {
-                newInstance().also {
+                getDeclaredConstructor().newInstance().also {
                     assertFailsWith<NoSuchMethodException> { getDeclaredMethod("lambdaData", String::class.java) }
                     assertEquals("($NUMBER)", getDeclaredMethod("lambdaData", Int::class.java).invoke(it, NUMBER))
                 }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConfigurationTests.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConfigurationTests.kt
@@ -55,13 +55,23 @@ class MetaFixConfigurationTests {
         output = result.output
         println(output)
 
-        assertThat(output).containsSubsequence(
-            "Caused by: org.gradle.api.InvalidUserCodeException:",
-            "Caused by: java.io.FileNotFoundException:"
-        )
+        val exceptions = output.reader().readLines()
+            .filter { it.startsWith("Caused by: ") }
+            .map(::extractExceptionName)
+
+        assertThat(exceptions).hasSize(2)
+        assertThat(exceptions[0]).isEqualTo("org.gradle.api.InvalidUserCodeException")
+        assertThat(exceptions[1]).isIn("java.io.FileNotFoundException", "java.nio.file.NoSuchFileException")
 
         val metafix = result.forTask("metafix")
         assertEquals(FAILED, metafix.outcome)
+    }
+
+    // The exception class name comes after "Caused by:" and is followed by another ':'.
+    private fun extractExceptionName(text: String): String {
+        val startIdx = text.indexOf(':') + 1
+        val endIdx = text.indexOf(':', startIdx)
+        return text.substring(startIdx, endIdx).trim()
     }
 
     private fun gradleProject(script: String): GradleRunner {

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFieldValPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFieldValPropertyTest.kt
@@ -25,14 +25,14 @@ class MetaFixFieldValPropertyTest {
 
         // Check that the unwanted property has been successfully
         // added to the metadata, and that the class is valid.
-        val sourceObj = sourceClass.newInstance()
+        val sourceObj = sourceClass.getDeclaredConstructor().newInstance()
         assertEquals(NUMBER, sourceClass.getField("wantedVal").get(sourceObj))
         assertThat("unwantedVal not found", sourceClass.kotlin.declaredMemberProperties, hasItem(unwantedVal))
         assertThat("wantedVal not found", sourceClass.kotlin.declaredMemberProperties, hasItem(wantedVal))
 
         // Rewrite the metadata according to the contents of the bytecode.
         val fixedClass = bytecode.fixMetadata(logger, pathsOf(WithFieldValProperty::class)).toClass<WithFieldValProperty, Any>()
-        val fixedObj = fixedClass.newInstance()
+        val fixedObj = fixedClass.getDeclaredConstructor().newInstance()
         assertEquals(NUMBER, fixedClass.getField("wantedVal").get(fixedObj))
         assertThat("unwantedVal still exists", fixedClass.kotlin.declaredMemberProperties, not(hasItem(unwantedVal)))
         assertThat("wantedVal not found", fixedClass.kotlin.declaredMemberProperties, hasItem(wantedVal))

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFieldVarPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFieldVarPropertyTest.kt
@@ -25,14 +25,14 @@ class MetaFixFieldVarPropertyTest {
 
         // Check that the unwanted property has been successfully
         // added to the metadata, and that the class is valid.
-        val sourceObj = sourceClass.newInstance()
+        val sourceObj = sourceClass.getDeclaredConstructor().newInstance()
         assertEquals(NUMBER, sourceClass.getField("wantedVar").get(sourceObj))
         assertThat("unwantedVar not found", sourceClass.kotlin.declaredMemberProperties, hasItem(unwantedVar))
         assertThat("wantedVar not found", sourceClass.kotlin.declaredMemberProperties, hasItem(wantedVar))
 
         // Rewrite the metadata according to the contents of the bytecode.
         val fixedClass = bytecode.fixMetadata(logger, pathsOf(WithFieldVarProperty::class)).toClass<WithFieldVarProperty, Any>()
-        val fixedObj = fixedClass.newInstance()
+        val fixedObj = fixedClass.getDeclaredConstructor().newInstance()
         assertEquals(NUMBER, fixedClass.getField("wantedVar").get(fixedObj))
         assertThat("unwantedVar still exists", fixedClass.kotlin.declaredMemberProperties, not(hasItem(unwantedVar)))
         assertThat("wantedVar not found", fixedClass.kotlin.declaredMemberProperties, hasItem(wantedVar))

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFunctionDefaultParameterTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFunctionDefaultParameterTest.kt
@@ -43,13 +43,13 @@ class MetaFixFunctionDefaultParameterTest {
         }
 
         val sourceUnwanted = sourceClass.kotlin.declaredFunctions.findOrFail("hasMandatoryParams")
-        assertThat(sourceUnwanted.call(sourceClass.newInstance(), BIG_NUMBER, NUMBER, MESSAGE))
+        assertThat(sourceUnwanted.call(sourceClass.getDeclaredConstructor().newInstance(), BIG_NUMBER, NUMBER, MESSAGE))
             .isEqualTo("Long: $BIG_NUMBER, Int: $NUMBER, String: $MESSAGE")
 
         assertTrue(sourceUnwanted.hasAllOptionalParameters, "All source parameters should be optional")
 
         val sourceWanted = sourceClass.kotlin.declaredFunctions.findOrFail("hasOptionalParams")
-        assertThat(sourceWanted.call(sourceClass.newInstance(), MESSAGE))
+        assertThat(sourceWanted.call(sourceClass.getDeclaredConstructor().newInstance(), MESSAGE))
             .isEqualTo(MESSAGE)
 
         assertTrue(sourceWanted.hasAllOptionalParameters, "All source parameters should be optional")

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFunctionTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFunctionTest.kt
@@ -26,7 +26,7 @@ class MetaFixFunctionTest {
 
         // Check that the unwanted function has been successfully
         // added to the metadata, and that the class is valid.
-        val sourceObj = sourceClass.newInstance()
+        val sourceObj = sourceClass.getDeclaredConstructor().newInstance()
         assertEquals(BIG_NUMBER, sourceObj.longData())
         with(sourceClass.kotlin.declaredFunctions) {
             assertThat("unwantedFun(String) not found", this, hasItem(unwantedFun))
@@ -35,7 +35,7 @@ class MetaFixFunctionTest {
 
         // Rewrite the metadata according to the contents of the bytecode.
         val fixedClass = bytecode.fixMetadata(logger, pathsOf(WithFunction::class)).toClass<WithFunction, HasLong>()
-        val fixedObj = fixedClass.newInstance()
+        val fixedObj = fixedClass.getDeclaredConstructor().newInstance()
         assertEquals(BIG_NUMBER, fixedObj.longData())
         with(fixedClass.kotlin.declaredFunctions) {
             assertThat("unwantedFun(String) still exists", this, not(hasItem(unwantedFun)))

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixValPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixValPropertyTest.kt
@@ -26,14 +26,14 @@ class MetaFixValPropertyTest {
 
         // Check that the unwanted property has been successfully
         // added to the metadata, and that the class is valid.
-        val sourceObj = sourceClass.newInstance()
+        val sourceObj = sourceClass.getDeclaredConstructor().newInstance()
         assertEquals(NUMBER, sourceObj.intVal)
         assertThat("unwantedVal not found", sourceClass.kotlin.declaredMemberProperties, hasItem(unwantedVal))
         assertThat("intVal not found", sourceClass.kotlin.declaredMemberProperties, hasItem(intVal))
 
         // Rewrite the metadata according to the contents of the bytecode.
         val fixedClass = bytecode.fixMetadata(logger, pathsOf(WithValProperty::class)).toClass<WithValProperty, HasIntVal>()
-        val fixedObj = fixedClass.newInstance()
+        val fixedObj = fixedClass.getDeclaredConstructor().newInstance()
         assertEquals(NUMBER, fixedObj.intVal)
         assertThat("unwantedVal still exists", fixedClass.kotlin.declaredMemberProperties, not(hasItem(unwantedVal)))
         assertThat("intVal not found", fixedClass.kotlin.declaredMemberProperties, hasItem(intVal))

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixVarPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixVarPropertyTest.kt
@@ -26,14 +26,14 @@ class MetaFixVarPropertyTest {
 
         // Check that the unwanted property has been successfully
         // added to the metadata, and that the class is valid.
-        val sourceObj = sourceClass.newInstance()
+        val sourceObj = sourceClass.getDeclaredConstructor().newInstance()
         assertEquals(NUMBER, sourceObj.intVar)
         assertThat("unwantedVar not found", sourceClass.kotlin.declaredMemberProperties, hasItem(unwantedVar))
         assertThat("intVar not found", sourceClass.kotlin.declaredMemberProperties, hasItem(intVar))
 
         // Rewrite the metadata according to the contents of the bytecode.
         val fixedClass = bytecode.fixMetadata(logger, pathsOf(WithVarProperty::class)).toClass<WithVarProperty, HasIntVar>()
-        val fixedObj = fixedClass.newInstance()
+        val fixedObj = fixedClass.getDeclaredConstructor().newInstance()
         assertEquals(NUMBER, fixedObj.intVar)
         assertThat("unwantedVar still exists", fixedClass.kotlin.declaredMemberProperties, not(hasItem(unwantedVar)))
         assertThat("intVar not found", fixedClass.kotlin.declaredMemberProperties, hasItem(intVar))

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/SanitiseDeleteConstructorTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/SanitiseDeleteConstructorTest.kt
@@ -66,7 +66,7 @@ class SanitiseDeleteConstructorTest {
 
                 val noArg = kotlin.noArgConstructor ?: fail("no-arg constructor missing")
                 assertThat(noArg.callBy(emptyMap()).longData()).isEqualTo(0)
-                assertThat(newInstance().longData()).isEqualTo(0)
+                assertThat(getDeclaredConstructor().newInstance().longData()).isEqualTo(0)
             }
         }
 
@@ -124,7 +124,7 @@ class SanitiseDeleteConstructorTest {
 
                 val noArg = kotlin.noArgConstructor ?: fail("no-arg constructor missing")
                 assertThat(noArg.callBy(emptyMap()).intData()).isEqualTo(0)
-                assertThat(newInstance().intData()).isEqualTo(0)
+                assertThat(getDeclaredConstructor().newInstance().intData()).isEqualTo(0)
             }
         }
 
@@ -180,7 +180,7 @@ class SanitiseDeleteConstructorTest {
 
                 val noArg = kotlin.noArgConstructor ?: fail("no-arg constructor missing")
                 assertThat(noArg.callBy(emptyMap()).stringData()).isEqualTo(DEFAULT_MESSAGE)
-                assertThat(newInstance().stringData()).isEqualTo(DEFAULT_MESSAGE)
+                assertThat(getDeclaredConstructor().newInstance().stringData()).isEqualTo(DEFAULT_MESSAGE)
             }
         }
 

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/SanitiseStubConstructorTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/SanitiseStubConstructorTest.kt
@@ -29,6 +29,14 @@ class SanitiseStubConstructorTest {
         fun setup(@TempDir testProjectDir: Path) {
             testProject = JarFilterProject(testProjectDir, "sanitise-stub-constructor").build()
         }
+
+        fun <T> newInstance(clazz: Class<T>): T {
+            return try {
+                clazz.getDeclaredConstructor().newInstance()
+            } catch (e: InvocationTargetException) {
+                throw e.targetException
+            }
+        }
     }
 
     @Test
@@ -60,7 +68,7 @@ class SanitiseStubConstructorTest {
 
                 val noArg = kotlin.noArgConstructor ?: fail("no-arg constructor missing")
                 assertThat(noArg.callBy(emptyMap()).longData()).isEqualTo(0)
-                assertThat(newInstance().longData()).isEqualTo(0)
+                assertThat(newInstance(this).longData()).isEqualTo(0)
             }
         }
 
@@ -80,7 +88,7 @@ class SanitiseStubConstructorTest {
                 assertThat(assertFailsWith<InvocationTargetException> { noArg.callBy(emptyMap()) }.targetException)
                     .isInstanceOf(UnsupportedOperationException::class.java)
                     .hasMessage("Method has been deleted")
-                assertThat(assertFailsWith<UnsupportedOperationException> { newInstance() })
+                assertThat(assertFailsWith<UnsupportedOperationException> { newInstance(this) })
                     .hasMessage("Method has been deleted")
             }
         }
@@ -115,7 +123,7 @@ class SanitiseStubConstructorTest {
 
                 val noArg = kotlin.noArgConstructor ?: fail("no-arg constructor missing")
                 assertThat(noArg.callBy(emptyMap()).intData()).isEqualTo(0)
-                assertThat(newInstance().intData()).isEqualTo(0)
+                assertThat(newInstance(this).intData()).isEqualTo(0)
             }
         }
 
@@ -135,7 +143,7 @@ class SanitiseStubConstructorTest {
                 assertThat(assertFailsWith<InvocationTargetException> { noArg.callBy(emptyMap()) }.targetException)
                     .isInstanceOf(UnsupportedOperationException::class.java)
                     .hasMessage("Method has been deleted")
-                assertThat(assertFailsWith<UnsupportedOperationException> { newInstance() })
+                assertThat(assertFailsWith<UnsupportedOperationException> { newInstance(this) })
                     .hasMessage("Method has been deleted")
             }
         }
@@ -170,7 +178,7 @@ class SanitiseStubConstructorTest {
 
                 val noArg = kotlin.noArgConstructor ?: fail("no-arg constructor missing")
                 assertThat(noArg.callBy(emptyMap()).stringData()).isEqualTo(DEFAULT_MESSAGE)
-                assertThat(newInstance().stringData()).isEqualTo(DEFAULT_MESSAGE)
+                assertThat(newInstance(this).stringData()).isEqualTo(DEFAULT_MESSAGE)
             }
         }
 
@@ -190,7 +198,7 @@ class SanitiseStubConstructorTest {
                 assertThat(assertFailsWith<InvocationTargetException> { noArg.callBy(emptyMap()) }.targetException)
                     .isInstanceOf(UnsupportedOperationException::class.java)
                     .hasMessage("Method has been deleted")
-                assertThat(assertFailsWith<UnsupportedOperationException> { newInstance() })
+                assertThat(assertFailsWith<UnsupportedOperationException> { newInstance(this) })
                     .hasMessage("Method has been deleted")
             }
         }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/StubFunctionOutTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/StubFunctionOutTest.kt
@@ -32,7 +32,7 @@ class StubFunctionOutTest {
             val parameter = cl.load<Annotation>(PARAMETER_ANNOTATION)
 
             cl.load<HasUnwantedFun>(FUNCTION_CLASS).apply {
-                newInstance().also { obj ->
+                getDeclaredConstructor().newInstance().also { obj ->
                     assertEquals(MESSAGE, obj.unwantedFun(MESSAGE))
                 }
                 getMethod("unwantedFun", String::class.java).also { method ->
@@ -52,7 +52,7 @@ class StubFunctionOutTest {
             val parameter = cl.load<Annotation>(PARAMETER_ANNOTATION)
 
             cl.load<HasUnwantedFun>(FUNCTION_CLASS).apply {
-                newInstance().also { obj ->
+                getDeclaredConstructor().newInstance().also { obj ->
                     assertFailsWith<UnsupportedOperationException> { obj.unwantedFun(MESSAGE) }.also { ex ->
                         assertEquals("Method has been deleted", ex.message)
                     }

--- a/jar-filter/src/test/resources/gradle.properties
+++ b/jar-filter/src/test/resources/gradle.properties
@@ -4,3 +4,4 @@ kotlin.incremental=false
 
 kotlin_api_version=$kotlin_api_version
 kotlin_version=$kotlin_version
+javax_annotations_version=$javax_annotations_version

--- a/jar-filter/src/test/resources/stub-function/build.gradle
+++ b/jar-filter/src/test/resources/stub-function/build.gradle
@@ -21,6 +21,7 @@ sourceSets {
 dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
+    compileOnly "javax.annotation:javax.annotation-api:$javax_annotations_version"
 }
 
 jar {


### PR DESCRIPTION
- `javax.annotation-api` must be included separately with JDK11.
- `Class.newInstance()` is deprecated in favour of `Class.getDeclaredConstructor().newInstance()`.
- Test using Corda 4.3 artifacts, which has preliminary Java 11 support.
- `ZipFile` throws `NoSuchFileException` instead of `FileNotFoundException` on Java 11.