### PR TITLE
Fixed race condition on jar extraction

### DIFF
--- a/flask/flask-heartbeat-agent/build.gradle
+++ b/flask/flask-heartbeat-agent/build.gradle
@@ -20,7 +20,7 @@ jar {
     }
     archiveFileName = "${project.name}.jar"
     from {
-        configurations.named('compileClasspath').map {
+        configurations.named('runtimeClasspath').map {
             it.collect { it.isDirectory() ? it : zipTree(it) }
         }
     }


### PR DESCRIPTION
Every flask process extract its own jar dependencies in a shared cache; in the cache folder the path to each jar is `lib/${SHA256_OF_THE_JAR}/${JAR_FILE_BASENAME}.jar`; before starting the extraction the process checks that the path doesn't already exist to avoid harming other processes that may be already running and using that jar (rewriting the file with one with identical content could break java processes reading from that file). The problem is that the jar may already exist in the cache because another process created it, but that process might still be writing the jar to the disk.

The result is that a Java process starts with the assumption that all of its dependencies are already in place while they might actually be incomplete (because extracting a big jar to the disk takes some time).

To address this, I added an extraction lock that must be exclusively held by every process during the extraction (and while evaluating which jars need to be extracted), so that only a single process can add files to the cache at any given time.

