### PR TITLE
NOTICK: Delete methods and fields whose descriptors contain deleted types. (#393)

### DIFF
--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/Utils.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/Utils.kt
@@ -9,6 +9,7 @@ import org.objectweb.asm.ClassReader.SKIP_FRAMES
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Opcodes.ASM9
+import org.objectweb.asm.Type
 import java.nio.file.attribute.FileTime
 import java.util.Calendar.FEBRUARY
 import java.util.GregorianCalendar
@@ -42,6 +43,13 @@ fun <T : Element> MutableCollection<T>.expire(element: T) {
     if (remove(element)) {
         element.kill()
         add(element)
+    }
+}
+
+val Type.underlyingType: Type get() {
+    return when (sort) {
+        Type.ARRAY -> elementType
+        else -> this
     }
 }
 

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteAmbiguousPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteAmbiguousPropertyTest.kt
@@ -44,10 +44,10 @@ class DeleteAmbiguousPropertyTest {
         classLoaderFor(testProject.sourceJar).use { cl ->
             cl.load<Any>(PROPERTY_CLASS).apply {
                 assertNotNull(getDeclaredConstructor().newInstance())
-                assertThat("nameIntToInt(Map) missing", kotlin.javaDeclaredMethods, hasItem(nameIntToInt))
-                assertThat("nameIntToByte(Map) missing", kotlin.javaDeclaredMethods, hasItem(nameIntToByte))
-                assertThat("nameString(Collection) missing", kotlin.javaDeclaredMethods, hasItem(nameString))
-                assertThat("nameLong(Collection) missing", kotlin.javaDeclaredMethods, hasItem(nameLong))
+                assertThat("nameIntToInt(Map) missing", javaDeclaredMethods, hasItem(nameIntToInt))
+                assertThat("nameIntToByte(Map) missing", javaDeclaredMethods, hasItem(nameIntToByte))
+                assertThat("nameString(Collection) missing", javaDeclaredMethods, hasItem(nameString))
+                assertThat("nameLong(Collection) missing", javaDeclaredMethods, hasItem(nameLong))
 
                 assertThat("Map<Int,Int>.name missing", kotlin.declaredMemberExtensionProperties, hasItem(mapIntToIntName))
                 assertThat("Map<Int,Byte>.name missing", kotlin.declaredMemberExtensionProperties, hasItem(mapIntToByteName))
@@ -59,10 +59,10 @@ class DeleteAmbiguousPropertyTest {
         classLoaderFor(testProject.filteredJar).use { cl ->
             cl.load<Any>(PROPERTY_CLASS).apply {
                 assertNotNull(getDeclaredConstructor().newInstance())
-                assertThat("nameIntToInt(Map) still exists", kotlin.javaDeclaredMethods, not(hasItem(nameIntToInt)))
-                assertThat("nameIntToByte(Map) does not exist", kotlin.javaDeclaredMethods, hasItem(nameIntToByte))
-                assertThat("nameString(Collection) does not exist", kotlin.javaDeclaredMethods, hasItem(nameString))
-                assertThat("nameLong(Collection) still exists", kotlin.javaDeclaredMethods, not(hasItem(nameLong)))
+                assertThat("nameIntToInt(Map) still exists", javaDeclaredMethods, not(hasItem(nameIntToInt)))
+                assertThat("nameIntToByte(Map) does not exist", javaDeclaredMethods, hasItem(nameIntToByte))
+                assertThat("nameString(Collection) does not exist", javaDeclaredMethods, hasItem(nameString))
+                assertThat("nameLong(Collection) still exists", javaDeclaredMethods, not(hasItem(nameLong)))
 
                 assertThat("Map<Int,Int>.name still exists", kotlin.declaredMemberExtensionProperties, not(hasItem(mapIntToIntName)))
                 assertThat("Map<Int,Byte>.name does not exist", kotlin.declaredMemberExtensionProperties, hasItem(mapIntToByteName))

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteAndStubTests.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteAndStubTests.kt
@@ -63,7 +63,7 @@ class DeleteAndStubTests {
                     assertEquals(MESSAGE, obj.stringVal)
                 }
                 assertThat("stringVal not found", kotlin.declaredMemberProperties, hasItem(stringVal))
-                assertThat("getStringVal() not found", kotlin.javaDeclaredMethods, hasItem(getStringVal))
+                assertThat("getStringVal() not found", javaDeclaredMethods, hasItem(getStringVal))
             }
         }
 
@@ -71,7 +71,7 @@ class DeleteAndStubTests {
             cl.load<HasStringVal>(VAL_PROPERTY_CLASS).apply {
                 assertNotNull(getDeclaredConstructor(String::class.java).newInstance(MESSAGE))
                 assertThat("stringVal still exists", kotlin.declaredMemberProperties, not(hasItem(stringVal)))
-                assertThat("getStringVal() still exists", kotlin.javaDeclaredMethods, not(hasItem(getStringVal)))
+                assertThat("getStringVal() still exists", javaDeclaredMethods, not(hasItem(getStringVal)))
             }
         }
     }
@@ -84,8 +84,8 @@ class DeleteAndStubTests {
                     assertEquals(BIG_NUMBER, obj.longVar)
                 }
                 assertThat("longVar not found", kotlin.declaredMemberProperties, hasItem(longVar))
-                assertThat("getLongVar() not found", kotlin.javaDeclaredMethods, hasItem(getLongVar))
-                assertThat("setLongVar() not found", kotlin.javaDeclaredMethods, hasItem(setLongVar))
+                assertThat("getLongVar() not found", javaDeclaredMethods, hasItem(getLongVar))
+                assertThat("setLongVar() not found", javaDeclaredMethods, hasItem(setLongVar))
             }
         }
 
@@ -93,8 +93,8 @@ class DeleteAndStubTests {
             cl.load<HasLongVar>(VAR_PROPERTY_CLASS).apply {
                 assertNotNull(getDeclaredConstructor(Long::class.java).newInstance(BIG_NUMBER))
                 assertThat("longVar still exists", kotlin.declaredMemberProperties, not(hasItem(longVar)))
-                assertThat("getLongVar() still exists", kotlin.javaDeclaredMethods, not(hasItem(getLongVar)))
-                assertThat("setLongVar() still exists", kotlin.javaDeclaredMethods, not(hasItem(setLongVar)))
+                assertThat("getLongVar() still exists", javaDeclaredMethods, not(hasItem(getLongVar)))
+                assertThat("setLongVar() still exists", javaDeclaredMethods, not(hasItem(setLongVar)))
             }
         }
     }
@@ -139,8 +139,8 @@ class DeleteAndStubTests {
                     }
                 }
                 assertThat("unwantedVar not found", kotlin.declaredMemberProperties, hasItem(unwantedVar))
