### PR TITLE
CORDA-4060: Upgrade JarFilter to use ASM 8.0.1.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Version 5.0.13
 
 * `dockerform`: Parsing for adding external service to docker-compose
+* `jar-filter`: Upgrade to ASM 8.0.1.
 
 ### Version 5.0.12
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ commons_io_version=2.6
 assertj_version=3.12.1
 junit_jupiter_version=5.6.2
 hamcrest_version=2.1
-asm_version=7.3.1
+asm_version=8.0.1
 docker_client_version=8.15.1
 javax_annotations_version=1.3.2
 

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/FilterTransformer.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/FilterTransformer.kt
@@ -30,7 +30,7 @@ class FilterTransformer private constructor (
     private val unwantedFields: MutableSet<FieldElement>,
     private val deletedMethods: MutableSet<MethodElement>,
     private val stubbedMethods: MutableSet<MethodElement>
-) : KotlinAfterProcessor(ASM7, visitor, logger, kotlinMetadata), Repeatable<FilterTransformer> {
+) : KotlinAfterProcessor(ASM8, visitor, logger, kotlinMetadata), Repeatable<FilterTransformer> {
     constructor(
         visitor: ClassVisitor,
         logger: Logger,
@@ -157,6 +157,24 @@ class FilterTransformer private constructor (
             }
         } else {
             super.visitOuterClass(outerName, methodName, methodDescriptor)
+        }
+    }
+
+    override fun visitNestHost(nestHost: String) {
+        logger.debug("--- nest host: {}", nestHost)
+        if (isUnwantedClass(nestHost) && unwantedElements.addClass(className)) {
+            logger.info("- Identified class {} as unwanted by its nest host {}", className, nestHost)
+        } else {
+            super.visitNestHost(nestHost)
+        }
+    }
+
+    override fun visitNestMember(nestMember: String) {
+        logger.debug("--- nest member: {}", nestMember)
+        if (isUnwantedClass(nestMember)) {
+            logger.info("- Delete unwanted nest member: {}", nestMember)
+        } else {
+            super.visitNestMember(nestMember)
         }
     }
 

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerVisitor.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerVisitor.kt
@@ -19,7 +19,7 @@ class MetaFixerVisitor private constructor(
     private val fields: MutableSet<FieldElement>,
     private val methods: MutableSet<String>,
     private val nestedClasses: MutableSet<String>
-) : KotlinAfterProcessor(ASM7, visitor, logger, kotlinMetadata), Repeatable<MetaFixerVisitor> {
+) : KotlinAfterProcessor(ASM8, visitor, logger, kotlinMetadata), Repeatable<MetaFixerVisitor> {
     constructor(visitor: ClassVisitor, logger: Logger, classNames: Set<String>)
         : this(visitor, logger, mutableMapOf(), classNames, mutableSetOf(), mutableSetOf(), mutableSetOf())
 

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/SanitisingTransformer.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/SanitisingTransformer.kt
@@ -26,7 +26,7 @@ class SanitisingTransformer(
     logger: Logger,
     private val unwantedAnnotations: Set<String>,
     private val syntheticMethods: UnwantedMap
-) : KotlinBeforeProcessor(ASM7, visitor, logger, mutableMapOf()) {
+) : KotlinBeforeProcessor(ASM8, visitor, logger, mutableMapOf()) {
 
     var isModified: Boolean = false
         private set

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/asm/MetadataTools.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/asm/MetadataTools.kt
@@ -6,7 +6,7 @@ import kotlinx.metadata.jvm.KotlinClassHeader
 import kotlinx.metadata.jvm.KotlinClassMetadata
 import net.corda.gradle.jarfilter.*
 import org.objectweb.asm.*
-import org.objectweb.asm.Opcodes.ASM7
+import org.objectweb.asm.Opcodes.ASM8
 
 /**
  * Rewrite the bytecode for this class with the Kotlin @Metadata of another class.
@@ -72,7 +72,7 @@ private fun Class<*>.readMetadata(): KotlinClassHeader {
     )
 }
 
-private class MetadataWriter(metadata: KotlinClassHeader, visitor: ClassVisitor) : ClassVisitor(ASM7, visitor) {
+private class MetadataWriter(metadata: KotlinClassHeader, visitor: ClassVisitor) : ClassVisitor(ASM8, visitor) {
     private val kotlinMetadata: MutableMap<String, Array<String>> = mutableMapOf(
         KOTLIN_METADATA_DATA_FIELD_NAME to metadata.data1,
         KOTLIN_METADATA_STRINGS_FIELD_NAME to metadata.data2

--- a/jar-filter/src/test/resources/annotations/java/net/corda/gradle/jarfilter/DeleteJava.java
+++ b/jar-filter/src/test/resources/annotations/java/net/corda/gradle/jarfilter/DeleteJava.java
@@ -1,0 +1,13 @@
+package net.corda.gradle.jarfilter;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({TYPE, CONSTRUCTOR, METHOD, FIELD, PACKAGE})
+@Retention(RUNTIME)
+public @interface DeleteJava {
+}
+

--- a/jar-filter/src/test/resources/delete-nested-class/build.gradle
+++ b/jar-filter/src/test/resources/delete-nested-class/build.gradle
@@ -15,6 +15,12 @@ sourceSets {
                 '../resources/test/annotations/kotlin'
             )
         }
+        java {
+            srcDir files(
+                '../resources/test/delete-nested-class/java',
+                '../resources/test/annotations/java'
+            )
+        }
     }
 }
 
@@ -29,6 +35,9 @@ jar {
 task jarFilter(type: JarFilterTask) {
     jars jar
     annotations {
-        forDelete = ["net.corda.gradle.jarfilter.DeleteMe"]
+        forDelete = [
+            "net.corda.gradle.jarfilter.DeleteMe",
+            "net.corda.gradle.jarfilter.DeleteJava"
+        ]
     }
 }

--- a/jar-filter/src/test/resources/delete-nested-class/java/net/corda/gradle/DeletedOuterClass.java
+++ b/jar-filter/src/test/resources/delete-nested-class/java/net/corda/gradle/DeletedOuterClass.java
@@ -1,0 +1,9 @@
+package net.corda.gradle;
+
+import net.corda.gradle.jarfilter.DeleteJava;
+
+@DeleteJava
+public class DeletedOuterClass {
+    public class InnerClass {}
+}
+

--- a/jar-filter/src/test/resources/delete-nested-class/java/net/corda/gradle/OuterClass.java
+++ b/jar-filter/src/test/resources/delete-nested-class/java/net/corda/gradle/OuterClass.java
@@ -1,0 +1,15 @@
+package net.corda.gradle;
+
+import net.corda.gradle.jarfilter.DeleteJava;
+
+public class OuterClass {
+
+    @DeleteJava
+    public class InnerClass {}
+
+    @DeleteJava
+    public static class StaticInnerClass {}
+
+    public class LeftOver {}
+}
+


### PR DESCRIPTION
ASM 8 includes support for JDK11's nest host and nest member byte-code elements.