### PR TITLE
NOTICK: Upgrade Gradle Enterprise plugin 3.4.1 -> 3.6.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -9,7 +9,7 @@ pluginManagement {
         id 'com.jfrog.artifactory' version artifactory_version
         id 'com.jfrog.bintray' version bintray_version
         id 'org.owasp.dependencycheck' version '5.3.2.1'
-        id 'com.gradle.enterprise' version '3.4.1'
+        id 'com.gradle.enterprise' version '3.6'
     }
 }
 


### PR DESCRIPTION
This plugin is used for generating Gradle build scans.