### PR TITLE
CORE-727: Create directory ZipEntry objects using the factory.

### DIFF
--- a/flask/build.gradle
+++ b/flask/build.gradle
@@ -51,6 +51,7 @@ dependencies {
         add(conf, [group: "org.projectlombok", name: "lombok", version: lombok_version])
     }
     testImplementation project("flask-common")
+    testImplementation "org.assertj:assertj-core:$assertj_version"
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_jupiter_version"
 }

--- a/flask/src/test/groovy/net/corda/gradle/flask/FlaskPluginTest.groovy
+++ b/flask/src/test/groovy/net/corda/gradle/flask/FlaskPluginTest.groovy
@@ -3,7 +3,6 @@ package net.corda.gradle.flask
 import groovy.transform.CompileStatic
 import net.corda.flask.common.Flask
 import org.gradle.testkit.runner.GradleRunner
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -15,8 +14,15 @@ import java.security.MessageDigest
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 
+import static net.corda.flask.common.Flask.Constants.BUFFER_SIZE
+import static net.corda.flask.common.Flask.Constants.ZIP_ENTRIES_DEFAULT_TIMESTAMP
+import static org.assertj.core.api.Assertions.assertThat
+import static org.junit.jupiter.api.Assertions.assertArrayEquals
+import static org.junit.jupiter.api.Assertions.assertEquals
+
 @CompileStatic
 class FlaskPluginTest {
+    private static final int EOF = -1
 
     private void installResource(String root, String resourceName, Path destination) {
         Path outputFile = with {
@@ -78,16 +84,45 @@ class FlaskPluginTest {
         println(runner.build().getOutput())
     }
 
+    static long consumeEntry(InputStream input) {
+        byte[] buffer = new byte[BUFFER_SIZE]
+        long totalBytes = 0
+        long bytesRead
+        while ((bytesRead = input.read(buffer)) != EOF) {
+            totalBytes += bytesRead
+        }
+        return totalBytes
+    }
+
     @Test
     void buildFlaskJar() {
         invokeGradle("flaskJar")
 
-        //Check that all zip entries have timestamp equal to Flask.Constants.ZIP_ENTRIES_DEFAULT_TIMESTAMP
+        //Check that all zip entries have timestamp equal to Flask.Constants.ZIP_ENTRIES_DEFAULT_TIMESTAMP,
+        //that directories and jars have been STORED, and everything else has been DEFLATED.
         Path flaskJar = testProjectDir.resolve("build/flask.jar")
         new ZipInputStream(Files.newInputStream(flaskJar)).withStream { zipInputStream ->
             ZipEntry zipEntry
             while((zipEntry = zipInputStream.nextEntry) != null) {
-                Assertions.assertEquals(Flask.Constants.ZIP_ENTRIES_DEFAULT_TIMESTAMP, zipEntry.time)
+                assertEquals(ZIP_ENTRIES_DEFAULT_TIMESTAMP, zipEntry.time)
+
+                // A DEFLATED zipEntry is not fully populated until its stream has been consumed.
+                long actualSize = consumeEntry(zipInputStream)
+                assertThat(zipEntry.size).isEqualTo(actualSize)
+                if (zipEntry.isDirectory()) {
+                    assertEquals(ZipEntry.STORED, zipEntry.method, zipEntry.name)
+                    assertThat(zipEntry.compressedSize).isZero()
+                    assertThat(zipEntry.size).isZero()
+                    assertThat(zipEntry.crc).isZero()
+                } else if (zipEntry.name.endsWith(".jar")) {
+                    assertEquals(ZipEntry.STORED, zipEntry.method, zipEntry.name)
+                    assertThat(zipEntry.compressedSize).isEqualTo(actualSize)
+                    assertThat(zipEntry.crc).isNotZero()
+                } else {
+                    assertEquals(ZipEntry.DEFLATED, zipEntry.method, zipEntry.name)
+                    assertThat(zipEntry.compressedSize).isLessThan(actualSize).isPositive()
+                    assertThat(zipEntry.crc).isNotZero()
+                }
             }
         }
     }
@@ -96,7 +131,7 @@ class FlaskPluginTest {
     void compareFlaskJars() {
         invokeGradle("flaskJar")
         Path flaskJar = testProjectDir.resolve("build/flask.jar")
-        byte[] buffer = new byte[Flask.Constants.BUFFER_SIZE]
+        byte[] buffer = new byte[BUFFER_SIZE]
         MessageDigest md = MessageDigest.getInstance("SHA-256")
         byte[] digest1 = Flask.computeDigest( { Files.newInputStream(flaskJar) }, md, buffer)
 
@@ -105,7 +140,7 @@ class FlaskPluginTest {
         byte[] digest2 = Flask.computeDigest( { Files.newInputStream(flaskJar) }, md, buffer)
         //Recreating the flask jar archive from the same project setting "preserveFileTimestamps = false"
         // and "reproducibleFileOrder = true" on all included artifacts should always result in the same byte sequence
-        Assertions.assertArrayEquals(digest1, digest2)
+        assertArrayEquals(digest1, digest2)
     }
 
     @Test
@@ -117,8 +152,8 @@ class FlaskPluginTest {
                 load(reader)
             }
         }
-        Assertions.assertEquals("net.corda.gradle.flask.test.Main", prop.mainClassName)
-        Assertions.assertEquals("arg1 arg2 arg3", prop.args)
+        assertEquals("net.corda.gradle.flask.test.Main", prop.mainClassName)
+        assertEquals("arg1 arg2 arg3", prop.args)
     }
 
     @Test
@@ -130,6 +165,6 @@ class FlaskPluginTest {
                 load(reader)
             }
         }
-        Assertions.assertEquals("net.corda.gradle.flask.test.AlternativeMain", prop.mainClassName)
+        assertEquals("net.corda.gradle.flask.test.AlternativeMain", prop.mainClassName)
     }
 }


### PR DESCRIPTION
We create zip directory entries in two places, so move their creation into `ZipEntryFactory` and then add a test to ensure we have caught them all.

Move handling of the "last modified" timestamp into `ZipEntryFactory` too.

Note: When using `ZipInputStream`, each `ZipEntry`'s `time`, `comment` and `extra` values are available immediately. But a `DEFLATED` entry's entire `InputStream` needs to be consumed before its `size`, `compressedSize` and `crc` values are set.

(:rotating_light: And this commit can be _**SQUASHED**_ too! :rotating_light:)