### PR TITLE
CORE-855: Update Cordformation plugin for Gradle 6.7.1.

### DIFF
--- a/cordformation/build.gradle
+++ b/cordformation/build.gradle
@@ -68,8 +68,8 @@ dependencies {
     testImplementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     testImplementation 'org.jetbrains.kotlin:kotlin-reflect'
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junit_jupiter_version")
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_jupiter_version"
     testImplementation "org.assertj:assertj-core:$assertj_version"
     testImplementation "net.corda:corda-serialization:$corda_release_version"
     testRuntimeOnly "net.corda:corda-node-api:$corda_release_version"
@@ -93,15 +93,6 @@ def generateSource = tasks.register('generateSource', Copy) {
 
 tasks.named('compileKotlin') { Task task ->
     task.dependsOn generateSource
-}
-
-tasks.named('validateTaskProperties', ValidateTaskProperties) {
-    // The official advice is to annotate Path inputs
-    // as @Input instead of @InputDirectory if we don't
-    // care about the directory contents changing.
-    // Unfortunately, Gradle also generates a warning
-    // for this which we are forced to tolerate.
-    failOnWarning = false
 }
 
 task createNodeRunner(type: Jar) {

--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
@@ -15,6 +15,9 @@ import java.io.File
  */
 class Cordformation : Plugin<Project> {
     internal companion object {
+        const val CORDA_RUNTIME_ONLY_CONFIGURATION_NAME = "cordaRuntimeOnly"
+        const val CORDA_DRIVER_CONFIGURATION_NAME = "cordaDriver"
+        const val CORDAPP_CONFIGURATION_NAME = "cordapp"
         const val CORDFORMATION_TYPE = "cordformationInternal"
         const val MINIMUM_GRADLE_VERSION = "5.1"
 
@@ -69,14 +72,14 @@ class Cordformation : Plugin<Project> {
         }
 
         // Apply the Java plugin on the assumption that we're building a JAR.
-        // This will also create the "compile", "compileOnly" and "runtime" configurations.
+        // This will also create the "compileOnly" and "runtimeOnly" configurations.
         project.pluginManager.apply(JavaPlugin::class.java)
 
         project.configurations.apply {
-            createCompileConfiguration("cordapp", this)
-            val cordaRuntimeOnly = createRuntimeOnlyConfiguration("cordaRuntimeOnly", this)
-            createChildConfiguration(CORDFORMATION_TYPE, cordaRuntimeOnly, this)
-            create("cordaDriver")
+            createCompileOnlyConfiguration(CORDAPP_CONFIGURATION_NAME)
+            val cordaRuntimeOnly = createRuntimeOnlyConfiguration(CORDA_RUNTIME_ONLY_CONFIGURATION_NAME)
+            createChildConfiguration(CORDFORMATION_TYPE, cordaRuntimeOnly)
+            maybeCreate(CORDA_DRIVER_CONFIGURATION_NAME)
         }
         // TODO: improve how we re-use existing declared external variables from root gradle.build
         val jolokiaVersion = project.findRootProperty("jolokia_version") ?: "1.6.0"

--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
@@ -5,6 +5,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME
 import org.gradle.util.GradleVersion
 import java.io.File
 
@@ -47,7 +48,7 @@ class Cordformation : Plugin<Project> {
                     ?: throw IllegalStateException("Could not find a valid declaration of \"corda_release_version\"")
             // need to cater for optional classifier (eg. corda-4.3-jdk11.jar)
             val pattern = "\\Q$jarName\\E(-enterprise)?-\\Q$releaseVersion\\E(-.+)?\\.jar\$".toRegex()
-            val maybeJar = project.configuration("runtime").filter {
+            val maybeJar = project.configuration(RUNTIME_CLASSPATH_CONFIGURATION_NAME).filter {
                 it.toString().contains(pattern)
             }
             if (maybeJar.isEmpty) {
@@ -73,8 +74,8 @@ class Cordformation : Plugin<Project> {
 
         project.configurations.apply {
             createCompileConfiguration("cordapp", this)
-            val cordaRuntime = createRuntimeConfiguration("cordaRuntime", this)
-            createChildConfiguration(CORDFORMATION_TYPE, cordaRuntime, this)
+            val cordaRuntimeOnly = createRuntimeOnlyConfiguration("cordaRuntimeOnly", this)
+            createChildConfiguration(CORDFORMATION_TYPE, cordaRuntimeOnly, this)
             create("cordaDriver")
         }
         // TODO: improve how we re-use existing declared external variables from root gradle.build

--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
@@ -33,6 +33,7 @@ class Cordformation : Plugin<Project> {
             tmpDir.mkdir()
             outputFile.outputStream().use { output ->
                 Cordformation::class.java.getResourceAsStream(filePathInJar)?.use { input ->
+                    // The copyTo() function uses its own buffer.
                     input.copyTo(output)
                 }
             }

--- a/cordformation/src/main/kotlin/net/corda/plugins/CordformationUtils.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/CordformationUtils.kt
@@ -36,8 +36,8 @@ fun createCompileConfiguration(name: String, configurations: ConfigurationContai
     return createChildConfiguration(name, configurations.single { it.name == "compile" }, configurations)
 }
 
-fun createRuntimeConfiguration(name: String, configurations: ConfigurationContainer): Configuration {
-    return createChildConfiguration(name, configurations.single { it.name == "runtime" }, configurations)
+fun createRuntimeOnlyConfiguration(name: String, configurations: ConfigurationContainer): Configuration {
+    return createChildConfiguration(name, configurations.single { it.name == "runtimeOnly" }, configurations)
 }
 
 fun createTempFileFromResource(resourcePath: String, tempFileName: String, tempFileExtension: String): Path {

--- a/cordformation/src/main/kotlin/net/corda/plugins/Dockerform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Dockerform.kt
@@ -85,7 +85,7 @@ open class Dockerform @Inject constructor(objects: ObjectFactory) : Baseform(obj
      */
     @TaskAction
     fun build() {
-        project.logger.lifecycle("Running DockerForm task")
+        logger.lifecycle("Running DockerForm task")
         initializeConfiguration()
         nodes.forEach { it.installDockerConfig(DEFAULT_SSH_PORT) }
         installCordaJar()

--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -2,6 +2,7 @@ package net.corda.plugins
 
 import com.typesafe.config.*
 import groovy.lang.Closure
+import net.corda.plugins.Cordformation.Companion.CORDA_DRIVER_CONFIGURATION_NAME
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
@@ -174,7 +175,7 @@ open class Node @Inject constructor(private val project: Project) {
      * @param p2pPort The Artemis messaging queue port.
      */
     fun p2pPort(p2pPort: Int) {
-        p2pAddress(DEFAULT_HOST + ':'.toString() + p2pPort)
+        p2pAddress("$DEFAULT_HOST:$p2pPort")
         this.p2pPort = p2pPort
     }
 
@@ -197,31 +198,11 @@ open class Node @Inject constructor(private val project: Project) {
     }
 
     /**
-     * Set the Artemis RPC port for this node on localhost.
-     *
-     * @param rpcPort The Artemis RPC queue port.
-     */
-    @Deprecated("Use {@link CordformNode#rpcSettings(RpcSettings)} instead. Will be removed by Corda V5.0.")
-    fun rpcPort(rpcPort: Int) {
-        rpcAddress(DEFAULT_HOST + ':'.toString() + rpcPort)
-    }
-
-    /**
-     * Set the Artemis RPC address for this node.
-     *
-     * @param rpcAddress The Artemis RPC queue host and port.
-     */
-    @Deprecated("Use {@link CordformNode#rpcSettings(RpcSettings)} instead. . Will be removed by Corda V5.0.")
-    fun rpcAddress(rpcAddress: String) {
-        setValue("rpcAddress", rpcAddress)
-    }
-
-    /**
      * Configure a webserver to connect to the node via RPC. This port will specify the port it will listen on. The node
      * must have an RPC address configured.
      */
     fun webPort(webPort: Int) {
-        webAddress(DEFAULT_HOST + ':'.toString() + webPort)
+        webAddress("$DEFAULT_HOST:$webPort")
     }
 
     /**
@@ -554,7 +535,7 @@ open class Node @Inject constructor(private val project: Project) {
         // TODO: improve how we re-use existing declared external variables from root gradle.build
         val jolokiaVersion = project.findRootProperty("jolokia_version") ?: "1.6.0"
 
-        val agentJar = project.configuration("runtime").files {
+        val agentJar = project.configuration("runtimeClasspath").files {
             (it.group == "org.jolokia") &&
                     (it.name == "jolokia-jvm") &&
                     (it.version == jolokiaVersion)
@@ -567,7 +548,7 @@ open class Node @Inject constructor(private val project: Project) {
     }
 
     internal fun installDrivers() {
-        project.configuration("cordaDriver").files.forEach {
+        project.configuration(CORDA_DRIVER_CONFIGURATION_NAME).files.forEach {
             project.logger.lifecycle("Copy ${it.name} to './drivers' directory")
             copyToDriversDir(it)
         }

--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -6,6 +6,7 @@ import net.corda.plugins.Cordformation.Companion.CORDA_DRIVER_CONFIGURATION_NAME
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.plugins.JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
@@ -29,6 +30,7 @@ open class Node @Inject constructor(private val project: Project) {
         const val webJarName = "corda-testserver.jar"
         const val configFileProperty = "configFile"
         const val DEFAULT_HOST = "localhost"
+        const val LOGS_DIR_NAME = "logs"
     }
 
     /**
@@ -488,8 +490,6 @@ open class Node @Inject constructor(private val project: Project) {
         runNodeJob(createSchemasCmd(), "node-schema-cordform.log")
     }
 
-    private val LOGS_DIR_NAME: String = "logs"
-
     private fun runNodeJob(command: List<String>, logfileName: String) {
         val logsDir = Files.createDirectories(nodeDir.toPath().resolve(LOGS_DIR_NAME))
         val nodeRedirectFile = logsDir.resolve(logfileName).toFile()
@@ -535,7 +535,7 @@ open class Node @Inject constructor(private val project: Project) {
         // TODO: improve how we re-use existing declared external variables from root gradle.build
         val jolokiaVersion = project.findRootProperty("jolokia_version") ?: "1.6.0"
 
-        val agentJar = project.configuration("runtimeClasspath").files {
+        val agentJar = project.configuration(RUNTIME_CLASSPATH_CONFIGURATION_NAME).files {
             (it.group == "org.jolokia") &&
                     (it.name == "jolokia-jvm") &&
                     (it.version == jolokiaVersion)

--- a/cordformation/src/test/resources/net/corda/plugins/DeployDockerImage.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeployDockerImage.gradle
@@ -5,11 +5,11 @@ plugins {
 apply from: 'repositories.gradle'
 
 dependencies {
-    cordaRuntime "$corda_group:corda:$corda_release_version"
-    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
-    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 def dockerImage = tasks.register('dockerImage', net.corda.plugins.DockerImage) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordapp.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordapp.gradle
@@ -5,11 +5,11 @@ plugins {
 apply from: 'repositories.gradle'
 
 dependencies {
-    cordaRuntime "$corda_group:corda:$corda_release_version"
-    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
-    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordapp.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordapp.gradle
@@ -20,8 +20,8 @@ task deployNodes(type: net.corda.plugins.Cordform) {
         name 'O=Notary Service,L=Zurich,C=CH'
         notary = [validating : true]
         p2pPort 10002
-        rpcPort 10003
         rpcSettings {
+            port 10003
             adminAddress "localhost:10004"
         }
         cordapps = ["$corda_group:corda-finance-contracts:$corda_release_version",

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappBackwardsCompatibility.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappBackwardsCompatibility.gradle
@@ -5,11 +5,11 @@ plugins {
 apply from: 'repositories.gradle'
 
 dependencies {
-    cordaRuntime "$corda_group:corda:$corda_release_version"
-    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
-    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappBackwardsCompatibility.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappBackwardsCompatibility.gradle
@@ -20,8 +20,8 @@ task deployNodes(type: net.corda.plugins.Cordform) {
         name 'O=Notary Service,L=Zurich,C=CH'
         notary = [validating : true]
         p2pPort 10002
-        rpcPort 10003
         rpcSettings {
+            port 10003
             adminAddress "localhost:10004"
         }
         cordapps = ["$corda_group:corda-finance-contracts:$corda_release_version",

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappConfig.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappConfig.gradle
@@ -20,8 +20,8 @@ task deployNodes(type: net.corda.plugins.Cordform) {
         name 'O=Notary Service,L=Zurich,C=CH'
         notary = [validating : true]
         p2pPort 10002
-        rpcPort 10003
         rpcSettings {
+            port 10003
             adminAddress "localhost:10004"
         }
         cordapp "$corda_group:corda-finance-contracts:$corda_release_version", {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappConfig.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappConfig.gradle
@@ -5,11 +5,11 @@ plugins {
 apply from: 'repositories.gradle'
 
 dependencies {
-    cordaRuntime "$corda_group:corda:$corda_release_version"
-    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
-    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappWithDocker.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappWithDocker.gradle
@@ -5,11 +5,11 @@ plugins {
 apply from: 'repositories.gradle'
 
 dependencies {
-    cordaRuntime "$corda_group:corda:$corda_release_version"
-    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
-    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task prepareDockerNodes(type: net.corda.plugins.Dockerform) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappWithNetworkConfigWithDocker.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappWithNetworkConfigWithDocker.gradle
@@ -5,11 +5,11 @@ plugins {
 apply from: 'repositories.gradle'
 
 dependencies {
-    cordaRuntime "$corda_group:corda:$corda_release_version"
-    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
-    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task prepareDockerNodes(type: net.corda.plugins.Dockerform) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappWithOU.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappWithOU.gradle
@@ -20,8 +20,8 @@ task deployNodes(type: net.corda.plugins.Cordform) {
         name 'OU=Org Unit, O=Notary Service, L=Zurich, C=CH'
         notary = [validating : true]
         p2pPort 10002
-        rpcPort 10003
         rpcSettings {
+            port 10003
             adminAddress "localhost:10004"
         }
         cordapps = ["$corda_group:corda-finance-contracts:$corda_release_version",

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappWithOU.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithCordappWithOU.gradle
@@ -5,11 +5,11 @@ plugins {
 apply from: 'repositories.gradle'
 
 dependencies {
-    cordaRuntime "$corda_group:corda:$corda_release_version"
-    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
-    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithExternalDBSettingsWithDocker.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithExternalDBSettingsWithDocker.gradle
@@ -6,11 +6,11 @@ apply from: 'repositories.gradle'
 apply from: 'postgres.gradle'
 
 dependencies {
-    cordaRuntime "$corda_group:corda:$corda_release_version"
-    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
-    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task prepareDockerNodes(type: net.corda.plugins.Dockerform, dependsOn: 'generateInitScripts') {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithExtraCommandForDbSchema.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithExtraCommandForDbSchema.gradle
@@ -24,8 +24,8 @@ task deployNodes(type: net.corda.plugins.Cordform) {
         name 'O=Notary Service,L=Zurich,C=CH'
         notary = [validating : true]
         p2pPort 10002
-        rpcPort 10003
         rpcSettings {
+            port 10003
             adminAddress "localhost:10004"
         }
         runSchemaMigration = true

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithExtraCommandForDbSchema.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithExtraCommandForDbSchema.gradle
@@ -9,11 +9,11 @@ repositories {
 }
 
 dependencies {
-    cordaRuntime "$corda_group:corda:$corda_release_version"
-    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
-    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
@@ -5,9 +5,9 @@ plugins {
 apply from: 'repositories.gradle'
 
 dependencies {
-    cordaRuntime "$corda_group:corda:$corda_release_version"
-    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
-    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntimeOnly "$corda_group:corda:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 jar {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
@@ -19,8 +19,8 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: [jar]) {
         name 'O=Notary Service,L=Zurich,C=CH'
         notary = [validating : true]
         p2pPort 10002
-        rpcPort 10003
         rpcSettings {
+            port 10003
             adminAddress "localhost:10004"
         }
         projectCordapp {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithNetworkParameterOverrides.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithNetworkParameterOverrides.gradle
@@ -35,8 +35,8 @@ task deployNodes(type: net.corda.plugins.Cordform) {
         name 'O=Notary Service,L=Zurich,C=CH'
         notary = [validating : true]
         p2pPort 10002
-        rpcPort 10003
         rpcSettings {
+            port 10003
             adminAddress "localhost:10004"
         }
         cordapps = ["$corda_group:corda-finance-contracts:$finance_release_version",

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithNetworkParameterOverrides.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithNetworkParameterOverrides.gradle
@@ -7,11 +7,11 @@ plugins {
 apply from: 'repositories.gradle'
 
 dependencies {
-    cordaRuntime "$corda_group:corda:$corda_release_version"
-    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$finance_release_version"
     cordapp "$corda_group:corda-finance-workflows:$finance_release_version"
-    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task deployNodes(type: net.corda.plugins.Cordform) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeployThreeNodeCordappWithExternalDBSettingsWithDocker.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeployThreeNodeCordappWithExternalDBSettingsWithDocker.gradle
@@ -6,11 +6,11 @@ apply from: 'repositories.gradle'
 apply from: 'postgres.gradle'
 
 dependencies {
-    cordaRuntime "$corda_group:corda:$corda_release_version"
-    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
-    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task prepareDockerNodes(type: net.corda.plugins.Dockerform, dependsOn: ['generateInitScripts', 'jar']) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeployThreeNodeCordappWithExternalDBSettingsWithNetworkConfigWithDocker.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeployThreeNodeCordappWithExternalDBSettingsWithNetworkConfigWithDocker.gradle
@@ -6,11 +6,11 @@ apply from: 'repositories.gradle'
 apply from: 'postgres.gradle'
 
 dependencies {
-    cordaRuntime "$corda_group:corda:$corda_release_version"
-    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
-    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task prepareDockerNodes(type: net.corda.plugins.Dockerform, dependsOn: ['generateInitScripts', 'jar']) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeployTwoNodeCordappWithDocker.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeployTwoNodeCordappWithDocker.gradle
@@ -5,11 +5,11 @@ plugins {
 apply from: 'repositories.gradle'
 
 dependencies {
-    cordaRuntime "$corda_group:corda:$corda_release_version"
-    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
-    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task prepareDockerNodes(type: net.corda.plugins.Dockerform, dependsOn: ['jar']) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeployTwoNodeCordappWithExternalService.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeployTwoNodeCordappWithExternalService.gradle
@@ -5,11 +5,11 @@ plugins {
 apply from: 'repositories.gradle'
 
 dependencies {
-    cordaRuntime "$corda_group:corda:$corda_release_version"
-    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
-    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task prepareDockerNodes(type: net.corda.plugins.Dockerform, dependsOn: ['jar']) {

--- a/cordformation/src/test/resources/net/corda/plugins/DeployTwoNodeCordappWithExternalServiceNoOption.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeployTwoNodeCordappWithExternalServiceNoOption.gradle
@@ -5,11 +5,11 @@ plugins {
 apply from: 'repositories.gradle'
 
 dependencies {
-    cordaRuntime "$corda_group:corda:$corda_release_version"
-    cordaRuntime "$corda_group:corda-node-api:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda:$corda_release_version"
+    cordaRuntimeOnly "$corda_group:corda-node-api:$corda_release_version"
     cordapp "$corda_group:corda-finance-contracts:$corda_release_version"
     cordapp "$corda_group:corda-finance-workflows:$corda_release_version"
-    cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
+    cordaRuntimeOnly "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
 task prepareDockerNodes(type: net.corda.plugins.Dockerform, dependsOn: ['jar']) {


### PR DESCRIPTION
- Replace uses of deprecated Gradle configurations.
- Update definition of `cordapp` configuration not to use deprecated `compile`.
- Use new `cordaRuntimeOnly` configuration instead of `cordaRuntime`.
- _Finally_ remove the deprecated `rpcPort` element from the DSL.
- Resolve compiler warnings.