-                assertThat("getUnwantedVar() not found", kotlin.javaDeclaredMethods, hasItem(getUnwantedVar))
-                assertThat("setUnwantedVar() not found", kotlin.javaDeclaredMethods, hasItem(setUnwantedVar))
+                assertThat("getUnwantedVar() not found", javaDeclaredMethods, hasItem(getUnwantedVar))
+                assertThat("setUnwantedVar() not found", javaDeclaredMethods, hasItem(setUnwantedVar))
                 assertThat("stringData() not found", kotlin.declaredMemberFunctions, hasItem(stringData))
             }
         }
@@ -149,10 +149,10 @@ class DeleteAndStubTests {
             cl.load<HasString>(DELETED_VAR_CLASS).apply {
                 assertNotNull(getDeclaredConstructor(String::class.java).newInstance(MESSAGE))
                 assertThat("unwantedVar still exists", kotlin.declaredMemberProperties, not(hasItem(unwantedVar)))
-                assertThat("getUnwantedVar() still exists", kotlin.javaDeclaredMethods, not(hasItem(getUnwantedVar)))
-                assertThat("setUnwantedVar() still exists", kotlin.javaDeclaredMethods, not(hasItem(setUnwantedVar)))
+                assertThat("getUnwantedVar() still exists", javaDeclaredMethods, not(hasItem(getUnwantedVar)))
+                assertThat("setUnwantedVar() still exists", javaDeclaredMethods, not(hasItem(setUnwantedVar)))
                 assertThat("stringData() not found", kotlin.declaredMemberFunctions, hasItem(stringData))
-                assertThat("stringData() not found", kotlin.javaDeclaredMethods, hasItem(stringDataJava))
+                assertThat("stringData() not found", javaDeclaredMethods, hasItem(stringDataJava))
             }
         }
     }
@@ -166,7 +166,7 @@ class DeleteAndStubTests {
                     assertEquals(MESSAGE, (obj as HasUnwantedVal).unwantedVal)
                 }
                 assertThat("unwantedVal not found", kotlin.declaredMemberProperties, hasItem(unwantedVal))
