### PR TITLE
NOTICK: Use Gradle lazy task configuration when publishing sources and javadoc.

### DIFF
--- a/publish-utils/src/main/groovy/net/corda/plugins/publish/PublishConfigurationProjectListener.groovy
+++ b/publish-utils/src/main/groovy/net/corda/plugins/publish/PublishConfigurationProjectListener.groovy
@@ -93,7 +93,7 @@ class PublishConfigurationProjectListener implements ProjectEvaluationListener {
                     }
                 }
                 if (publishConfig.publishJavadoc.get()) {
-                    Task javadocJar = project.tasks.findByName(JAVADOC_TASK_NAME)
+                    Task javadocJar = project.tasks.findByName(JAVADOC_JAR_TASK_NAME)
                     if (javadocJar) {
                         project.logger.info('Publishing javadoc for {}', publishName)
                         pub.artifact javadocJar


### PR DESCRIPTION
Also resolve warnings about deprecated Gradle API usage in `publish-utils`.