### PR TITLE
CORDA-4061: Resolve warning in quasar-utils about deprecated Gradle API.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,8 +4,9 @@
 
 ### Version 5.0.13
 
-* `dockerform`: Parsing for adding external service to docker-compose
+* `cordformation`: Parsing for adding external service to docker-compose
 * `jar-filter`: Upgrade to ASM 8.0.1.
+* `quasar-utils`: Resolve warning about deprecated Gradle API usage.
 
 ### Version 5.0.12
 

--- a/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarPlugin.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarPlugin.groovy
@@ -67,7 +67,7 @@ class QuasarPlugin implements Plugin<Project> {
         }
 
         // Add Quasar to the compile classpath WITHOUT any of its transitive dependencies.
-        project.dependencies.add(COMPILE_ONLY_CONFIGURATION_NAME, quasar)
+        project.configurations.getByName(COMPILE_ONLY_CONFIGURATION_NAME).extendsFrom(quasar)
 
         // Instrumented code needs both the Quasar agent and its transitive dependencies at runtime.
         def cordaRuntime = createRuntimeConfiguration("cordaRuntime", project.configurations)


### PR DESCRIPTION
Adding a Gradle configuration as a dependency is deprecated as of Gradle 6.7.