### PR TITLE
NOTICK: Clean some JarFilter technical debt: (#391)

### DIFF
--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/FilterTransformer.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/FilterTransformer.kt
@@ -92,7 +92,7 @@ class FilterTransformer private constructor (
         visitor = visitor,
         logger = logger,
         kotlinMetadata = kotlinMetadata,
-        importExtra =  { null },
+        importExtra = { null },
         removeAnnotations = removeAnnotations,
         deleteAnnotations = deleteAnnotations,
         stubAnnotations = stubAnnotations,
@@ -129,7 +129,7 @@ class FilterTransformer private constructor (
             return null
         }
         val fv = super.visitField(access, fieldName, descriptor, signature, value) ?: return null
-        return UnwantedFieldAdapter(fv, field)
+        return if (isUnwantedClass) fv else UnwantedFieldAdapter(fv, field)
     }
 
     override fun visitMethod(access: Int, methodName: String, descriptor: String, signature: String?, exceptions: Array<String>?): MethodVisitor? {
@@ -153,7 +153,7 @@ class FilterTransformer private constructor (
             return if (method.isVoidFunction) VoidStubMethodAdapter(mv) else ThrowingStubMethodAdapter(mv)
         }
 
-        return UnwantedMethodAdapter(mv, method)
+        return if (isUnwantedClass) mv else UnwantedMethodAdapter(mv, method)
     }
 
     override fun visitInnerClass(clsName: String, outerName: String?, innerName: String?, access: Int) {

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/UnwantedCache.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/UnwantedCache.kt
@@ -43,4 +43,3 @@ class UnwantedCache {
                 (methodName != null && methodDescriptor != null && containsMethod(className, MethodElement(methodName, methodDescriptor)))
     }
 }
-

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteConstructorTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteConstructorTest.kt
@@ -1,6 +1,7 @@
 package net.corda.gradle.jarfilter
 
 import net.corda.gradle.jarfilter.matcher.isConstructor
+import net.corda.gradle.jarfilter.matcher.isKonstructor
 import net.corda.gradle.jarfilter.matcher.matches
 import net.corda.gradle.unwanted.HasAll
 import net.corda.gradle.unwanted.HasInt
@@ -41,7 +42,7 @@ class DeleteConstructorTest {
 
     @Test
     fun deleteConstructorWithLongParameter() {
-        val longConstructor = isConstructor(SECONDARY_CONSTRUCTOR_CLASS, Long::class)
+        val longConstructor = isKonstructor(SECONDARY_CONSTRUCTOR_CLASS, Long::class)
 
         classLoaderFor(testProject.sourceJar).use { cl ->
             with(cl.load<HasLong>(SECONDARY_CONSTRUCTOR_CLASS)) {
@@ -63,7 +64,7 @@ class DeleteConstructorTest {
 
     @Test
     fun deleteConstructorWithStringParameter() {
-        val stringConstructor = isConstructor(SECONDARY_CONSTRUCTOR_CLASS, String::class)
+        val stringConstructor = isKonstructor(SECONDARY_CONSTRUCTOR_CLASS, String::class)
 
         classLoaderFor(testProject.sourceJar).use { cl ->
             with(cl.load<HasString>(SECONDARY_CONSTRUCTOR_CLASS)) {
@@ -85,7 +86,7 @@ class DeleteConstructorTest {
 
     @Test
     fun showUnannotatedConstructorIsUnaffected() {
-        val intConstructor = isConstructor(SECONDARY_CONSTRUCTOR_CLASS, Int::class)
+        val intConstructor = isKonstructor(SECONDARY_CONSTRUCTOR_CLASS, Int::class)
         classLoaderFor(testProject.filteredJar).use { cl ->
             with(cl.load<HasAll>(SECONDARY_CONSTRUCTOR_CLASS)) {
                 getDeclaredConstructor(Int::class.java).newInstance(NUMBER).also {
@@ -101,7 +102,7 @@ class DeleteConstructorTest {
 
     @Test
     fun deletePrimaryConstructorWithStringParameter() {
-        val stringConstructor = isConstructor(STRING_PRIMARY_CONSTRUCTOR_CLASS, String::class)
+        val stringConstructor = isKonstructor(STRING_PRIMARY_CONSTRUCTOR_CLASS, String::class)
 
         classLoaderFor(testProject.sourceJar).use { cl ->
             with(cl.load<HasString>(STRING_PRIMARY_CONSTRUCTOR_CLASS)) {
@@ -124,7 +125,7 @@ class DeleteConstructorTest {
 
     @Test
     fun deletePrimaryConstructorWithLongParameter() {
-        val longConstructor = isConstructor(LONG_PRIMARY_CONSTRUCTOR_CLASS, Long::class)
+        val longConstructor = isKonstructor(LONG_PRIMARY_CONSTRUCTOR_CLASS, Long::class)
 
         classLoaderFor(testProject.sourceJar).use { cl ->
             with(cl.load<HasLong>(LONG_PRIMARY_CONSTRUCTOR_CLASS)) {
@@ -147,7 +148,7 @@ class DeleteConstructorTest {
 
     @Test
     fun deletePrimaryConstructorWithIntParameter() {
-        val intConstructor = isConstructor(INT_PRIMARY_CONSTRUCTOR_CLASS, Int::class)
+        val intConstructor = isKonstructor(INT_PRIMARY_CONSTRUCTOR_CLASS, Int::class)
 
         classLoaderFor(testProject.sourceJar).use { cl ->
             with(cl.load<HasInt>(INT_PRIMARY_CONSTRUCTOR_CLASS)) {
@@ -170,7 +171,7 @@ class DeleteConstructorTest {
 
     @Test
     fun deletePrimaryConstructorWithDefaultParameter() {
-        val defaultValueConstructor = isConstructor(DEFAULT_VALUE_PRIMARY_CLASS, String::class)
+        val defaultValueConstructor = isKonstructor(DEFAULT_VALUE_PRIMARY_CLASS, String::class)
 
         classLoaderFor(testProject.sourceJar).use { cl ->
             with(cl.load<HasString>(DEFAULT_VALUE_PRIMARY_CLASS)) {
@@ -193,7 +194,7 @@ class DeleteConstructorTest {
 
     @Test
     fun deleteSecondaryConstructorWithDefaultParameter() {
-        val defaultValueConstructor = isConstructor(DEFAULT_VALUE_SECONDARY_CLASS, String::class)
+        val defaultValueConstructor = isKonstructor(DEFAULT_VALUE_SECONDARY_CLASS, String::class)
         val syntheticSecondaryConstructor = isConstructor(
             equalTo(DEFAULT_VALUE_SECONDARY_CLASS),
             matches(String::class.java), matches(Integer.TYPE), equalTo("kotlin.jvm.internal.DefaultConstructorMarker")

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteInnerLambdaTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteInnerLambdaTest.kt
@@ -1,6 +1,6 @@
 package net.corda.gradle.jarfilter
 
-import net.corda.gradle.jarfilter.matcher.isConstructor
+import net.corda.gradle.jarfilter.matcher.isKonstructor
 import net.corda.gradle.unwanted.HasInt
 import org.assertj.core.api.Assertions.assertThat
 import org.hamcrest.MatcherAssert.assertThat
@@ -18,8 +18,8 @@ class DeleteInnerLambdaTest {
         private const val LAMBDA_CLASS = "net.corda.gradle.HasInnerLambda"
         private const val SIZE = 64
 
-        private val constructInt = isConstructor(LAMBDA_CLASS, Int::class)
-        private val constructBytes = isConstructor(LAMBDA_CLASS, ByteArray::class)
+        private val constructInt = isKonstructor(LAMBDA_CLASS, Int::class)
+        private val constructBytes = isKonstructor(LAMBDA_CLASS, ByteArray::class)
 
         private lateinit var testProject: JarFilterProject
         private lateinit var sourceClasses: List<String>

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixAnnotationTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixAnnotationTest.kt
@@ -2,7 +2,7 @@ package net.corda.gradle.jarfilter
 
 import net.corda.gradle.jarfilter.asm.bytecode
 import net.corda.gradle.jarfilter.asm.toClass
-import net.corda.gradle.jarfilter.matcher.isConstructor
+import net.corda.gradle.jarfilter.matcher.isKonstructor
 import org.gradle.api.logging.Logger
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsIterableContaining.hasItem
@@ -11,10 +11,10 @@ import org.junit.jupiter.api.Test
 class MetaFixAnnotationTest {
     companion object {
         private val logger: Logger = StdOutLogging(MetaFixAnnotationTest::class)
-        private val defaultCon = isConstructor(
+        private val defaultCon = isKonstructor(
             returnType = SimpleAnnotation::class
         )
-        private val valueCon = isConstructor(
+        private val valueCon = isKonstructor(
             returnType = AnnotationWithValue::class,
             parameters = *arrayOf(String::class)
         )

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConstructorDefaultParameterTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConstructorDefaultParameterTest.kt
@@ -2,7 +2,7 @@ package net.corda.gradle.jarfilter
 
 import net.corda.gradle.jarfilter.asm.recodeMetadataFor
 import net.corda.gradle.jarfilter.asm.toClass
-import net.corda.gradle.jarfilter.matcher.isConstructor
+import net.corda.gradle.jarfilter.matcher.isKonstructor
 import net.corda.gradle.unwanted.HasAll
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.api.logging.Logger
@@ -18,9 +18,9 @@ class MetaFixConstructorDefaultParameterTest {
     companion object {
         private val logger: Logger = StdOutLogging(MetaFixConstructorDefaultParameterTest::class)
         private val primaryCon
-                = isConstructor(WithConstructorParameters::class, Long::class, Int::class, String::class)
+                = isKonstructor(WithConstructorParameters::class, Long::class, Int::class, String::class)
         private val secondaryCon
-                = isConstructor(WithConstructorParameters::class, Char::class, String::class)
+                = isKonstructor(WithConstructorParameters::class, Char::class, String::class)
 
         lateinit var sourceClass: Class<out HasAll>
         lateinit var fixedClass: Class<out HasAll>

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConstructorTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConstructorTest.kt
@@ -2,7 +2,7 @@ package net.corda.gradle.jarfilter
 
 import net.corda.gradle.jarfilter.asm.recodeMetadataFor
 import net.corda.gradle.jarfilter.asm.toClass
-import net.corda.gradle.jarfilter.matcher.isConstructor
+import net.corda.gradle.jarfilter.matcher.isKonstructor
 import net.corda.gradle.unwanted.HasLong
 import org.gradle.api.logging.Logger
 import org.hamcrest.MatcherAssert.assertThat
@@ -15,8 +15,8 @@ import kotlin.jvm.kotlin
 class MetaFixConstructorTest {
     companion object {
         private val logger: Logger = StdOutLogging(MetaFixConstructorTest::class)
-        private val unwantedCon = isConstructor(WithConstructor::class, Int::class, Long::class)
-        private val wantedCon = isConstructor(WithConstructor::class, Long::class)
+        private val unwantedCon = isKonstructor(WithConstructor::class, Int::class, Long::class)
+        private val wantedCon = isKonstructor(WithConstructor::class, Long::class)
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/SanitiseDeleteConstructorTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/SanitiseDeleteConstructorTest.kt
@@ -1,6 +1,7 @@
 package net.corda.gradle.jarfilter
 
 import net.corda.gradle.jarfilter.matcher.isConstructor
+import net.corda.gradle.jarfilter.matcher.isKonstructor
 import net.corda.gradle.jarfilter.matcher.matches
 import net.corda.gradle.unwanted.HasInt
 import net.corda.gradle.unwanted.HasLong
@@ -53,7 +54,7 @@ class SanitiseDeleteConstructorTest {
     )
 
     private fun checkClassWithLongParameter(longClass: String, deleted: List<Array<Matcher<in String>>>) {
-        val longConstructor = isConstructor(longClass, Long::class)
+        val longConstructor = isKonstructor(longClass, Long::class)
         val deletedConstructors = deleted.map { args -> isConstructor(equalTo(longClass), *args) }.toTypedArray()
 
         classLoaderFor(testProject.sourceJar).use { cl ->
@@ -111,7 +112,7 @@ class SanitiseDeleteConstructorTest {
     )
 
     private fun checkClassWithIntParameter(intClass: String, deleted: List<Array<Matcher<in String>>>) {
-        val intConstructor = isConstructor(intClass, Int::class)
+        val intConstructor = isKonstructor(intClass, Int::class)
         val deletedConstructors = deleted.map { args -> isConstructor(equalTo(intClass), *args) }.toTypedArray()
 
         classLoaderFor(testProject.sourceJar).use { cl ->
@@ -169,7 +170,7 @@ class SanitiseDeleteConstructorTest {
     )
 
     private fun checkClassWithStringParameter(stringClass: String, deleted: List<Array<Matcher<in String>>>) {
-        val stringConstructor = isConstructor(stringClass, String::class)
+        val stringConstructor = isKonstructor(stringClass, String::class)
         val deletedConstructors = deleted.map { args -> isConstructor(equalTo(stringClass), *args) }.toTypedArray()
 
         classLoaderFor(testProject.sourceJar).use { cl ->
@@ -211,7 +212,7 @@ class SanitiseDeleteConstructorTest {
 
     @Test
     fun deleteOverloadedComplexConstructor() {
-        val complexConstructor = isConstructor(COMPLEX_CONSTRUCTOR_CLASS, Int::class, String::class)
+        val complexConstructor = isKonstructor(COMPLEX_CONSTRUCTOR_CLASS, Int::class, String::class)
         val syntheticConstructor = isConstructor(
             equalTo(COMPLEX_CONSTRUCTOR_CLASS),
             matches(Integer.TYPE), matches(String::class.java), matches(Integer.TYPE), isDefaultConstructorMarker

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/SanitiseStubConstructorTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/SanitiseStubConstructorTest.kt
@@ -1,6 +1,6 @@
 package net.corda.gradle.jarfilter
 
-import net.corda.gradle.jarfilter.matcher.isConstructor
+import net.corda.gradle.jarfilter.matcher.isKonstructor
 import net.corda.gradle.unwanted.HasInt
 import net.corda.gradle.unwanted.HasLong
 import net.corda.gradle.unwanted.HasString
@@ -53,7 +53,7 @@ class SanitiseStubConstructorTest {
     )
 
     private fun checkClassWithLongParameter(longClass: String, constructorCount: Int) {
-        val longConstructor = isConstructor(longClass, Long::class)
+        val longConstructor = isKonstructor(longClass, Long::class)
 
         classLoaderFor(testProject.sourceJar).use { cl ->
             with(cl.load<HasLong>(longClass)) {
@@ -108,7 +108,7 @@ class SanitiseStubConstructorTest {
     )
 
     private fun checkClassWithIntParameter(intClass: String, constructorCount: Int) {
-        val intConstructor = isConstructor(intClass, Int::class)
+        val intConstructor = isKonstructor(intClass, Int::class)
 
         classLoaderFor(testProject.sourceJar).use { cl ->
             with(cl.load<HasInt>(intClass)) {
@@ -163,7 +163,7 @@ class SanitiseStubConstructorTest {
     )
 
     private fun checkClassWithStringParameter(stringClass: String, constructorCount: Int) {
-        val stringConstructor = isConstructor(stringClass, String::class)
+        val stringConstructor = isKonstructor(stringClass, String::class)
 
         classLoaderFor(testProject.sourceJar).use { cl ->
             with(cl.load<HasString>(stringClass)) {
@@ -207,7 +207,7 @@ class SanitiseStubConstructorTest {
 
     @Test
     fun stubOverloadedComplexConstructor() {
-        val complexConstructor = isConstructor(COMPLEX_CONSTRUCTOR_CLASS, Int::class, String::class)
+        val complexConstructor = isKonstructor(COMPLEX_CONSTRUCTOR_CLASS, Int::class, String::class)
 
         classLoaderFor(testProject.sourceJar).use { cl ->
             with(cl.load<Any>(COMPLEX_CONSTRUCTOR_CLASS)) {

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/StubConstructorTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/StubConstructorTest.kt
@@ -1,6 +1,6 @@
 package net.corda.gradle.jarfilter
 
-import net.corda.gradle.jarfilter.matcher.isConstructor
+import net.corda.gradle.jarfilter.matcher.isKonstructor
 import net.corda.gradle.unwanted.HasAll
 import net.corda.gradle.unwanted.HasInt
 import net.corda.gradle.unwanted.HasLong
@@ -164,7 +164,7 @@ class StubConstructorTest {
 
     @Test
     fun stubPrimaryConstructorWithDefaultParameter() {
-        val defaultValueConstructor = isConstructor(DEFAULT_VALUE_PRIMARY_CLASS, String::class)
+        val defaultValueConstructor = isKonstructor(DEFAULT_VALUE_PRIMARY_CLASS, String::class)
 
         classLoaderFor(testProject.sourceJar).use { cl ->
             with(cl.load<HasString>(DEFAULT_VALUE_PRIMARY_CLASS)) {

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/matcher/KotlinMatchers.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/matcher/KotlinMatchers.kt
@@ -25,16 +25,16 @@ fun isFunction(name: String, returnType: KClass<*>, vararg parameters: KClass<*>
     return isFunction(equalTo(name), matches(returnType), *parameters.toMatchers())
 }
 
-fun isConstructor(returnType: Matcher<in String>, vararg parameters: Matcher<in KParameter>): Matcher<in KFunction<*>> {
+fun isKonstructor(returnType: Matcher<in String>, vararg parameters: Matcher<in KParameter>): Matcher<in KFunction<*>> {
     return KFunctionMatcher(equalTo("<init>"), returnType, *parameters)
 }
 
-fun isConstructor(returnType: KClass<*>, vararg parameters: KClass<*>): Matcher<in KFunction<*>> {
-    return isConstructor(matches(returnType), *parameters.toMatchers())
+fun isKonstructor(returnType: KClass<*>, vararg parameters: KClass<*>): Matcher<in KFunction<*>> {
+    return isKonstructor(matches(returnType), *parameters.toMatchers())
 }
 
-fun isConstructor(returnType: String, vararg parameters: KClass<*>): Matcher<in KFunction<*>> {
-    return isConstructor(equalTo(returnType), *parameters.toMatchers())
+fun isKonstructor(returnType: String, vararg parameters: KClass<*>): Matcher<in KFunction<*>> {
+    return isKonstructor(equalTo(returnType), *parameters.toMatchers())
 }
 
 fun hasParam(type: Matcher<in String>): Matcher<KParameter> = KParameterMatcher(type)


### PR DESCRIPTION
- Stop filtering methods and fields once we decide to delete the class.
- Differentiate between matchers for Java and Kotlin constructors.
- Fix some whitespace issues.