### PR TITLE
CORE-855: A better fix for deprecation warning in API Scanner and JarFilter. (#377)

### DIFF
--- a/api-scanner/src/main/java/net/corda/plugins/apiscanner/ApiScanner.java
+++ b/api-scanner/src/main/java/net/corda/plugins/apiscanner/ApiScanner.java
@@ -3,7 +3,6 @@ package net.corda.plugins.apiscanner;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskCollection;
@@ -48,14 +47,14 @@ public class ApiScanner implements Plugin<Project> {
         TaskProvider<ScanApi> scanProvider = project.getTasks().register(SCAN_TASK_NAME, ScanApi.class, scanTask -> {
             TaskCollection<Jar> jarTasks = project.getTasks()
                 .withType(Jar.class)
+                .matching(Jar::isEnabled)
                 .matching(jarTask ->
-                     matches(jarTask.getArchiveClassifier(), extension.getTargetClassifier()) && jarTask.isEnabled()
+                     matches(jarTask.getArchiveClassifier(), extension.getTargetClassifier())
                 );
-            FileCollection jarSources = project.files(jarTasks);
 
             scanTask.setClasspath(project.getConfigurations().getByName(COMPILE_CLASSPATH_CONFIGURATION_NAME));
             // Automatically creates a dependency on jar tasks.
-            scanTask.setSources(jarSources);
+            scanTask.setSources(jarTasks);
             scanTask.setExcludePackages(extension.getExcludePackages());
             scanTask.setExcludeClasses(extension.getExcludeClasses());
             scanTask.setExcludeMethods(extension.getExcludeMethods());

--- a/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/CordappPlugin.kt
@@ -155,8 +155,8 @@ class CordappPlugin @Inject constructor(private val objects: ObjectFactory): Plu
 
     private fun configurePomCreation(project: Project) {
         project.tasks.withType(GenerateMavenPom::class.java).configureEach { task ->
-            task.doFirst {
-                project.logger.info("Modifying task: ${task.name} in project ${project.path} to exclude all dependencies from pom")
+            task.doFirst { _ ->
+                task.logger.info("Modifying task: ${task.name} in project ${project.path} to exclude all dependencies from pom")
                 // The CorDapp is a semi-fat jar, so we need to exclude its compile and runtime
                 // scoped dependencies from its Maven POM when we publish it.
                 task.pom = filterDependenciesFor(task.pom)

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTask.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetaFixerTask.kt
@@ -67,14 +67,18 @@ open class MetaFixerTask @Inject constructor(objects: ObjectFactory, layouts: Pr
     @get:Input
     val preserveTimestamps: Property<Boolean> = objects.property(Boolean::class.javaObjectType).convention(true)
 
-    private val _metafixed: ConfigurableFileCollection = project.files(outputDir.map { dir ->
-        _jars.elements.map { files ->
-            files.map { file -> toMetaFixed(dir, file) }
-        }
-    }).apply(ConfigurableFileCollection::disallowChanges)
-    val metafixed: Provider<Set<FileSystemLocation>>
+    private val _metafixed = objects.fileCollection().apply {
+        setFrom(outputDir.flatMap { dir ->
+            _jars.elements.map { files ->
+                files.map { file -> toMetaFixed(dir, file) }
+            }
+        })
+        disallowChanges()
+    }
+
+    val metafixed: FileCollection
         @OutputFiles
-        get() = _metafixed.elements
+        get() = _metafixed
 
     private fun toMetaFixed(dir: Directory, source: File): Provider<RegularFile> {
         return dir.file(suffix.map { sfx -> source.name.replace(JAR_PATTERN, "$sfx\$1") })

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterConfigurationTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterConfigurationTest.kt
@@ -276,6 +276,7 @@ class JarFilterConfigurationTest {
             .withProjectDir(testProjectDir.toFile())
             .withArguments(getBasicArgsForTasks("jarFilter"))
             .withPluginClasspath()
+            .withDebug(true)
     }
 
     private fun BuildResult.forTask(name: String): BuildTask {

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterExecuteTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterExecuteTest.kt
@@ -1,0 +1,105 @@
+package net.corda.gradle.jarfilter
+
+import net.corda.gradle.jarfilter.matcher.isFunction
+import net.corda.gradle.jarfilter.matcher.isProperty
+import net.corda.gradle.unwanted.HasAll
+import net.corda.gradle.unwanted.HasAllVal
+import net.corda.gradle.unwanted.HasAllVar
+import org.assertj.core.api.Assertions.assertThat
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.core.IsIterableContaining.hasItem
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.reflect.full.declaredFunctions
+import kotlin.reflect.full.declaredMemberProperties
+
+class JarFilterExecuteTest {
+    companion object {
+        private const val EXAMPLE_CLASS = "net.corda.gradle.ExampleKotlin"
+        private const val NESTED_CLASS = "net.corda.gradle.ExampleKotlin\$Nested"
+        private const val INNER_CLASS = "net.corda.gradle.ExampleKotlin\$Inner"
+
+        private val stringData = isFunction("stringData", String::class)
+        private val longData = isFunction("longData", Long::class)
+        private val intData = isFunction("intData", Int::class)
+        private val stringVal = isProperty("stringVal", String::class)
+        private val longVal = isProperty("longVal", Long::class)
+        private val intVal = isProperty("intVal", Int::class)
+        private val stringVar = isProperty("stringVar", String::class)
+        private val longVar = isProperty("longVar", Long::class)
+        private val intVar = isProperty("intVar", Int::class)
+
+        private lateinit var testProject: JarFilterProject
+
+        @BeforeAll
+        @JvmStatic
+        fun setup(@TempDir testProjectDir: Path) {
+            testProject = JarFilterProject(testProjectDir, "basic-execute").build()
+        }
+    }
+
+    @Test
+    fun testTaskOutput() {
+        assertThat(testProject.output)
+            .containsOnlyOnce("RESULT: ${testProject.filteredJar.fileName}")
+    }
+
+    @Test
+    fun testExampleClass() {
+        classLoaderFor(testProject.sourceJar).use { cl ->
+            cl.load<HasAll>(EXAMPLE_CLASS).apply {
+                assertThat("stringData() not found", kotlin.declaredFunctions, hasItem(stringData))
+                assertThat("longData() not found", kotlin.declaredFunctions, hasItem(longData))
+                assertThat("intData() not found", kotlin.declaredFunctions, hasItem(intData))
+            }
+        }
+
+        classLoaderFor(testProject.filteredJar).use { cl ->
+            cl.load<HasAll>(EXAMPLE_CLASS).apply {
+                assertThat("stringData() not found", kotlin.declaredFunctions, hasItem(stringData))
+                assertThat("longData() not found", kotlin.declaredFunctions, hasItem(longData))
+                assertThat("intData() not found", kotlin.declaredFunctions, hasItem(intData))
+            }
+        }
+    }
+
+    @Test
+    fun testNestedClass() {
+        classLoaderFor(testProject.sourceJar).use { cl ->
+            cl.load<HasAllVal>(NESTED_CLASS).apply {
+                assertThat("stringVal not found", kotlin.declaredMemberProperties, hasItem(stringVal))
+                assertThat("longVal not found", kotlin.declaredMemberProperties, hasItem(longVal))
+                assertThat("intVal not found", kotlin.declaredMemberProperties, hasItem(intVal))
+            }
+        }
+
+        classLoaderFor(testProject.filteredJar).use { cl ->
+            cl.load<HasAllVal>(NESTED_CLASS).apply {
+                assertThat("stringVal not found", kotlin.declaredMemberProperties, hasItem(stringVal))
+                assertThat("longVal not found", kotlin.declaredMemberProperties, hasItem(longVal))
+                assertThat("intVal not found", kotlin.declaredMemberProperties, hasItem(intVal))
+            }
+        }
+    }
+
+    @Test
+    fun testInnerClass() {
+        classLoaderFor(testProject.sourceJar).use { cl ->
+            cl.load<HasAllVar>(INNER_CLASS).apply {
+                assertThat("stringVar not found", kotlin.declaredMemberProperties, hasItem(stringVar))
+                assertThat("longVar not found", kotlin.declaredMemberProperties, hasItem(longVar))
+                assertThat("intVar not found", kotlin.declaredMemberProperties, hasItem(intVar))
+            }
+        }
+
+        classLoaderFor(testProject.filteredJar).use { cl ->
+            cl.load<HasAllVar>(INNER_CLASS).apply {
+                assertThat("stringVar not found", kotlin.declaredMemberProperties, hasItem(stringVar))
+                assertThat("longVar not found", kotlin.declaredMemberProperties, hasItem(longVar))
+                assertThat("intVar not found", kotlin.declaredMemberProperties, hasItem(intVar))
+            }
+        }
+    }
+}

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConfigurationTests.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConfigurationTests.kt
@@ -82,6 +82,7 @@ class MetaFixConfigurationTests {
             .withProjectDir(testProjectDir.toFile())
             .withArguments(getBasicArgsForTasks("metafix"))
             .withPluginClasspath()
+            .withDebug(true)
     }
 
     private fun BuildResult.forTask(name: String): BuildTask {

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixExecuteTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixExecuteTest.kt
@@ -1,0 +1,105 @@
+package net.corda.gradle.jarfilter
+
+import net.corda.gradle.jarfilter.matcher.isFunction
+import net.corda.gradle.jarfilter.matcher.isProperty
+import net.corda.gradle.unwanted.HasAll
+import net.corda.gradle.unwanted.HasAllVal
+import net.corda.gradle.unwanted.HasAllVar
+import org.assertj.core.api.Assertions.assertThat
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.core.IsIterableContaining.hasItem
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.reflect.full.declaredFunctions
+import kotlin.reflect.full.declaredMemberProperties
+
+class MetaFixExecuteTest {
+    companion object {
+        private const val EXAMPLE_CLASS = "net.corda.gradle.ExampleKotlin"
+        private const val NESTED_CLASS = "net.corda.gradle.ExampleKotlin\$Nested"
+        private const val INNER_CLASS = "net.corda.gradle.ExampleKotlin\$Inner"
+
+        private val stringData = isFunction("stringData", String::class)
+        private val longData = isFunction("longData", Long::class)
+        private val intData = isFunction("intData", Int::class)
+        private val stringVal = isProperty("stringVal", String::class)
+        private val longVal = isProperty("longVal", Long::class)
+        private val intVal = isProperty("intVal", Int::class)
+        private val stringVar = isProperty("stringVar", String::class)
+        private val longVar = isProperty("longVar", Long::class)
+        private val intVar = isProperty("intVar", Int::class)
+
+        private lateinit var testProject: MetaFixProject
+
+        @BeforeAll
+        @JvmStatic
+        fun setup(@TempDir testProjectDir: Path) {
+            testProject = MetaFixProject(testProjectDir, "basic-execute").build()
+        }
+    }
+
+    @Test
+    fun testTaskOutput() {
+        assertThat(testProject.output)
+            .containsOnlyOnce("RESULT: ${testProject.metafixedJar.fileName}")
+    }
+
+    @Test
+    fun testExampleClass() {
+        classLoaderFor(testProject.sourceJar).use { cl ->
+            cl.load<HasAll>(EXAMPLE_CLASS).apply {
+                assertThat("stringData() not found", kotlin.declaredFunctions, hasItem(stringData))
+                assertThat("longData() not found", kotlin.declaredFunctions, hasItem(longData))
+                assertThat("intData() not found", kotlin.declaredFunctions, hasItem(intData))
+            }
+        }
+
+        classLoaderFor(testProject.metafixedJar).use { cl ->
+            cl.load<HasAll>(EXAMPLE_CLASS).apply {
+                assertThat("stringData() not found", kotlin.declaredFunctions, hasItem(stringData))
+                assertThat("longData() not found", kotlin.declaredFunctions, hasItem(longData))
+                assertThat("intData() not found", kotlin.declaredFunctions, hasItem(intData))
+            }
+        }
+    }
+
+    @Test
+    fun testNestedClass() {
+        classLoaderFor(testProject.sourceJar).use { cl ->
+            cl.load<HasAllVal>(NESTED_CLASS).apply {
+                assertThat("stringVal not found", kotlin.declaredMemberProperties, hasItem(stringVal))
+                assertThat("longVal not found", kotlin.declaredMemberProperties, hasItem(longVal))
+                assertThat("intVal not found", kotlin.declaredMemberProperties, hasItem(intVal))
+            }
+        }
+
+        classLoaderFor(testProject.metafixedJar).use { cl ->
+            cl.load<HasAllVal>(NESTED_CLASS).apply {
+                assertThat("stringVal not found", kotlin.declaredMemberProperties, hasItem(stringVal))
+                assertThat("longVal not found", kotlin.declaredMemberProperties, hasItem(longVal))
+                assertThat("intVal not found", kotlin.declaredMemberProperties, hasItem(intVal))
+            }
+        }
+    }
+
+    @Test
+    fun testInnerClass() {
+        classLoaderFor(testProject.sourceJar).use { cl ->
+            cl.load<HasAllVar>(INNER_CLASS).apply {
+                assertThat("stringVar not found", kotlin.declaredMemberProperties, hasItem(stringVar))
+                assertThat("longVar not found", kotlin.declaredMemberProperties, hasItem(longVar))
+                assertThat("intVar not found", kotlin.declaredMemberProperties, hasItem(intVar))
+            }
+        }
+
+        classLoaderFor(testProject.metafixedJar).use { cl ->
+            cl.load<HasAllVar>(INNER_CLASS).apply {
+                assertThat("stringVar not found", kotlin.declaredMemberProperties, hasItem(stringVar))
+                assertThat("longVar not found", kotlin.declaredMemberProperties, hasItem(longVar))
+                assertThat("intVar not found", kotlin.declaredMemberProperties, hasItem(intVar))
+            }
+        }
+    }
+}

--- a/jar-filter/src/test/resources/basic-execute/build.gradle
+++ b/jar-filter/src/test/resources/basic-execute/build.gradle
@@ -1,0 +1,46 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+import net.corda.gradle.jarfilter.MetaFixerTask
+
+plugins {
+    id 'org.jetbrains.kotlin.jvm'
+    id 'net.corda.plugins.jar-filter' apply false
+}
+apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
+
+sourceSets {
+    main {
+        kotlin {
+            srcDir files('../resources/test/basic-execute/kotlin')
+        }
+    }
+}
+
+dependencies {
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
+}
+
+jar {
+    archiveBaseName = 'basic-execute'
+}
+
+tasks.register('jarFilter', JarFilterTask) {
+    jars jar
+
+    doLast {
+        filtered.forEach { file ->
+            println "RESULT: ${file.name}"
+        }
+    }
+}
+
+tasks.register('metafix', MetaFixerTask) {
+    jars jar
+
+    doLast {
+        metafixed.forEach { file ->
+            println "RESULT: ${file.name}"
+        }
+    }
+}

--- a/jar-filter/src/test/resources/basic-execute/kotlin/net/corda/gradle/ExampleKotlin.kt
+++ b/jar-filter/src/test/resources/basic-execute/kotlin/net/corda/gradle/ExampleKotlin.kt
@@ -1,0 +1,23 @@
+package net.corda.gradle
+
+import net.corda.gradle.unwanted.HasAll
+import net.corda.gradle.unwanted.HasAllVal
+import net.corda.gradle.unwanted.HasAllVar
+
+class ExampleKotlin : HasAll {
+    class Nested(
+         override val stringVal: String,
+         override val longVal: Long,
+         override val intVal: Int
+    ) : HasAllVal
+
+    inner class Inner(
+        override var stringVar: String,
+        override var longVar: Long,
+        override var intVar: Int
+    ) : HasAllVar
+
+    override fun stringData(): String = "Hello World!"
+    override fun longData(): Long = Long.MAX_VALUE
+    override fun intData(): Int = Int.MIN_VALUE
+}


### PR DESCRIPTION
Preserve JarFilter's public API. However, the `ScanApi` task is private and can be streamlined.