### PR TITLE
NOTICK Fixed race condition on lock file creation

### DIFF
--- a/flask/flask-common/src/main/java/net/corda/flask/common/LockFile.java
+++ b/flask/flask-common/src/main/java/net/corda/flask/common/LockFile.java
@@ -17,7 +17,6 @@ public class LockFile implements Closeable {
 
     private static RandomAccessFile createLockFile(Path path) throws IOException {
         Files.createDirectories(path.getParent());
-        if (!Files.exists(path)) Files.createFile(path);
         return new RandomAccessFile(path.toFile(), "rw");
     }
 


### PR DESCRIPTION
According to [RandomAccessFile documentation](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/RandomAccessFile.html#%3Cinit%3E(java.io.File,java.lang.String)) there is no need to create the file before invoking the constructor since with 'rw' mode it will be created if it doesn't exist yet.
This also resolves a race condition where multiple Flask processes are started, the lock file file doesn't exist so one process try to create it but between the `File.exists` call and the `Files.createFile` call another process creates it causing `Files.createFile` to fail with `java.nio.file.FileAlreadyExistsException`

