### PR TITLE
NOTICK: Enable debugging for two JarFilter test projects.

### DIFF
--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterTimestampTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterTimestampTest.kt
@@ -53,6 +53,7 @@ class JarFilterTimestampTest {
                 .withProjectDir(testProjectDir.toFile())
                 .withArguments(getGradleArgsForTasks("jarFilter"))
                 .withPluginClasspath()
+                .withDebug(true)
                 .build()
             output = result.output
             println(output)

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixTimestampTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixTimestampTest.kt
@@ -54,6 +54,7 @@ class MetaFixTimestampTest {
                 .withProjectDir(testProjectDir.toFile())
                 .withArguments(getGradleArgsForTasks("metafix"))
                 .withPluginClasspath()
+                .withDebug(true)
                 .build()
             output = result.output
             println(output)


### PR DESCRIPTION
Allow these final two Gradle test projects to be debugged.