-                assertThat("getUnwantedVal() not found", kotlin.javaDeclaredMethods, hasItem(getUnwantedVal))
+                assertThat("getUnwantedVal() not found", javaDeclaredMethods, hasItem(getUnwantedVal))
                 assertThat("stringData() not found", kotlin.declaredMemberFunctions, hasItem(stringData))
             }
         }
@@ -175,9 +175,9 @@ class DeleteAndStubTests {
             cl.load<HasString>(DELETED_VAL_CLASS).apply {
                 assertNotNull(getDeclaredConstructor(String::class.java).newInstance(MESSAGE))
                 assertThat("unwantedVal still exists", kotlin.declaredMemberProperties, not(hasItem(unwantedVal)))
-                assertThat("getUnwantedVal() still exists", kotlin.javaDeclaredMethods, not(hasItem(getUnwantedVal)))
+                assertThat("getUnwantedVal() still exists", javaDeclaredMethods, not(hasItem(getUnwantedVal)))
                 assertThat("stringData() not found", kotlin.declaredMemberFunctions, hasItem(stringData))
-                assertThat("stringData() not found", kotlin.javaDeclaredMethods, hasItem(stringDataJava))
+                assertThat("stringData() not found", javaDeclaredMethods, hasItem(stringDataJava))
             }
         }
     }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteClassReferencesTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteClassReferencesTest.kt
