### PR TITLE
CORE-855: Update quasar-utils plugin to use OSGi Quasar 0.8.x.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,18 @@ belong in this repository.
 
 ## Version number
 
-To modify the version number edit the root build.gradle.
+To modify the version number edit the root `build.gradle`.
 
 Until `v4.0`, the version number was tracking the Corda version number it was built for. Eg; Corda `4.0` was built as `4.0.x`.
 This was broken from `v4.3` onwards (Corda 4.3 and plugins 5.0). The major version number will change when there is a breaking change,
 for example when the minimum (major) version of Gradle changes.
 
+Corda 5 requires Corda Gradle Plugins 6.x.
+
 ## Getting started
 
 You will need JVM 8 installed and on the path to run and install these plugins.
+However, some plugins may also require a Java 11 toolchain for testing purposes.
 
 ## Installing locally
 
@@ -58,20 +61,20 @@ you with a `runnodes` script to boot it all up afterwards.
 
 - [`net.corda.plugins.quasar-utils`](quasar-utils/README.rst)\
 This plugin configures a Gradle module to use Quasar. Specifically:
-    - It allows you to specify the Maven group, version and classifier of
-the `quasar-core` artifact to use.
-    - Adds the `quasar-core` artifact, along with all of its transitive
-dependencies, to Gradle's `cordaRuntime` configuration.
-    - Adds the `quasar-core` artifact to Gradle's `compileOnly`
+    - It allows you to specify the Maven group and version of
+the `quasar-core-osgi` artifacts to use.
+    - Adds the `quasar-core-osgi` artifact, along with all of its transitive
+dependencies, to Gradle's `cordaRuntimeOnly` configuration.
+    - Adds the `quasar-core-osgi` artifact to Gradle's `cordaProvided`
 configuration without any of its transitive dependencies.
-    - Applies `quasar-core` as a Java agent to all of the module's
+    - Applies the `quasar-core-osgi` Java agent to all of the module's
 `JavaExec` tasks.
-    - Applies `quasar-core` as a Java agent to all of the module's
+    - Applies the `quasar-core-osgi` Java agent to all of the module's
 `Test` tasks.
     - Provides a `quasar` Gradle extension so that you can configure
-which classes the Quasar java agent should not instrument at runtime.
+which packages the Quasar Java agent should not instrument at runtime.
 
-    <sup>Requires Gradle 5.1</sup>
+    <sup>Requires Gradle 6.6</sup>
 
 ### Internal Corda plugins.
 These plugins are unlikely to be useful to CorDapp developers outside of R3.

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 * Compatible with Gradle 6.x.
 * `quasar-utils`: Upgrade to use Quasar 0.8.2_r3 OSGi bundles.
+* `quasar-utils`: Support configurable `@Suspendable` annotation.
 
 ## Version 5
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@
 ### Version 6.0.0
 
 * Compatible with Gradle 6.x.
-* `quasar-utils`: Upgrade to use Quasar 0.8.2_r3 OSGi bundles.
+* `quasar-utils`: Upgrade to use Quasar 0.8.5_r3 OSGi bundles.
 * `quasar-utils`: Support configurable `@Suspendable` annotation.
 
 ## Version 5

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Version 6.0.0
 
 * Compatible with Gradle 6.x.
+* `quasar-utils`: Upgrade to use Quasar 0.8.2_r3 OSGi bundles.
 
 ## Version 5
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 ### Version 6.0.0
 
-* Compatible with Gradle 6.x.
+* Compatible with Gradle 6.6+.
 * `quasar-utils`: Upgrade to use Quasar 0.8.5_r3 OSGi bundles.
 * `quasar-utils`: Support configurable `@Suspendable` annotation.
 

