### PR TITLE
CORE-855: Disable Gradle's auto-provisioning for JDKs.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 kotlin.incremental=true
 kotlin.stdlib.default.dependency=false
+org.gradle.java.installations.auto-download=false
 org.gradle.jvmargs=-XX:+UseG1GC -Xmx1g
 org.gradle.caching=false
 


### PR DESCRIPTION
Prevent Gradle from auto-downloading any missing JDK toolchain. We should be providing them ourselves.

The Jenkins image contains both JDK8 and JDK11.