@@ -1,0 +1,78 @@
+package net.corda.gradle.jarfilter
+
+import net.corda.gradle.jarfilter.matcher.*
+import net.corda.gradle.unwanted.HasStringVal
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.core.IsEqual.equalTo
+import org.hamcrest.core.IsIterableContaining.hasItem
+import org.hamcrest.core.IsNot.not
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.reflect.full.declaredFunctions
+import kotlin.reflect.full.declaredMemberProperties
+import kotlin.test.assertFailsWith
+
+class DeleteClassReferencesTest {
+    companion object {
+        private const val USES_UNWANTED_CLASS = "net.corda.gradle.UsesUnwantedData"
+        private const val UNWANTED_CLASS = "net.corda.gradle.UnwantedData"
+
+        private val inputMethod = isMethod(equalTo("input"), isVoid, equalTo(UNWANTED_CLASS))
+        private val inputFunction = isFunction(equalTo("input"), isUnit, hasParam(equalTo(UNWANTED_CLASS)))
+        private val outputMethod = isMethod(equalTo("output"), equalTo(UNWANTED_CLASS))
+        private val outputFunction = isFunction(equalTo("output"), equalTo(UNWANTED_CLASS))
+        private val unwantedVar = isProperty(equalTo("unwantedVar"), equalTo(UNWANTED_CLASS))
+        private val unwantedVal = isProperty(equalTo("unwantedVal"), equalTo(UNWANTED_CLASS))
+        private val jvmUnwantedVar = isProperty(equalTo("jvmUnwantedVar"), equalTo(UNWANTED_CLASS))
+        private val jvmUnwantedVal = isProperty(equalTo("jvmUnwantedVal"), equalTo(UNWANTED_CLASS))
+        private val jvmCompanionVar = isField(equalTo("jvmCompanionVar"), equalTo(UNWANTED_CLASS))
+        private val jvmCompanionVal = isField(equalTo("jvmCompanionVal"), equalTo(UNWANTED_CLASS))
+
+        private lateinit var testProject: JarFilterProject
+
+        @BeforeAll
+        @JvmStatic
+        fun setup(@TempDir testProjectDir: Path) {
+            testProject = JarFilterProject(testProjectDir, "delete-class-references").build()
+        }
+    }
+
+    @Test
+    fun deleteClassReferences() {
+        classLoaderFor(testProject.sourceJar).use { cl ->
+            cl.load<HasStringVal>(UNWANTED_CLASS)
+            cl.load<Any>(USES_UNWANTED_CLASS).apply {
+                assertThat("input() not found", javaDeclaredMethods, hasItem(inputMethod))
+                assertThat("output() not found", javaDeclaredMethods, hasItem(outputMethod))
+                assertThat("input() not found", kotlin.declaredFunctions, hasItem(inputFunction))
+                assertThat("output() not found", kotlin.declaredFunctions, hasItem(outputFunction))
+                assertThat("unwantedVar not found", kotlin.declaredMemberProperties, hasItem(unwantedVar))
+                assertThat("unwantedVal not found", kotlin.declaredMemberProperties, hasItem(unwantedVal))
+                assertThat("jvmUnwantedVar not found", kotlin.declaredMemberProperties, hasItem(jvmUnwantedVar))
+                assertThat("jvmUnwantedVal not found", kotlin.declaredMemberProperties, hasItem(jvmUnwantedVal))
+                assertThat("jvmCompanionVar not found", javaDeclaredFields, hasItem(jvmCompanionVar))
+                assertThat("jvmUnwantedVal not found", javaDeclaredFields, hasItem(jvmCompanionVal))
+            }
+        }
+
+        classLoaderFor(testProject.filteredJar).use { cl ->
+            assertFailsWith<ClassNotFoundException> {
+                cl.load<HasStringVal>(UNWANTED_CLASS)
+            }
+            cl.load<Any>(USES_UNWANTED_CLASS).apply {
+                assertThat("input() still exists", javaDeclaredMethods, not(hasItem(inputMethod)))
+                assertThat("output() still exists", javaDeclaredMethods, not(hasItem(outputMethod)))
+                assertThat("input() still exists", kotlin.declaredFunctions, not(hasItem(inputFunction)))
+                assertThat("output() still exists", kotlin.declaredFunctions, not(hasItem(outputFunction)))
+                assertThat("unwantedVar still exists", kotlin.declaredMemberProperties, not(hasItem(unwantedVar)))
+                assertThat("unwantedVal still exists", kotlin.declaredMemberProperties, not(hasItem(unwantedVal)))
+                assertThat("jvmUnwantedVar still exists", kotlin.declaredMemberProperties, not(hasItem(jvmUnwantedVar)))
+                assertThat("jvmUnwantedVal still exists", kotlin.declaredMemberProperties, not(hasItem(jvmUnwantedVal)))
+                assertThat("jvmCompanionVar still exists", javaDeclaredFields, not(hasItem(jvmCompanionVar)))
+                assertThat("jvmCompanionVal still exists", javaDeclaredFields, not(hasItem(jvmCompanionVal)))
+            }
+        }
+    }
+}

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteExtensionValPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteExtensionValPropertyTest.kt
@@ -37,7 +37,7 @@ class DeleteExtensionValPropertyTest {
         classLoaderFor(testProject.sourceJar).use { cl ->
             cl.load<HasUnwantedVal>(PROPERTY_CLASS).apply {
                 assertThat("unwantedVal not found", kotlin.declaredMemberProperties, hasItem(unwantedVal))
-                assertThat("getUnwantedVal not found", kotlin.javaDeclaredMethods, hasItem(getUnwantedVal))
+                assertThat("getUnwantedVal not found", javaDeclaredMethods, hasItem(getUnwantedVal))
                 assertThat("List.unwantedVal not found", kotlin.declaredMemberExtensionProperties, hasItem(listUnwantedVal))
             }
         }
@@ -45,7 +45,7 @@ class DeleteExtensionValPropertyTest {
         classLoaderFor(testProject.filteredJar).use { cl ->
             cl.load<HasUnwantedVal>(PROPERTY_CLASS).apply {
                 assertThat("unwantedVal not found", kotlin.declaredMemberProperties, hasItem(unwantedVal))
-                assertThat("getUnwantedVal still exists", kotlin.javaDeclaredMethods, not(hasItem(getUnwantedVal)))
+                assertThat("getUnwantedVal still exists", javaDeclaredMethods, not(hasItem(getUnwantedVal)))
                 assertThat("List.unwantedVal still exists", kotlin.declaredMemberExtensionProperties, not(hasItem(listUnwantedVal)))
             }
         }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteLazyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteLazyTest.kt
@@ -50,7 +50,7 @@ class DeleteLazyTest {
                 getConstructor(String::class.java).newInstance(MESSAGE).also { obj ->
                     assertEquals(MESSAGE, obj.unwantedVal)
                 }
-                assertThat("getUnwantedVal not found", kotlin.javaDeclaredMethods, hasItem(getUnwantedVal))
+                assertThat("getUnwantedVal not found", javaDeclaredMethods, hasItem(getUnwantedVal))
                 assertThat("unwantedVal not found", kotlin.declaredMemberProperties, hasItem(unwantedVal))
             }
         }
@@ -58,7 +58,7 @@ class DeleteLazyTest {
         classLoaderFor(testProject.filteredJar).use { cl ->
             cl.load<HasUnwantedVal>(LAZY_VAL_CLASS).apply {
                 assertFailsWith<NoSuchMethodException> { getConstructor(String::class.java) }
-                assertThat("getUnwantedVal still exists", kotlin.javaDeclaredMethods, not(hasItem(getUnwantedVal)))
+                assertThat("getUnwantedVal still exists", javaDeclaredMethods, not(hasItem(getUnwantedVal)))
                 assertThat("unwantedVal still exists", kotlin.declaredMemberProperties, not(hasItem(unwantedVal)))
             }
         }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteValPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteValPropertyTest.kt
@@ -44,7 +44,7 @@ class DeleteValPropertyTest {
                 }
                 assertTrue(getDeclaredField("unwantedVal").hasModifiers(ACC_PRIVATE))
                 assertThat("unwantedVal not found", kotlin.declaredMemberProperties, hasItem(unwantedVal))
-                assertThat("getUnwantedVal not found", kotlin.javaDeclaredMethods, hasItem(getUnwantedVal))
+                assertThat("getUnwantedVal not found", javaDeclaredMethods, hasItem(getUnwantedVal))
             }
         }
 
