### PR TITLE
NOTICK: Allow publishing without developer information.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * `cordformation`: Parsing for adding external service to docker-compose
 * `jar-filter`: Upgrade to ASM 8.0.1.
 * `quasar-utils`: Resolve warning about deprecated Gradle API usage.
+* `publish-utils`: Make the developers information optional.
 
 ### Version 5.0.12
 

--- a/publish-utils/src/main/groovy/net/corda/plugins/publish/PublishConfigurationProjectListener.groovy
+++ b/publish-utils/src/main/groovy/net/corda/plugins/publish/PublishConfigurationProjectListener.groovy
@@ -167,11 +167,19 @@ class PublishConfigurationProjectListener implements ProjectEvaluationListener {
                     }
                 }
 
-                developers {
-                    developer {
-                        id config.developer.id.get()
-                        name config.developer.name.get()
-                        email config.developer.email.get()
+                if (config.developer.isPresent()) {
+                    developers {
+                        developer {
+                            if (config.developer.id.isPresent()) {
+                                id config.developer.id.get()
+                            }
+                            if (config.developer.name.isPresent()) {
+                                name config.developer.name.get()
+                            }
+                            if (config.developer.email.isPresent()) {
+                                email config.developer.email.get()
+                            }
+                        }
                     }
                 }
             }

--- a/publish-utils/src/main/groovy/net/corda/plugins/publish/bintray/Developer.groovy
+++ b/publish-utils/src/main/groovy/net/corda/plugins/publish/bintray/Developer.groovy
@@ -37,4 +37,11 @@ class Developer {
     Property<String> getEmail() {
         return email
     }
+
+    /**
+     * Determines whether there is any developer information.
+     */
+    boolean isPresent() {
+        return id.isPresent() || name.isPresent() || email.isPresent()
+    }
 }


### PR DESCRIPTION
We may need to repackage some artifacts for republishing into Artifactory, and these artifacts may not have such things as a "developer email address". Make the "developers" section optional.