### PR TITLE
NOTICK: Fix "deprecated in Gradle 7.x" warning for API Scanner.

### DIFF
--- a/api-scanner/src/main/java/net/corda/plugins/apiscanner/ScanApi.java
+++ b/api-scanner/src/main/java/net/corda/plugins/apiscanner/ScanApi.java
@@ -173,7 +173,7 @@ class ScanApi extends DefaultTask {
     }
 
     @Console
-    public Provider<Boolean> isVerbose() {
+    public Provider<Boolean> getVerbose() {
         return verbose;
     }
 


### PR DESCRIPTION
Gradle doesn't recognise `isXXX()` as a getter method for a bean, so replace with `getXXX()`.