@@ -55,7 +55,7 @@ class DeleteValPropertyTest {
                 }
                 assertFailsWith<NoSuchFieldException> { getDeclaredField("unwantedVal") }
                 assertThat("unwantedVal still exists", kotlin.declaredMemberProperties, not(hasItem(unwantedVal)))
-                assertThat("getUnwantedVal still exists", kotlin.javaDeclaredMethods, not(hasItem(getUnwantedVal)))
+                assertThat("getUnwantedVal still exists", javaDeclaredMethods, not(hasItem(getUnwantedVal)))
             }
         }
     }
@@ -68,7 +68,7 @@ class DeleteValPropertyTest {
                     assertEquals(MESSAGE, obj.unwantedVal)
                 }
                 assertTrue(getDeclaredField("unwantedVal").hasModifiers(ACC_PRIVATE))
-                assertThat("getUnwantedVal not found", kotlin.javaDeclaredMethods, hasItem(getUnwantedVal))
+                assertThat("getUnwantedVal not found", javaDeclaredMethods, hasItem(getUnwantedVal))
             }
         }
 
@@ -78,7 +78,7 @@ class DeleteValPropertyTest {
                     assertFailsWith<AbstractMethodError> { obj.unwantedVal }
                 }
                 assertTrue(getDeclaredField("unwantedVal").hasModifiers(ACC_PRIVATE))
-                assertThat("getUnwantedVal still exists", kotlin.javaDeclaredMethods, not(hasItem(getUnwantedVal)))
+                assertThat("getUnwantedVal still exists", javaDeclaredMethods, not(hasItem(getUnwantedVal)))
             }
         }
     }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteVarPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteVarPropertyTest.kt
@@ -48,8 +48,8 @@ class DeleteVarPropertyTest {
                 }
                 assertTrue(getDeclaredField("unwantedVar").hasModifiers(ACC_PRIVATE))
                 assertThat("unwantedVar not found", kotlin.declaredMemberProperties, hasItem(unwantedVar))
-                assertThat("getUnwantedVar not found", kotlin.javaDeclaredMethods, hasItem(getUnwantedVar))
-                assertThat("setUnwantedVar not found", kotlin.javaDeclaredMethods, hasItem(setUnwantedVar))
+                assertThat("getUnwantedVar not found", javaDeclaredMethods, hasItem(getUnwantedVar))
+                assertThat("setUnwantedVar not found", javaDeclaredMethods, hasItem(setUnwantedVar))
             }
         }
 
@@ -61,8 +61,8 @@ class DeleteVarPropertyTest {
                 }
                 assertFailsWith<NoSuchFieldException> { getDeclaredField("unwantedVar") }
                 assertThat("unwantedVar still exists", kotlin.declaredMemberProperties, not(hasItem(unwantedVar)))
-                assertThat("getUnwantedVar still exists", kotlin.javaDeclaredMethods, not(hasItem(getUnwantedVar)))
-                assertThat("setUnwantedVar still exists", kotlin.javaDeclaredMethods, not(hasItem(setUnwantedVar)))
+                assertThat("getUnwantedVar still exists", javaDeclaredMethods, not(hasItem(getUnwantedVar)))
+                assertThat("setUnwantedVar still exists", javaDeclaredMethods, not(hasItem(setUnwantedVar)))
             }
         }
     }
@@ -75,7 +75,7 @@ class DeleteVarPropertyTest {
                     assertEquals(MESSAGE, obj.unwantedVar)
                 }
                 assertTrue(getDeclaredField("unwantedVar").hasModifiers(ACC_PRIVATE))