--- a/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarExtension.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarExtension.groovy
@@ -21,14 +21,14 @@ class QuasarExtension {
     final Property<String> version
 
     /**
-     * Maven classifier for the Quasar agent.
+     * Dependency notation for the Quasar bundle to use.
      */
-    final Property<String> classifier
+    final Provider<Map<String, String>> dependency
 
     /**
      * Dependency notation for the Quasar agent to use.
      */
-    final Provider<Map<String, String>> dependency
+    final Provider<Map<String, String>> agent
 
     /**
      * Runtime options for the Quasar agent:
@@ -53,19 +53,17 @@ class QuasarExtension {
         ObjectFactory objects,
         String defaultGroup,
         String defaultVersion,
-        String defaultClassifier,
         Iterable<? extends String> initialPackageExclusions,
         Iterable<? extends String> initialClassLoaderExclusions
     ) {
         group = objects.property(String).convention(defaultGroup)
         version = objects.property(String).convention(defaultVersion)
-        classifier = objects.property(String).convention(defaultClassifier)
-        dependency = group.flatMap { grp ->
-            version.flatMap { ver ->
-                classifier.map { cls ->
-                    [ group: grp, name: 'quasar-core', version: ver, classifier: cls, ext: 'jar' ]
-                }
-            }
+        dependency = group.zip(version) { grp, ver ->
+            [ group: grp, name: 'quasar-core-osgi', version: ver, ext: 'jar' ]
+        }
+        agent = dependency.map {
+            it['classifier'] = 'agent'
+            it
         }
 
         debug = objects.property(Boolean).convention(false)

--- a/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarPlugin.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarPlugin.groovy
@@ -28,7 +28,7 @@ class QuasarPlugin implements Plugin<Project> {
 
     private static final String QUASAR = "quasar"
     private static final String QUASAR_AGENT = "quasarAgent"
-    private static final String MINIMUM_GRADLE_VERSION = "5.1"
+    private static final String MINIMUM_GRADLE_VERSION = "6.6"
     private static final String CORDA_PROVIDED_CONFIGURATION_NAME = "cordaProvided"
     private static final String CORDA_RUNTIME_ONLY_CONFIGURATION_NAME = "cordaRuntimeOnly"
     @PackageScope static final String defaultGroup = "co.paralleluniverse"

--- a/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarPlugin.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarPlugin.groovy
@@ -32,7 +32,7 @@ class QuasarPlugin implements Plugin<Project> {
     private static final String CORDA_PROVIDED_CONFIGURATION_NAME = "cordaProvided"
     private static final String CORDA_RUNTIME_ONLY_CONFIGURATION_NAME = "cordaRuntimeOnly"
     @PackageScope static final String defaultGroup = "co.paralleluniverse"
-    @PackageScope static final String defaultVersion = "0.8.4_r3"
+    @PackageScope static final String defaultVersion = "0.8.5_r3"
 
     private final ObjectFactory objects
 

--- a/quasar-utils/src/test/groovy/net/corda/plugins/quasar/QuasarPluginTest.groovy
+++ b/quasar-utils/src/test/groovy/net/corda/plugins/quasar/QuasarPluginTest.groovy
@@ -19,7 +19,7 @@ if (org.gradle.api.JavaVersion.current().java9Compatible) {
     version = '0.8.2_r3'
     classifier = ''
 } else {
-    version = '0.7.14_r3-SNAPSHOT'
+    version = '0.7.14_r3'
 }
 """
 
@@ -48,7 +48,7 @@ apply from: 'repositories.gradle'
 task show {
     doFirst {
         def configs = configurations.matching {
-            it.name in ['quasar', 'quasarAgent', 'cordaRuntimeOnly', 'compileOnly', 'compileClasspath', 'runtimeClasspath']
+            it.name in ['quasar', 'quasarAgent', 'cordaRuntimeOnly', 'compileOnly', 'cordaProvided','compileClasspath', 'runtimeClasspath']
         }
         configs.collectEntries { [(it.name):it.incoming.dependencies] }.each { name, dependencies ->
             dependencies.each { dep ->
@@ -66,6 +66,7 @@ task show {
             "cordaRuntimeOnly: co.paralleluniverse:quasar-core-osgi:jar:${QUASAR_VERSION}:".toString(),
             "runtimeClasspath: co.paralleluniverse:quasar-core-osgi:jar:${QUASAR_VERSION}:".toString(),
             "compileOnly: co.paralleluniverse:quasar-core-osgi:jar:${QUASAR_VERSION}:".toString(),
+            "cordaProvided: co.paralleluniverse:quasar-core-osgi:jar:${QUASAR_VERSION}:".toString(),
             "compileClasspath: co.paralleluniverse:quasar-core-osgi:jar:${QUASAR_VERSION}:".toString()
         )
     }
@@ -94,7 +95,7 @@ apply from: 'repositories.gradle'
 task show {
     doFirst {
         def configs = configurations.matching {
-            it.name in ['quasar', 'quasarAgent', 'cordaRuntimeOnly', 'compileOnly', 'compileClasspath', 'runtimeClasspath']
+            it.name in ['quasar', 'quasarAgent', 'cordaRuntimeOnly', 'compileOnly', 'cordaProvided', 'compileClasspath', 'runtimeClasspath']
         }
         configs.collectEntries { [(it.name):it.incoming.dependencies] }.each { name, dependencies ->
             dependencies.each { dep ->
@@ -112,6 +113,7 @@ task show {
             "cordaRuntimeOnly: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
             "runtimeClasspath: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
             "compileOnly: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
+            "cordaProvided: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
             "compileClasspath: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString()
         )
     }
@@ -141,7 +143,7 @@ quasar {
 task show {
     doFirst {
         def configs = configurations.matching {
-            it.name in ['quasar', 'quasarAgent', 'cordaRuntimeOnly', 'compileOnly', 'compileClasspath', 'runtimeClasspath']
+            it.name in ['quasar', 'quasarAgent', 'cordaRuntimeOnly', 'compileOnly', 'cordaProvided', 'compileClasspath', 'runtimeClasspath']
         }
         configs.collectEntries { [(it.name):it.incoming.dependencies] }.each { name, dependencies ->
             dependencies.each { dep ->
@@ -159,6 +161,7 @@ task show {
             "cordaRuntimeOnly: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
             "runtimeClasspath: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
             "compileOnly: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
+            "cordaProvided: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
             "compileClasspath: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString()
         )
     }
@@ -178,7 +181,7 @@ apply plugin: 'net.corda.plugins.quasar-utils'
 
 task show {
     doFirst {
-        def configs = configurations.matching { it.name in ['quasar', 'quasarAgent', 'cordaRuntimeOnly', 'compileClasspath', 'compileOnly', 'runtimeClasspath'] }
+        def configs = configurations.matching { it.name in ['quasar', 'quasarAgent', 'cordaRuntimeOnly', 'compileClasspath', 'cordaProvided', 'compileOnly', 'runtimeClasspath'] }
         configs.collectEntries { [(it.name):it] }.each { name, files ->
             files.each { file ->
                 println "\$name: \${file.name}"
@@ -191,6 +194,7 @@ task show {
         assertThat(output.findAll { it.startsWith("quasarAgent:") }).hasSize(1)
         assertThat(output.findAll { it.startsWith("cordaRuntimeOnly:") }).hasSize(1)
         assertThat(output.findAll { it.startsWith("compileOnly:") }).hasSize(1)
+        assertThat(output.findAll { it.startsWith("cordaProvided:") }).hasSize(1)
         assertThat(output.findAll { it.startsWith("compileClasspath:") }).hasSize(1)
         assertThat(output.findAll { it.startsWith("runtimeClasspath:") }.size()).isGreaterThan(1)
     }

--- a/quasar-utils/src/test/groovy/net/corda/plugins/quasar/QuasarPluginTest.groovy
+++ b/quasar-utils/src/test/groovy/net/corda/plugins/quasar/QuasarPluginTest.groovy
@@ -13,14 +13,13 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 class QuasarPluginTest {
     private static final String TEST_GRADLE_USER_HOME = System.getProperty("test.gradle.user.home", ".")
     private static final String QUASAR_VERSION = QuasarPlugin.defaultVersion
-    private static final String QUASAR_CLASSIFIER = QuasarPlugin.defaultClassifier
 
     private static final String QUASAR_R3 = """\
 if (org.gradle.api.JavaVersion.current().java9Compatible) {
-    version = '0.8.0_r3'
+    version = '0.8.2_r3'
     classifier = ''
 } else {
-    version = '0.7.12_r3'
+    version = '0.7.14_r3-SNAPSHOT'
 }
 """
 
@@ -42,14 +41,14 @@ plugins {
     id 'net.corda.plugins.quasar-utils'
 }
 
-description 'Show quasar-core added to configurations'
+description 'Show quasar-core-osgi added to configurations'
     
 apply from: 'repositories.gradle'
 
 task show {
     doFirst {
         def configs = configurations.matching {
-            it.name in ['quasar', 'cordaRuntime', 'compileOnly', 'compileClasspath', 'runtimeClasspath']
+            it.name in ['quasar', 'quasarAgent', 'cordaRuntimeOnly', 'compileOnly', 'compileClasspath', 'runtimeClasspath']
         }
         configs.collectEntries { [(it.name):it.incoming.dependencies] }.each { name, dependencies ->
             dependencies.each { dep ->
@@ -62,11 +61,12 @@ task show {
 }
 """, "show"
         assertThat(output).containsOnlyOnce(
-            "quasar: co.paralleluniverse:quasar-core:jar:${QUASAR_VERSION}:".toString(),
-            "cordaRuntime: co.paralleluniverse:quasar-core:jar:${QUASAR_VERSION}:".toString(),
-            "runtimeClasspath: co.paralleluniverse:quasar-core:jar:${QUASAR_VERSION}:".toString(),
-            "compileOnly: co.paralleluniverse:quasar-core:jar:${QUASAR_VERSION}:".toString(),
-            "compileClasspath: co.paralleluniverse:quasar-core:jar:${QUASAR_VERSION}:".toString()
+            "quasar: co.paralleluniverse:quasar-core-osgi:jar:${QUASAR_VERSION}:".toString(),
+            "quasarAgent: co.paralleluniverse:quasar-core-osgi:jar:${QUASAR_VERSION}:agent".toString(),
+            "cordaRuntimeOnly: co.paralleluniverse:quasar-core-osgi:jar:${QUASAR_VERSION}:".toString(),
+            "runtimeClasspath: co.paralleluniverse:quasar-core-osgi:jar:${QUASAR_VERSION}:".toString(),
+            "compileOnly: co.paralleluniverse:quasar-core-osgi:jar:${QUASAR_VERSION}:".toString(),
+            "compileClasspath: co.paralleluniverse:quasar-core-osgi:jar:${QUASAR_VERSION}:".toString()
         )
     }
 
@@ -87,14 +87,14 @@ plugins {
     id 'net.corda.plugins.quasar-utils'
 }
 
-description 'Show quasar-core added to configurations'
+description 'Show quasar-core-osgi added to configurations'
     
 apply from: 'repositories.gradle'
 
 task show {
     doFirst {
         def configs = configurations.matching {
-            it.name in ['quasar', 'cordaRuntime', 'compileOnly', 'compileClasspath', 'runtimeClasspath']
+            it.name in ['quasar', 'quasarAgent', 'cordaRuntimeOnly', 'compileOnly', 'compileClasspath', 'runtimeClasspath']
         }
         configs.collectEntries { [(it.name):it.incoming.dependencies] }.each { name, dependencies ->
             dependencies.each { dep ->
@@ -107,11 +107,12 @@ task show {
 }
 """, "show"
         assertThat(output).containsOnlyOnce(
-            "quasar: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
-            "cordaRuntime: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
-            "runtimeClasspath: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
-            "compileOnly: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
-            "compileClasspath: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString()
+            "quasar: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
+            "quasarAgent: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:agent".toString(),
+            "cordaRuntimeOnly: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
+            "runtimeClasspath: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
+            "compileOnly: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
+            "compileClasspath: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString()
         )
     }
 
@@ -131,7 +132,6 @@ plugins {
     id 'net.corda.plugins.quasar-utils'
 }
 
-apply plugin: 'net.corda.plugins.quasar-utils'
 apply from: 'repositories.gradle'
 
 quasar {
@@ -141,7 +141,7 @@ quasar {
 task show {
     doFirst {
         def configs = configurations.matching {
-            it.name in ['quasar', 'cordaRuntime', 'compileOnly', 'compileClasspath', 'runtimeClasspath']
+            it.name in ['quasar', 'quasarAgent', 'cordaRuntimeOnly', 'compileOnly', 'compileClasspath', 'runtimeClasspath']
         }
         configs.collectEntries { [(it.name):it.incoming.dependencies] }.each { name, dependencies ->
             dependencies.each { dep ->
@@ -154,55 +154,12 @@ task show {
 }
 """, "show"
         assertThat(output).containsOnlyOnce(
-            "quasar: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
-            "cordaRuntime: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
-            "runtimeClasspath: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
-            "compileOnly: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
-            "compileClasspath: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString()
-        )
-    }
-
-    @Test
-    void checkLocalOverriddenClassifierVersionIsUsed() {
-        def quasarVersion = '0.7.12_r3'
-        def quasarClassifier = 'jdk8'
-        assertThat(quasarVersion).isNotEqualTo(QUASAR_VERSION)
-        assertThat(quasarClassifier).isNotEqualTo(QUASAR_CLASSIFIER)
-
-        def output = runGradleFor """
-plugins {
-    id 'net.corda.plugins.quasar-utils'
-}
-
-apply from: 'repositories.gradle'
-
-quasar {
-    group = 'co.paralleluniverse'
-    version = '${quasarVersion}'
-    classifier = '${quasarClassifier}'
-}
-
-task show {
-    doFirst {
-        def configs = configurations.matching {
-            it.name in ['quasar', 'cordaRuntime', 'compileOnly', 'compileClasspath', 'runtimeClasspath']
-        }
-        configs.collectEntries { [(it.name):it.incoming.dependencies] }.each { name, dependencies ->
-            dependencies.each { dep ->
-                dep.artifacts.each { art ->
-                    println "\$name: \${dep.group}:\${dep.name}:\${art.extension}:\${dep.version}:\${art.classifier ?: ''}"
-                }
-            }
-        }
-    }
-}
-""", "show"
-        assertThat(output).containsOnlyOnce(
-            "quasar: co.paralleluniverse:quasar-core:jar:${quasarVersion}:${quasarClassifier}".toString(),
-            "cordaRuntime: co.paralleluniverse:quasar-core:jar:${quasarVersion}:${quasarClassifier}".toString(),
-            "runtimeClasspath: co.paralleluniverse:quasar-core:jar:${quasarVersion}:${quasarClassifier}".toString(),
-            "compileOnly: co.paralleluniverse:quasar-core:jar:${quasarVersion}:${quasarClassifier}".toString(),
-            "compileClasspath: co.paralleluniverse:quasar-core:jar:${quasarVersion}:${quasarClassifier}".toString()
+            "quasar: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
+            "quasarAgent: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:agent".toString(),
+            "cordaRuntimeOnly: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
+            "runtimeClasspath: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
+            "compileOnly: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
+            "compileClasspath: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString()
         )
     }
 
@@ -213,7 +170,7 @@ plugins {
     id 'net.corda.plugins.quasar-utils'
 }
 
-description 'Show quasar-core added to configurations'
+description 'Show quasar-core-osgi added to configurations'
     
 apply from: 'repositories.gradle'
 
@@ -221,7 +178,7 @@ apply plugin: 'net.corda.plugins.quasar-utils'
 
 task show {
     doFirst {
-        def configs = configurations.matching { it.name in ['quasar', 'cordaRuntime', 'compileClasspath', 'compileOnly', 'runtimeClasspath'] }
+        def configs = configurations.matching { it.name in ['quasar', 'quasarAgent', 'cordaRuntimeOnly', 'compileClasspath', 'compileOnly', 'runtimeClasspath'] }
         configs.collectEntries { [(it.name):it] }.each { name, files ->
             files.each { file ->
                 println "\$name: \${file.name}"
@@ -231,7 +188,8 @@ task show {
 }
 """, "show"
         assertThat(output.findAll { it.startsWith("quasar:") }).hasSize(1)
-        assertThat(output.findAll { it.startsWith("cordaRuntime:") }).hasSize(1)
+        assertThat(output.findAll { it.startsWith("quasarAgent:") }).hasSize(1)
+        assertThat(output.findAll { it.startsWith("cordaRuntimeOnly:") }).hasSize(1)
         assertThat(output.findAll { it.startsWith("compileOnly:") }).hasSize(1)
         assertThat(output.findAll { it.startsWith("compileClasspath:") }).hasSize(1)
         assertThat(output.findAll { it.startsWith("runtimeClasspath:") }.size()).isGreaterThan(1)
@@ -244,7 +202,7 @@ plugins {
     id 'net.corda.plugins.quasar-utils'
 }
 
-description 'Show quasar-core added to test JVM arguments'
+description 'Show quasar-core-osgi added to test JVM arguments'
 
 apply from: 'repositories.gradle'
 
@@ -269,7 +227,7 @@ test {
 }
 """, "test"
         assertThat(output).anyMatch {
-            it.startsWith("TEST-JVM: -javaagent:") && it.contains("quasar-core-") && it.endsWith(".jar")
+            it.startsWith("TEST-JVM: -javaagent:") && it.contains("quasar-core-osgi-") && it.endsWith(".jar")
         }.anyMatch {
             it == "TEST-JVM: -Dco.paralleluniverse.fibers.verifyInstrumentation"
         }
@@ -288,7 +246,7 @@ plugins {
     id 'net.corda.plugins.quasar-utils'
 }
 
-description 'Show quasar-core added to test JVM arguments'
+description 'Show quasar-core-osgi added to test JVM arguments'
 
 apply from: 'repositories.gradle'
 
@@ -325,7 +283,7 @@ plugins {
     id 'net.corda.plugins.quasar-utils'
 }
 
-description 'Show quasar-core added to test JVM arguments'
+description 'Show quasar-core-osgi added to test JVM arguments'
 
 apply from: 'repositories.gradle'
 
@@ -362,7 +320,7 @@ plugins {
     id 'net.corda.plugins.quasar-utils'
 }
 
-description 'Show quasar-core added to test JVM arguments'
+description 'Show quasar-core-osgi added to test JVM arguments'
 
 apply from: 'repositories.gradle'
 
@@ -408,7 +366,7 @@ plugins {
     id 'net.corda.plugins.quasar-utils'
 }
 
-description 'Show quasar-core added to test JVM arguments'
+description 'Show quasar-core-osgi added to test JVM arguments'
 
 apply from: 'repositories.gradle'
 """, "test").buildAndFail()

--- a/quasar-utils/src/test/groovy/net/corda/plugins/quasar/QuasarPluginTest.groovy
+++ b/quasar-utils/src/test/groovy/net/corda/plugins/quasar/QuasarPluginTest.groovy
@@ -13,6 +13,7 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 class QuasarPluginTest {
     private static final String TEST_GRADLE_USER_HOME = System.getProperty("test.gradle.user.home", ".")
     private static final String QUASAR_VERSION = QuasarPlugin.defaultVersion
+    private static final String JUNIT_VERSION = "4.13"
 
     private static final String QUASAR_R3 = """\
 if (org.gradle.api.JavaVersion.current().java9Compatible) {
@@ -39,6 +40,7 @@ if (org.gradle.api.JavaVersion.current().java9Compatible) {
         def output = runGradleFor """
 plugins {
     id 'net.corda.plugins.quasar-utils'
+    id 'java-library'
 }
 
 description 'Show quasar-core-osgi added to configurations'
@@ -86,6 +88,7 @@ buildscript {
 
 plugins {
     id 'net.corda.plugins.quasar-utils'
+    id 'java-library'
 }
 
 description 'Show quasar-core-osgi added to configurations'
@@ -132,6 +135,7 @@ buildscript {
 
 plugins {
     id 'net.corda.plugins.quasar-utils'
+    id 'java-library'
 }
 
 apply from: 'repositories.gradle'
@@ -171,6 +175,7 @@ task show {
         def output = runGradleFor """
 plugins {
     id 'net.corda.plugins.quasar-utils'
+    id 'java-library'
 }
 
 description 'Show quasar-core-osgi added to configurations'
@@ -204,6 +209,7 @@ task show {
         def output = runGradleFor """
 plugins {
     id 'net.corda.plugins.quasar-utils'
+    id 'java-library'
 }
 
 description 'Show quasar-core-osgi added to test JVM arguments'
@@ -211,7 +217,7 @@ description 'Show quasar-core-osgi added to test JVM arguments'
 apply from: 'repositories.gradle'
 
 dependencies {
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:${JUNIT_VERSION}'
 }
 
 quasar {
@@ -248,6 +254,7 @@ buildscript {
 
 plugins {
     id 'net.corda.plugins.quasar-utils'
+    id 'java-library'
 }
 
 description 'Show quasar-core-osgi added to test JVM arguments'
@@ -255,7 +262,7 @@ description 'Show quasar-core-osgi added to test JVM arguments'
 apply from: 'repositories.gradle'
 
 dependencies {
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:${JUNIT_VERSION}'
 }
 
 quasar {
@@ -285,6 +292,7 @@ test {
         def output = runGradleFor """
 plugins {
     id 'net.corda.plugins.quasar-utils'
+    id 'java-library'
 }
 
 description 'Show quasar-core-osgi added to test JVM arguments'
@@ -292,7 +300,7 @@ description 'Show quasar-core-osgi added to test JVM arguments'
 apply from: 'repositories.gradle'
 
 dependencies {
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:${JUNIT_VERSION}'
 }
 
 quasar {
@@ -322,6 +330,7 @@ test {
         def output = runGradleFor """
 plugins {
     id 'net.corda.plugins.quasar-utils'
+    id 'java-library'
 }
 
 description 'Show quasar-core-osgi added to test JVM arguments'
@@ -333,7 +342,7 @@ ext {
 }
 
 dependencies {
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:${JUNIT_VERSION}'
 }
 
 quasar {
@@ -368,6 +377,7 @@ buildscript {
 }
 plugins {
     id 'net.corda.plugins.quasar-utils'
+    id 'java-library'
 }
 
 description 'Show quasar-core-osgi added to test JVM arguments'
@@ -389,11 +399,12 @@ apply from: 'repositories.gradle'
         def output = runGradleFor """
 plugins {
     id 'net.corda.plugins.quasar-utils'
+    id 'java-library'
 }
 apply from: 'repositories.gradle'
 
 dependencies {
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:${JUNIT_VERSION}'
 }
 
 quasar {
@@ -423,11 +434,12 @@ test {
         def output = runGradleFor """
 plugins {
     id 'net.corda.plugins.quasar-utils'
+    id 'java-library'
 }
 apply from: 'repositories.gradle'
 
 dependencies {
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:${JUNIT_VERSION}'
 }
 
 quasar {
@@ -457,11 +469,12 @@ test {
         def output = runGradleFor """
 plugins {
     id 'net.corda.plugins.quasar-utils'
+    id 'java-library'
 }
 apply from: 'repositories.gradle'
 
 dependencies {
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:${JUNIT_VERSION}'
 }
 
 quasar {

--- a/quasar-utils/src/test/groovy/net/corda/plugins/quasar/QuasarPluginTest.groovy
+++ b/quasar-utils/src/test/groovy/net/corda/plugins/quasar/QuasarPluginTest.groovy
@@ -17,8 +17,7 @@ class QuasarPluginTest {
 
     private static final String QUASAR_R3 = """\
 if (org.gradle.api.JavaVersion.current().java9Compatible) {
-    version = '0.8.2_r3'
-    classifier = ''
+    version = '0.8.4_r3'
 } else {
     version = '0.7.14_r3'
 }

--- a/quasar-utils/src/test/groovy/net/corda/plugins/quasar/QuasarSuspendableTest.groovy
+++ b/quasar-utils/src/test/groovy/net/corda/plugins/quasar/QuasarSuspendableTest.groovy
@@ -1,0 +1,171 @@
+package net.corda.plugins.quasar
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+import java.nio.file.Path
+
+import static org.assertj.core.api.Assertions.assertThat
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class QuasarSuspendableTest {
+    private static final String TEST_GRADLE_USER_HOME = System.getProperty("test.gradle.user.home", ".")
+    private static final String JUNIT_VERSION = "4.13"
+
+    @TempDir
+    public Path testProjectDir
+
+    @BeforeEach
+    void setup() {
+        Utilities.installResource(testProjectDir, "gradle.properties")
+        Utilities.installResource(testProjectDir, "settings.gradle")
+        Utilities.installResource(testProjectDir, "repositories.gradle")
+        Utilities.installResource(testProjectDir, "src/test/java/BasicTest.java")
+    }
+
+    @Test
+    void testWithSuspendableAnnotation() {
+        def quasarVersion = '0.8.4_r3'
+        def output = runGradleFor """
+plugins {
+    id 'net.corda.plugins.quasar-utils'
+    id 'java-library'
+}
+
+apply from: 'repositories.gradle'
+
+quasar {
+    suspendableAnnotation = 'net.corda.base.annotations.Suspendable'
+    version = '${quasarVersion}'
+}
+
+task show {
+    doFirst {
+        def configs = configurations.matching {
+            it.name in ['quasar', 'quasarAgent', 'cordaRuntimeOnly', 'compileOnly', 'cordaProvided', 'compileClasspath', 'runtimeClasspath']
+        }
+        configs.collectEntries { [(it.name):it.incoming.dependencies] }.each { name, dependencies ->
+            dependencies.each { dep ->
+                dep.artifacts.each { art ->
+                    println "\$name: \${dep.group}:\${dep.name}:\${art.extension}:\${dep.version}:\${art.classifier ?: ''}"
+                }
+            }
+        }
+    }
+}
+""", "show"
+        assertThat(output).containsOnlyOnce(
+            "quasar: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
+            "quasarAgent: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:agent".toString(),
+        ).doesNotContain(
+            "cordaRuntimeOnly: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
+            "runtimeClasspath: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
+            "compileOnly: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
+            "cordaProvided: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
+            "compileClasspath: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString()
+        )
+    }
+
+    @Test
+    void testWithEmptySuspendableAnnotation() {
+        def quasarVersion = '0.8.4_r3'
+        def output = runGradleFor """
+plugins {
+    id 'net.corda.plugins.quasar-utils'
+    id 'java-library'
+}
+
+apply from: 'repositories.gradle'
+
+quasar {
+    suspendableAnnotation = ''
+    version = '${quasarVersion}'
+}
+
+task show {
+    doFirst {
+        def configs = configurations.matching {
+            it.name in ['quasar', 'quasarAgent', 'cordaRuntimeOnly', 'compileOnly', 'cordaProvided', 'compileClasspath', 'runtimeClasspath']
+        }
+        configs.collectEntries { [(it.name):it.incoming.dependencies] }.each { name, dependencies ->
+            dependencies.each { dep ->
+                dep.artifacts.each { art ->
+                    println "\$name: \${dep.group}:\${dep.name}:\${art.extension}:\${dep.version}:\${art.classifier ?: ''}"
+                }
+            }
+        }
+    }
+
+    doLast {
+        println "QUASAR-ARG: [\${quasar.options.get()}]"
+    }
+}
+""", "show"
+        assertThat(output).containsOnlyOnce(
+            "quasar: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
+            "quasarAgent: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:agent".toString(),
+            "cordaRuntimeOnly: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
+            "runtimeClasspath: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
+            "compileOnly: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
+            "cordaProvided: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
+            "compileClasspath: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString()
+        )
+        assertThat(output).containsOnlyOnce("QUASAR-ARG: []")
+    }
+
+    @Test
+    void checkJVMArgsAddedForTests() {
+        def output = runGradleFor """
+plugins {
+    id 'net.corda.plugins.quasar-utils'
+    id 'java-library'
+}
+
+description 'Show quasar-core-osgi added to test JVM arguments'
+
+apply from: 'repositories.gradle'
+
+dependencies {
+    testImplementation 'junit:junit:${JUNIT_VERSION}'
+}
+
+quasar {
+    suspendableAnnotation = 'net.corda.base.annotations.Suspendable'
+}
+
+jar {
+    enabled = false
+}
+
+task show {
+    doLast {
+        println "QUASAR-ARG: [\${quasar.options.get()}]"
+    }
+}
+""", "show"
+        assertThat(output).containsOnlyOnce("QUASAR-ARG: [=a(SUSPENDABLE=net.corda.base.annotations.Suspendable)]")
+    }
+
+    private List<String> runGradleFor(String script, String taskName) {
+        def result = runnerFor(script, taskName).build()
+        println result.output
+
+        def build = result.task(":$taskName")
+        assertThat(build).isNotNull()
+        assertThat(build.outcome).isEqualTo(SUCCESS)
+
+        return result.output.readLines()
+    }
+
+    private GradleRunner runnerFor(String script, String taskName) {
+        def buildFile = testProjectDir.resolve("build.gradle")
+        buildFile.text = script
+        return GradleRunner.create()
+            .withProjectDir(testProjectDir.toFile())
+            .withArguments("--info", "--stacktrace", taskName, "-g", TEST_GRADLE_USER_HOME)
+            .withPluginClasspath()
+            .withDebug(true)
+    }
+}

--- a/quasar-utils/src/test/resources/repositories.gradle
+++ b/quasar-utils/src/test/resources/repositories.gradle
@@ -1,6 +1,9 @@
 repositories {
     mavenCentral()
     maven {
+        url 'https://software.r3.com/artifactory/corda-dependencies-dev'
+    }
+    maven {
         url 'https://software.r3.com/artifactory/corda-dependencies'
     }
 }


### PR DESCRIPTION
Update `quasar-utils` to use the OSGi-compatible Quasar 0.8.x artifacts. The tests only verify the Quasar `-javaagent:` parameter is correct, and do not actually instrument any classes. This means that they do not need to be executed on a Java 11+ JVM.