### PR TITLE
CORE-855: Adjust definition of cordaProvided configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,4 +109,4 @@ Unfortunately, it is heavily constrained by how JFrog's Bintray and Artifactory
 plugins themselves work, and so we're currently stuck with it "as is". It _is_
 useful though - just shut your eyes and hold your nose.
 
-    <sup>Requires Gradle 5.1</sup>
+    <sup>Requires Gradle 6.6</sup>

--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
@@ -77,7 +77,7 @@ class Cordformation : Plugin<Project> {
         project.pluginManager.apply(JavaPlugin::class.java)
 
         project.configurations.apply {
-            createCompileOnlyConfiguration(CORDAPP_CONFIGURATION_NAME)
+            createCompileConfiguration(CORDAPP_CONFIGURATION_NAME)
             val cordaRuntimeOnly = createRuntimeOnlyConfiguration(CORDA_RUNTIME_ONLY_CONFIGURATION_NAME)
             createChildConfiguration(CORDFORMATION_TYPE, cordaRuntimeOnly)
             maybeCreate(CORDA_DRIVER_CONFIGURATION_NAME)

--- a/cordformation/src/main/kotlin/net/corda/plugins/CordformationUtils.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/CordformationUtils.kt
@@ -34,11 +34,15 @@ fun ConfigurationContainer.createChildConfiguration(name: String, parent: Config
     }
 }
 
-fun ConfigurationContainer.createCompileOnlyConfiguration(name: String): Configuration {
+fun ConfigurationContainer.createCompileConfiguration(name: String): Configuration {
+    return createCompileConfiguration(name, "Implementation")
+}
+
+private fun ConfigurationContainer.createCompileConfiguration(name: String, testSuffix: String): Configuration {
     return findByName(name) ?: run {
         val configuration = create(name)
         getByName(COMPILE_ONLY_CONFIGURATION_NAME).extendsFrom(configuration)
-        matching { it.name.endsWith("CompileOnly") }.configureEach { cfg ->
+        matching { it.name.endsWith(testSuffix) }.configureEach { cfg ->
             cfg.extendsFrom(configuration)
         }
         configuration

--- a/publish-utils/src/main/groovy/net/corda/plugins/publish/PublishConfigurationProjectListener.groovy
+++ b/publish-utils/src/main/groovy/net/corda/plugins/publish/PublishConfigurationProjectListener.groovy
@@ -7,13 +7,14 @@ import net.corda.plugins.publish.bintray.BintrayConfigExtension
 import org.gradle.api.Project
 import org.gradle.api.ProjectEvaluationListener
 import org.gradle.api.ProjectState
-import org.gradle.api.Task
+import org.gradle.api.UnknownTaskException
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ResolvedConfiguration
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPom
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.tasks.bundling.Jar
 
 import static net.corda.plugins.publish.PublishPlugin.*
 
@@ -86,17 +87,19 @@ class PublishConfigurationProjectListener implements ProjectEvaluationListener {
                 pub.artifactId = publishName
 
                 if (publishConfig.publishSources.get()) {
-                    Task sourceJar = project.tasks.findByName(SOURCES_TASK_NAME)
-                    if (sourceJar) {
+                    try {
                         project.logger.info('Publishing sources for {}', publishName)
-                        pub.artifact sourceJar
+                        pub.artifact project.tasks.named(SOURCES_TASK_NAME, Jar)
+                    } catch (UnknownTaskException ignored) {
+                        project.logger.warn("Missing {} task", SOURCES_TASK_NAME)
                     }
                 }
                 if (publishConfig.publishJavadoc.get()) {
-                    Task javadocJar = project.tasks.findByName(JAVADOC_JAR_TASK_NAME)
-                    if (javadocJar) {
+                    try {
                         project.logger.info('Publishing javadoc for {}', publishName)
-                        pub.artifact javadocJar
+                        pub.artifact project.tasks.named(JAVADOC_JAR_TASK_NAME, Jar)
+                    } catch (UnknownTaskException ignored) {
+                        project.logger.warn("Missing {} task", JAVADOC_JAR_TASK_NAME)
                     }
                 }
 

--- a/publish-utils/src/main/groovy/net/corda/plugins/publish/PublishPlugin.groovy
+++ b/publish-utils/src/main/groovy/net/corda/plugins/publish/PublishPlugin.groovy
@@ -23,7 +23,7 @@ class PublishPlugin implements Plugin<Project> {
     private static final String BINTRAY_CONFIG_EXTENSION_NAME = 'bintrayConfig'
     private static final String PUBLISH_EXTENSION_NAME = 'publish'
     private static final String INSTALL_TASK_NAME = 'install'
-    private static final String MINIMUM_GRADLE_VERSION = "5.1"
+    private static final String MINIMUM_GRADLE_VERSION = "6.6"
 
     @PackageScope
     static final String PUBLISH_CONFIGURATION_NAME = 'publish'

--- a/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarPlugin.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarPlugin.groovy
@@ -86,7 +86,7 @@ class QuasarPlugin implements Plugin<Project> {
         // If we're building a JAR then also add the Quasar bundle to the appropriate configurations.
         project.pluginManager.withPlugin('java') {
             // Add Quasar bundle to the compile classpath WITHOUT any of its transitive dependencies.
-            def cordaProvided = createCompileOnlyConfiguration(CORDA_PROVIDED_CONFIGURATION_NAME, project.configurations)
+            def cordaProvided = createCompileConfiguration(CORDA_PROVIDED_CONFIGURATION_NAME, project.configurations)
             cordaProvided.withDependencies(new QuasarAction(project.dependencies, extension, false))
 
             // Instrumented code needs both the Quasar bundle and its transitive dependencies at runtime.
@@ -120,12 +120,16 @@ class QuasarPlugin implements Plugin<Project> {
         return configuration
     }
 
-    private static Configuration createCompileOnlyConfiguration(String name, ConfigurationContainer configurations) {
+    private static Configuration createCompileConfiguration(String name, ConfigurationContainer configurations) {
+        return createCompileConfiguration(name, "Implementation", configurations)
+    }
+
+    private static Configuration createCompileConfiguration(String name, String testSuffix, ConfigurationContainer configurations) {
         Configuration configuration = configurations.findByName(name)
         if (configuration == null) {
             configuration = configurations.create(name)
             configurations.getByName(COMPILE_ONLY_CONFIGURATION_NAME).extendsFrom(configuration)
-            configurations.matching { it.name.endsWith("CompileOnly") }.configureEach { cfg ->
+            configurations.matching { it.name.endsWith(testSuffix) }.configureEach { cfg ->
                 cfg.extendsFrom(configuration)
             }
         }


### PR DESCRIPTION
A `cordaProvided` dependency contributes to `compileClasspath` but not to `runtimeClasspath`, because we expect Corda to provide it at runtime. However, we would also like to include it on the `testRuntimeClasspath`, `integrationTestRuntimeClasspath` etc to make developers' testing easier.

We will use the contents of the `runtimeClasspath` to determine the dependencies to include in the CPK, and so need to keep it free of Corda artifacts and their transitive dependencies.

Also update `publish-utils` for Gradle 6.6 lazy artifact support, c.f. "task configuration avoidance".