-                assertThat("getUnwantedVar not found", kotlin.javaDeclaredMethods, hasItem(getUnwantedVar))
+                assertThat("getUnwantedVar not found", javaDeclaredMethods, hasItem(getUnwantedVar))
             }
         }
 
@@ -85,7 +85,7 @@ class DeleteVarPropertyTest {
                     assertFailsWith<AbstractMethodError> { obj.unwantedVar }
                 }
                 assertTrue(getDeclaredField("unwantedVar").hasModifiers(ACC_PRIVATE))
-                assertThat("getUnwantedVar still exists", kotlin.javaDeclaredMethods, not(hasItem(getUnwantedVar)))
+                assertThat("getUnwantedVar still exists", javaDeclaredMethods, not(hasItem(getUnwantedVar)))
             }
         }
     }
@@ -102,7 +102,7 @@ class DeleteVarPropertyTest {
                 getDeclaredField("unwantedVar").also { field ->
                     assertTrue(field.hasModifiers(ACC_PRIVATE))
                 }
-                assertThat("setUnwantedVar not found", kotlin.javaDeclaredMethods, hasItem(setUnwantedVar))
+                assertThat("setUnwantedVar not found", javaDeclaredMethods, hasItem(setUnwantedVar))
             }
         }
 
@@ -115,7 +115,7 @@ class DeleteVarPropertyTest {
                 getDeclaredField("unwantedVar").also { field ->
                     assertTrue(field.hasModifiers(ACC_PRIVATE))
                 }
-                assertThat("setUnwantedVar still exists", kotlin.javaDeclaredMethods, not(hasItem(setUnwantedVar)))
+                assertThat("setUnwantedVar still exists", javaDeclaredMethods, not(hasItem(setUnwantedVar)))
             }
         }
     }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/RemoveAnnotationsTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/RemoveAnnotationsTest.kt
