### PR TITLE
NOTICK: Publish the Gradle plugin marker to Artifactory.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -209,6 +209,10 @@ artifactory {
         defaults {
             if (publishProjects.contains(project)) {
                 publications(project.name)
+
+                project.extensions['gradlePlugin'].plugins.forEach { plugin ->
+                    publications(project.name + '-' + plugin.name)
+                }
             }
         }
     }


### PR DESCRIPTION
Publishing this extra POM artifact for each plugin allows us to download the Corda Gradle plugins from Artifactory via Gradle's `plugins` block.