### PR TITLE
CORE-830: Upgrade JarFilter to use ASM 9.0.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@
 ### Version 5.0.13
 
 * `cordformation`: Parsing for adding external service to docker-compose
-* `jar-filter`: Upgrade to ASM 8.0.1.
+* `jar-filter`: Upgrade to ASM 9.0.
 * `quasar-utils`: Resolve warning about deprecated Gradle API usage.
 * `publish-utils`: Make the developers information optional.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ commons_io_version=2.6
 assertj_version=3.16.1
 junit_jupiter_version=5.7.0
 hamcrest_version=2.1
-asm_version=8.0.1
+asm_version=9.0
 docker_client_version=8.15.1
 javax_annotations_version=1.3.2
 

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTask.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTask.kt
@@ -108,14 +108,8 @@ open class MetaFixerTask @Inject constructor(objects: ObjectFactory, layouts: Pr
          */
         private val target: Path = outputDir.flatMap { dir -> toMetaFixed(dir, inFile) }.get().asFile.toPath()
         private val inJar = ZipFile(inFile)
-        private val outJar: ZipOutputStream
-
-        init {
-            // Default options for newOutputStream() are CREATE, TRUNCATE_EXISTING.
-            outJar = ZipOutputStream(Files.newOutputStream(target)).apply {
-                setLevel(BEST_COMPRESSION)
-            }
-        }
+        // Default options for newOutputStream() are CREATE, TRUNCATE_EXISTING.
+        private val outJar = ZipOutputStream(Files.newOutputStream(target).buffered())
 
         @Throws(IOException::class)
         override fun close() {
@@ -126,6 +120,7 @@ open class MetaFixerTask @Inject constructor(objects: ObjectFactory, layouts: Pr
 
         fun run() {
             logger.info("Writing to {}", target)
+            outJar.setLevel(BEST_COMPRESSION)
             outJar.setComment(inJar.comment)
 
             val classNames = inJar.entries().asSequence().namesEndingWith(".class")

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerVisitor.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerVisitor.kt
@@ -6,10 +6,9 @@ import org.gradle.api.logging.Logger
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.FieldVisitor
 import org.objectweb.asm.MethodVisitor
-import org.objectweb.asm.Opcodes.ASM8
 
 /**
- * ASM [ClassVisitor] for the MetaFixer task. This visitor inventories every function,
+ * ASM [ClassVisitor] for the [MetaFixerTask]. This visitor inventories every function,
  * property and inner class within the byte-code and then passes this information to
  * the [MetaFixerTransformer].
  */
@@ -21,7 +20,7 @@ class MetaFixerVisitor private constructor(
     private val fields: MutableSet<FieldElement>,
     private val methods: MutableSet<String>,
     private val nestedClasses: MutableSet<String>
-) : KotlinAfterProcessor(ASM8, visitor, logger, kotlinMetadata), Repeatable<MetaFixerVisitor> {
+) : KotlinAfterProcessor(ASM_API, visitor, logger, kotlinMetadata), Repeatable<MetaFixerVisitor> {
     constructor(visitor: ClassVisitor, logger: Logger, classNames: Set<String>)
         : this(visitor, logger, mutableMapOf(), classNames, mutableSetOf(), mutableSetOf(), mutableSetOf())
 
@@ -53,7 +52,7 @@ class MetaFixerVisitor private constructor(
         if (outerName == className && innerName != null && nestedClasses.add(innerName)) {
             logger.info("- inner class {}", clsName)
         }
-        return super.visitInnerClass(clsName, outerName, innerName, access)
+        super.visitInnerClass(clsName, outerName, innerName, access)
     }
 
     override fun processClassMetadata(kmClass: KmClass): KmClass? {

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetadataTransformer.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetadataTransformer.kt
@@ -51,7 +51,7 @@ abstract class MetadataTransformer<out T : KmDeclarationContainer>(
                 val method = function.signature?.toMethodElement() ?: continue
                 val synthetic = method.asKotlinDefaultFunction(classDescriptor) ?: continue
 
-                // The synthetic "$default" method may not have been annotated,
+                // The synthetic `$default` method may not have been annotated,
                 // so ensure we handle it in the same way as its "host" method.
                 synthetic.handleSameAs(method)
             }

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/SanitisingTransformer.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/SanitisingTransformer.kt
@@ -10,7 +10,6 @@ import org.gradle.api.logging.Logger
 import org.objectweb.asm.AnnotationVisitor
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.MethodVisitor
-import org.objectweb.asm.Opcodes.ASM8
 
 /**
  * This is (hopefully?!) a temporary solution for classes with [JvmOverloads] constructors.
@@ -28,7 +27,7 @@ class SanitisingTransformer(
     logger: Logger,
     private val unwantedAnnotations: Set<String>,
     private val syntheticMethods: UnwantedMap
-) : KotlinBeforeProcessor(ASM8, visitor, logger, mutableMapOf()) {
+) : KotlinBeforeProcessor(ASM_API, visitor, logger, mutableMapOf()) {
 
     var isModified: Boolean = false
         private set

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/Utils.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/Utils.kt
@@ -8,6 +8,7 @@ import org.objectweb.asm.ClassReader.SKIP_DEBUG
 import org.objectweb.asm.ClassReader.SKIP_FRAMES
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Opcodes.ASM9
 import java.nio.file.attribute.FileTime
 import java.util.Calendar.FEBRUARY
 import java.util.GregorianCalendar
@@ -21,6 +22,8 @@ import kotlin.text.RegexOption.IGNORE_CASE
 const val GROUP_NAME = "JarFilter"
 const val MINIMUM_GRADLE_VERSION = "5.6"
 const val FILTER_FLAGS = SKIP_DEBUG and SKIP_FRAMES
+
+const val ASM_API = ASM9
 
 @JvmField
 val JAR_PATTERN = "(\\.jar)\$".toRegex(IGNORE_CASE)

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteJava15SealedClassTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteJava15SealedClassTest.kt
@@ -1,0 +1,38 @@
+package net.corda.gradle.jarfilter
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledForJreRange
+import org.junit.jupiter.api.condition.JRE.JAVA_15
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.test.assertFailsWith
+
+@EnabledForJreRange(min = JAVA_15)
+class DeleteJava15SealedClassTest {
+    companion object {
+        private const val SEALED_CLASS = "net.corda.gradle.DeletableSealedClass"
+        private const val SUBCLASS = "net.corda.gradle.SealedSubclass"
+
+        private lateinit var testProject: JarFilterProject
+
+        @BeforeAll
+        @JvmStatic
+        fun setup(@TempDir testProjectDir: Path) {
+            testProject = JarFilterProject(testProjectDir, "delete-java15-sealed-class").build()
+        }
+    }
+
+    @Test
+    fun deleteSealedClass() {
+        classLoaderFor(testProject.sourceJar).use { cl ->
+            cl.load<Any>(SEALED_CLASS)
+            cl.load<Any>(SUBCLASS)
+        }
+
+        classLoaderFor(testProject.filteredJar).use { cl ->
+            assertFailsWith<ClassNotFoundException> { cl.load<Any>(SEALED_CLASS) }
+            assertFailsWith<ClassNotFoundException> { cl.load<Any>(SUBCLASS) }
+        }
+    }
+}

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/asm/MetadataTools.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/asm/MetadataTools.kt
@@ -4,12 +4,12 @@ package net.corda.gradle.jarfilter.asm
 import kotlinx.metadata.InconsistentKotlinMetadataException
 import kotlinx.metadata.jvm.KotlinClassHeader
 import kotlinx.metadata.jvm.KotlinClassMetadata
+import net.corda.gradle.jarfilter.ASM_API
 import net.corda.gradle.jarfilter.KOTLIN_METADATA_DATA_FIELD_NAME
 import net.corda.gradle.jarfilter.KOTLIN_METADATA_DESC
 import net.corda.gradle.jarfilter.KOTLIN_METADATA_STRINGS_FIELD_NAME
 import org.objectweb.asm.AnnotationVisitor
 import org.objectweb.asm.ClassVisitor
-import org.objectweb.asm.Opcodes.ASM8
 
 /**
  * Rewrite the bytecode for this class with the Kotlin @Metadata of another class.
@@ -75,7 +75,7 @@ private fun Class<*>.readMetadata(): KotlinClassHeader {
     )
 }
 
-private class MetadataWriter(metadata: KotlinClassHeader, visitor: ClassVisitor) : ClassVisitor(ASM8, visitor) {
+private class MetadataWriter(metadata: KotlinClassHeader, visitor: ClassVisitor) : ClassVisitor(ASM_API, visitor) {
     private val kotlinMetadata: MutableMap<String, Array<String>> = mutableMapOf(
         KOTLIN_METADATA_DATA_FIELD_NAME to metadata.data1,
         KOTLIN_METADATA_STRINGS_FIELD_NAME to metadata.data2

--- a/jar-filter/src/test/resources/delete-java15-permitted-subclass/build.gradle
+++ b/jar-filter/src/test/resources/delete-java15-permitted-subclass/build.gradle
@@ -1,0 +1,40 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+import static org.gradle.api.JavaVersion.VERSION_15
+
+plugins {
+    id 'net.corda.plugins.jar-filter' apply false
+    id 'java-library'
+}
+apply from: 'repositories.gradle'
+
+java {
+    sourceCompatibility = VERSION_15
+    targetCompatibility = VERSION_15
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir files(
+                '../resources/test/delete-java15-permitted-subclass/java',
+                '../resources/test/annotations/java'
+            )
+        }
+    }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs += "--enable-preview"
+    options.encoding = 'UTF-8'
+}
+
+jar {
+    archiveBaseName = 'delete-java15-permitted-subclass'
+}
+
+task jarFilter(type: JarFilterTask) {
+    jars jar
+    annotations {
+        forDelete = ["net.corda.gradle.jarfilter.DeleteJava"]
+    }
+}

--- a/jar-filter/src/test/resources/delete-java15-permitted-subclass/java/net/corda/gradle/UnwantedSubclass.java
+++ b/jar-filter/src/test/resources/delete-java15-permitted-subclass/java/net/corda/gradle/UnwantedSubclass.java
@@ -1,0 +1,7 @@
+package net.corda.gradle;
+
+import net.corda.gradle.jarfilter.DeleteJava;
+
+@DeleteJava
+public final class UnwantedSubclass extends WantedSealedClass {
+}

--- a/jar-filter/src/test/resources/delete-java15-permitted-subclass/java/net/corda/gradle/WantedSealedClass.java
+++ b/jar-filter/src/test/resources/delete-java15-permitted-subclass/java/net/corda/gradle/WantedSealedClass.java
@@ -1,0 +1,4 @@
+package net.corda.gradle;
+
+public abstract sealed class WantedSealedClass permits WantedSubclass, UnwantedSubclass {
+}

--- a/jar-filter/src/test/resources/delete-java15-permitted-subclass/java/net/corda/gradle/WantedSubclass.java
+++ b/jar-filter/src/test/resources/delete-java15-permitted-subclass/java/net/corda/gradle/WantedSubclass.java
@@ -1,0 +1,4 @@
+package net.corda.gradle;
+
+public final class WantedSubclass extends WantedSealedClass {
+}

--- a/jar-filter/src/test/resources/delete-java15-sealed-class/build.gradle
+++ b/jar-filter/src/test/resources/delete-java15-sealed-class/build.gradle
@@ -1,0 +1,40 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+import static org.gradle.api.JavaVersion.VERSION_15
+
+plugins {
+    id 'net.corda.plugins.jar-filter' apply false
+    id 'java-library'
+}
+apply from: 'repositories.gradle'
+
+java {
+    sourceCompatibility = VERSION_15
+    targetCompatibility = VERSION_15
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir files(
+                '../resources/test/delete-java15-sealed-class/java',
+                '../resources/test/annotations/java'
+            )
+        }
+    }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs += "--enable-preview"
+    options.encoding = 'UTF-8'
+}
+
+jar {
+    archiveBaseName = 'delete-java15-sealed-class'
+}
+
+task jarFilter(type: JarFilterTask) {
+    jars jar
+    annotations {
+        forDelete = ["net.corda.gradle.jarfilter.DeleteJava"]
+    }
+}

--- a/jar-filter/src/test/resources/delete-java15-sealed-class/java/net/corda/gradle/DeletableSealedClass.java
+++ b/jar-filter/src/test/resources/delete-java15-sealed-class/java/net/corda/gradle/DeletableSealedClass.java
@@ -1,0 +1,7 @@
+package net.corda.gradle;
+
+import net.corda.gradle.jarfilter.DeleteJava;
+
+@DeleteJava
+public abstract sealed class DeletableSealedClass permits SealedSubclass {
+}

--- a/jar-filter/src/test/resources/delete-java15-sealed-class/java/net/corda/gradle/SealedSubclass.java
+++ b/jar-filter/src/test/resources/delete-java15-sealed-class/java/net/corda/gradle/SealedSubclass.java
@@ -1,0 +1,4 @@
+package net.corda.gradle;
+
+public final class SealedSubclass extends DeletableSealedClass {
+}


### PR DESCRIPTION
Leverages ASM's support for `Permitted Subclasses`, but `record` support will require deeper study.