@@ -5,6 +5,7 @@ import net.corda.gradle.unwanted.HasUnwantedVal
 import net.corda.gradle.unwanted.HasUnwantedVar
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -22,19 +23,25 @@ class RemoveAnnotationsTest {
         fun setup(@TempDir testProjectDir: Path) {
             testProject = JarFilterProject(testProjectDir, "remove-annotations").build()
         }
+
+        fun ClassLoader.loadAnnotation(className: String): Class<out Annotation> {
+            return load<Annotation>(className).apply {
+                assertTrue(isAnnotation)
+            }
+        }
     }
 
     @Test
     fun deleteFromClass() {
         classLoaderFor(testProject.sourceJar).use { cl ->
-            val removeMe = cl.load<Annotation>(REMOVE_ME_CLASS)
+            val removeMe = cl.loadAnnotation(REMOVE_ME_CLASS)
             cl.load<Any>(ANNOTATED_CLASS).apply {
                 assertNotNull(getAnnotation(removeMe))
             }
         }
 
         classLoaderFor(testProject.filteredJar).use { cl ->
-            val removeMe = cl.load<Annotation>(REMOVE_ME_CLASS)
+            val removeMe = cl.loadAnnotation(REMOVE_ME_CLASS)
             cl.load<Any>(ANNOTATED_CLASS).apply {
                 assertNull(getAnnotation(removeMe))
             }
@@ -44,7 +51,7 @@ class RemoveAnnotationsTest {
     @Test
     fun deleteFromDefaultConstructor() {
         classLoaderFor(testProject.sourceJar).use { cl ->
-            val removeMe = cl.load<Annotation>(REMOVE_ME_CLASS)
+            val removeMe = cl.loadAnnotation(REMOVE_ME_CLASS)
             cl.load<Any>(ANNOTATED_CLASS).apply {
                 getDeclaredConstructor().also { con ->
                     assertNotNull(con.getAnnotation(removeMe))
@@ -53,7 +60,7 @@ class RemoveAnnotationsTest {
         }
 
         classLoaderFor(testProject.filteredJar).use { cl ->
-            val removeMe = cl.load<Annotation>(REMOVE_ME_CLASS)
+            val removeMe = cl.loadAnnotation(REMOVE_ME_CLASS)
             cl.load<Any>(ANNOTATED_CLASS).apply {
                 getDeclaredConstructor().also { con ->
                     assertNull(con.getAnnotation(removeMe))
@@ -65,7 +72,7 @@ class RemoveAnnotationsTest {
     @Test
     fun deleteFromPrimaryConstructor() {
         classLoaderFor(testProject.sourceJar).use { cl ->
-            val removeMe = cl.load<Annotation>(REMOVE_ME_CLASS)
+            val removeMe = cl.loadAnnotation(REMOVE_ME_CLASS)
             cl.load<Any>(ANNOTATED_CLASS).apply {
                 getDeclaredConstructor(Long::class.java, String::class.java).also { con ->
                     assertNotNull(con.getAnnotation(removeMe))
@@ -74,7 +81,7 @@ class RemoveAnnotationsTest {
         }
 
         classLoaderFor(testProject.filteredJar).use { cl ->
-            val removeMe = cl.load<Annotation>(REMOVE_ME_CLASS)
+            val removeMe = cl.loadAnnotation(REMOVE_ME_CLASS)
             cl.load<Any>(ANNOTATED_CLASS).apply {
                 getDeclaredConstructor(Long::class.java, String::class.java).also { con ->
                     assertNull(con.getAnnotation(removeMe))
@@ -86,7 +93,7 @@ class RemoveAnnotationsTest {
     @Test
     fun deleteFromField() {
         classLoaderFor(testProject.sourceJar).use { cl ->
-            val removeMe = cl.load<Annotation>(REMOVE_ME_CLASS)
+            val removeMe = cl.loadAnnotation(REMOVE_ME_CLASS)
             cl.load<Any>(ANNOTATED_CLASS).apply {
                 getField("longField").also { field ->
                     assertNotNull(field.getAnnotation(removeMe))
@@ -95,7 +102,7 @@ class RemoveAnnotationsTest {
         }
 
         classLoaderFor(testProject.filteredJar).use { cl ->
-            val removeMe = cl.load<Annotation>(REMOVE_ME_CLASS)
+            val removeMe = cl.loadAnnotation(REMOVE_ME_CLASS)
             cl.load<Any>(ANNOTATED_CLASS).apply {
                 getField("longField").also { field ->
                     assertNull(field.getAnnotation(removeMe))
@@ -107,7 +114,7 @@ class RemoveAnnotationsTest {
     @Test
     fun deleteFromMethod() {
         classLoaderFor(testProject.sourceJar).use { cl ->
-            val removeMe = cl.load<Annotation>(REMOVE_ME_CLASS)
+            val removeMe = cl.loadAnnotation(REMOVE_ME_CLASS)
             cl.load<HasUnwantedFun>(ANNOTATED_CLASS).apply {
                 getMethod("unwantedFun", String::class.java).also { method ->
                     assertNotNull(method.getAnnotation(removeMe))
@@ -116,7 +123,7 @@ class RemoveAnnotationsTest {
         }
 
         classLoaderFor(testProject.filteredJar).use { cl ->
-            val removeMe = cl.load<Annotation>(REMOVE_ME_CLASS)
+            val removeMe = cl.loadAnnotation(REMOVE_ME_CLASS)
             cl.load<HasUnwantedFun>(ANNOTATED_CLASS).apply {
                 getMethod("unwantedFun", String::class.java).also { method ->
                     assertNull(method.getAnnotation(removeMe))
@@ -128,7 +135,7 @@ class RemoveAnnotationsTest {
     @Test
     fun deleteFromValProperty() {
         classLoaderFor(testProject.sourceJar).use { cl ->
-            val removeMe = cl.load<Annotation>(REMOVE_ME_CLASS)
+            val removeMe = cl.loadAnnotation(REMOVE_ME_CLASS)
             cl.load<HasUnwantedVal>(ANNOTATED_CLASS).apply {
                 getMethod("getUnwantedVal").also { method ->
                     assertNotNull(method.getAnnotation(removeMe))
@@ -137,7 +144,7 @@ class RemoveAnnotationsTest {
         }
 
         classLoaderFor(testProject.filteredJar).use { cl ->
-            val removeMe = cl.load<Annotation>(REMOVE_ME_CLASS)
+            val removeMe = cl.loadAnnotation(REMOVE_ME_CLASS)
             cl.load<HasUnwantedVal>(ANNOTATED_CLASS).apply {
                 getMethod("getUnwantedVal").also { method ->
                     assertNull(method.getAnnotation(removeMe))
@@ -149,7 +156,7 @@ class RemoveAnnotationsTest {
     @Test
     fun deleteFromVarProperty() {
         classLoaderFor(testProject.sourceJar).use { cl ->
-            val removeMe = cl.load<Annotation>(REMOVE_ME_CLASS)
+            val removeMe = cl.loadAnnotation(REMOVE_ME_CLASS)
             cl.load<HasUnwantedVar>(ANNOTATED_CLASS).apply {
                 getMethod("getUnwantedVar").also { method ->
                     assertNotNull(method.getAnnotation(removeMe))
@@ -161,7 +168,7 @@ class RemoveAnnotationsTest {
         }
 
         classLoaderFor(testProject.filteredJar).use { cl ->
-            val removeMe = cl.load<Annotation>(REMOVE_ME_CLASS)
+            val removeMe = cl.loadAnnotation(REMOVE_ME_CLASS)
             cl.load<HasUnwantedVar>(ANNOTATED_CLASS).apply {
                 getMethod("getUnwantedVar").also { method ->
                     assertNull(method.getAnnotation(removeMe))

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/matcher/KotlinMatchers.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/matcher/KotlinMatchers.kt
@@ -17,6 +17,8 @@ import kotlin.reflect.full.createType
 import kotlin.reflect.full.valueParameters
 import kotlin.reflect.jvm.jvmName
 
+val isUnit: Matcher<String> get() = equalTo(Unit::class.java.name)
+
 fun isFunction(name: Matcher<in String>, returnType: Matcher<in String>, vararg parameters: Matcher<in KParameter>): Matcher<in KFunction<*>> {
     return KFunctionMatcher(name, returnType, *parameters)
 }

--- a/jar-filter/src/test/resources/delete-class-references/build.gradle
+++ b/jar-filter/src/test/resources/delete-class-references/build.gradle
@@ -1,0 +1,35 @@
+import net.corda.gradle.jarfilter.JarFilterTask
+
+plugins {
+    id 'org.jetbrains.kotlin.jvm'
+    id 'net.corda.plugins.jar-filter' apply false
+}
+apply from: 'repositories.gradle'
+apply from: 'kotlin.gradle'
+
+sourceSets {
+    main {
+        kotlin {
+            srcDir files(
+                '../resources/test/delete-class-references/kotlin',
+                '../resources/test/annotations/kotlin'
+            )
+        }
+    }
+}
+
+dependencies {
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    compileOnly files('../../unwanteds/build/libs/unwanteds.jar')
+}
+
+jar {
+    archiveBaseName = 'delete-class-references'
+}
+
+task jarFilter(type: JarFilterTask) {
+    jars jar
+    annotations {
+        forDelete = ["net.corda.gradle.jarfilter.DeleteMe"]
+    }
+}

--- a/jar-filter/src/test/resources/delete-class-references/kotlin/net/corda/gradle/UsesUnwantedData.kt
+++ b/jar-filter/src/test/resources/delete-class-references/kotlin/net/corda/gradle/UsesUnwantedData.kt
@@ -1,0 +1,41 @@
+@file:Suppress("unused", "PackageDirectoryMismatch")
+package net.corda.gradle
+
+import net.corda.gradle.jarfilter.DeleteMe
+import net.corda.gradle.unwanted.HasStringVal
+
+class UsesUnwantedData {
+    companion object {
+        @JvmField
+        val jvmCompanionVal = UnwantedData("jvmCompanionVal")
+
+        @JvmField
+        var jvmCompanionVar = UnwantedData("jvmCompanionVar")
+    }
+
+    private lateinit var unwantedField: UnwantedData
+
+    @JvmField
+    var jvmUnwantedVar = UnwantedData("jvmVar")
+
+    @JvmField
+    val jvmUnwantedVal = UnwantedData("jvmVal")
+
+    var unwantedVar: UnwantedData
+        get() = throw UnsupportedOperationException("VAR-GETTER")
+        set(value) = throw UnsupportedOperationException("VAR-SETTER $value")
+
+    val unwantedVal: UnwantedData
+        get() = throw UnsupportedOperationException("VAR-GETTER")
+
+    fun input(input: UnwantedData) {
+        throw UnsupportedOperationException("INPUT: $input")
+    }
+
+    fun output(): UnwantedData {
+        throw UnsupportedOperationException("OUTPUT")
+    }
+}
+
+@DeleteMe
+data class UnwantedData(override val stringVal: String) : HasStringVal


### PR DESCRIPTION
Methods with a deleted return type or parameter type must be deleted too. Similarly fields whose type has been deleted.
We also need to remove Kotlin metadata for properties without a backing field whose accessor functions have all been deleted.