### PR TITLE
CORE-1134: Replace cordformation DSL Closure elements with Action.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ### Version 5.0.14
 
+* `cordformation`: Replace `Closure` with `Action` in the DSL.
+
 ### Version 5.0.13
 
 * `cordformation`: Parsing for adding external service to docker-compose

--- a/cordformation/src/main/kotlin/net/corda/plugins/CordaMock.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/CordaMock.kt
@@ -1,0 +1,46 @@
+@file:JvmName("Mocking")
+package net.corda.plugins
+
+import java.lang.reflect.Proxy
+
+internal interface CordaMock
+
+internal inline fun <reified T> cordaMock(): T = cordaMock(T::class.java)
+
+internal fun <T> cordaMock(clazz: Class<T>): T {
+    return clazz.cast(Proxy.newProxyInstance(
+        CordaMock::class.java.classLoader,
+        arrayOf(clazz, CordaMock::class.java)
+    ) { obj, method, args ->
+        when {
+            args == null || args.isEmpty() ->
+                when (method.name) {
+                    "hashCode" -> System.identityHashCode(obj)
+                    "toString" -> "CordaMock\$${System.identityHashCode(obj)}"
+                    else -> method.returnType.nullValue
+                }
+            args.size == 1 && method.name == "equals" ->
+                obj === args[0]
+            else ->
+                method.returnType.nullValue
+        }
+    })
+}
+
+private val Class<*>.nullValue: Any? get() {
+    return if (isPrimitive) {
+        when (this) {
+            Int::class.javaPrimitiveType -> 0
+            Long::class.javaPrimitiveType -> 0L
+            Short::class.javaPrimitiveType -> 0.toShort()
+            Byte::class.javaPrimitiveType -> 0.toByte()
+            Boolean::class.javaPrimitiveType -> false
+            Char::class.javaPrimitiveType -> 0.toChar()
+            Double::class.javaPrimitiveType -> 0.0
+            Float::class.javaPrimitiveType -> 0.0.toFloat()
+            else -> null
+        }
+    } else {
+        null
+    }
+}

--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordapp.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordapp.kt
@@ -2,16 +2,19 @@ package net.corda.plugins
 
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import java.io.File
 import javax.inject.Inject
 
+@Suppress("unused")
 open class Cordapp @Inject constructor(
-        @get:[Optional Input] val coordinates: String?,
-        @get:[Optional Input] val project: Project?
+    @get:Input val coordinates: String,
+    @get:Internal val project: Project
 ) {
-    constructor(coordinates: String) : this(coordinates, null)
-    constructor(cordappProject: Project) : this(null, cordappProject)
+    @get:Optional
+    @get:Input
+    internal val projectPath: String? = project.path
 
     // The configuration text that will be written
     @get:Optional

--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordform.kt
@@ -10,7 +10,7 @@ import javax.inject.Inject
  *
  * See documentation for examples.
  */
-@Suppress("unused")
+@Suppress("unused", "UnstableApiUsage")
 open class Cordform @Inject constructor(objects: ObjectFactory) : Baseform(objects) {
     init {
         description = "Creates and configures a deployment of Corda Node directories."
@@ -30,7 +30,7 @@ open class Cordform @Inject constructor(objects: ObjectFactory) : Baseform(objec
     private fun installRunScript() {
         project.copy {
             it.apply {
-                from(Cordformation.getPluginFile(project, "runnodes.jar"))
+                from(Cordformation.getPluginFile(this@Cordform, "runnodes.jar"))
                 fileMode = Cordformation.executableFileMode
                 into("$directory/")
             }
@@ -38,7 +38,7 @@ open class Cordform @Inject constructor(objects: ObjectFactory) : Baseform(objec
 
         project.copy {
             it.apply {
-                from(Cordformation.getPluginFile(project, "runnodes"))
+                from(Cordformation.getPluginFile(this@Cordform, "runnodes"))
                 // Replaces end of line with lf to avoid issues with the bash interpreter and Windows style line endings.
                 filter(mapOf("eol" to FixCrLfFilter.CrLf.newInstance("lf")), FixCrLfFilter::class.java)
                 fileMode = Cordformation.executableFileMode
@@ -48,7 +48,7 @@ open class Cordform @Inject constructor(objects: ObjectFactory) : Baseform(objec
 
         project.copy {
             it.apply {
-                from(Cordformation.getPluginFile(project, "runnodes.bat"))
+                from(Cordformation.getPluginFile(this@Cordform, "runnodes.bat"))
                 into("$directory/")
             }
         }
@@ -59,7 +59,7 @@ open class Cordform @Inject constructor(objects: ObjectFactory) : Baseform(objec
      */
     @TaskAction
     fun build() {
-        project.logger.lifecycle("Running Cordform task")
+        logger.lifecycle("Running Cordform task")
         initializeConfiguration()
         nodes.forEach {
             if (it.p2pAddress == null) {

--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
@@ -3,8 +3,10 @@ package net.corda.plugins
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME
 import org.gradle.util.GradleVersion
 import java.io.File
 
@@ -23,10 +25,8 @@ class Cordformation : Plugin<Project> {
          * @param filePathInJar The file in the JAR, relative to root, you wish to access.
          * @return A file handle to the file in the JAR.
          */
-        fun getPluginFile(project: Project, filePathInJar: String): File {
-            val tmpDir = File(project.buildDir, "tmp")
-            val outputFile = File(tmpDir, filePathInJar)
-            tmpDir.mkdir()
+        fun getPluginFile(task: Task, filePathInJar: String): File {
+            val outputFile = File(task.temporaryDir, filePathInJar)
             outputFile.outputStream().use { output ->
                 Cordformation::class.java.getResourceAsStream(filePathInJar)?.use { input ->
                     input.copyTo(output)
@@ -47,7 +47,7 @@ class Cordformation : Plugin<Project> {
                     ?: throw IllegalStateException("Could not find a valid declaration of \"corda_release_version\"")
             // need to cater for optional classifier (eg. corda-4.3-jdk11.jar)
             val pattern = "\\Q$jarName\\E(-enterprise)?-\\Q$releaseVersion\\E(-.+)?\\.jar\$".toRegex()
-            val maybeJar = project.configuration("runtime").filter {
+            val maybeJar = project.configuration(RUNTIME_CLASSPATH_CONFIGURATION_NAME).filter {
                 it.toString().contains(pattern)
             }
             if (maybeJar.isEmpty) {

--- a/cordformation/src/main/kotlin/net/corda/plugins/Dockerform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Dockerform.kt
@@ -6,7 +6,12 @@ import org.gradle.api.Action
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.PathSensitivity.RELATIVE
 import org.yaml.snakeyaml.DumperOptions
 import org.yaml.snakeyaml.Yaml
@@ -24,7 +29,7 @@ import javax.inject.Inject
  *
  * See documentation for examples.
  */
-@Suppress("unused")
+@Suppress("unused", "UnstableApiUsage")
 open class Dockerform @Inject constructor(objects: ObjectFactory) : Baseform(objects) {
 
     private companion object {
@@ -85,7 +90,7 @@ open class Dockerform @Inject constructor(objects: ObjectFactory) : Baseform(obj
      */
     @TaskAction
     fun build() {
-        project.logger.lifecycle("Running DockerForm task")
+        logger.lifecycle("Running DockerForm task")
         initializeConfiguration()
         nodes.forEach { it.installDockerConfig(DEFAULT_SSH_PORT) }
         installCordaJar()
@@ -212,7 +217,7 @@ open class Dockerform @Inject constructor(objects: ObjectFactory) : Baseform(obj
             services[it.containerName] = service
         }
 
-        if (external.containerImage.isPresent()) {
+        if (external.containerImage.isPresent) {
 
             val extra = mutableMapOf(
                     "container_name" to external.containerName.get(),
@@ -228,10 +233,10 @@ open class Dockerform @Inject constructor(objects: ObjectFactory) : Baseform(obj
             if(external.privileged.get() == true) {
                 extra["privileged"] = external.privileged.get()
             }
-            if(external.commands.isPresent()){
+            if(external.commands.isPresent){
                 extra["command"] = external.commands.get()
             }
-            services["${external.containerName.get()}"] = extra
+            services[external.containerName.get()] = extra
         }
 
         val dockerComposeObject = mutableMapOf(

--- a/cordformation/src/main/kotlin/net/corda/plugins/RpcSettings.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/RpcSettings.kt
@@ -3,10 +3,7 @@ package net.corda.plugins
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigValueFactory
-import org.gradle.api.InvalidUserDataException
 import org.gradle.api.tasks.Input
-import java.net.URI
-import java.net.URISyntaxException
 
 class RpcSettings {
     private var config = ConfigFactory.empty()

--- a/cordformation/src/test/kotlin/net/corda/plugins/Assertions.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/Assertions.kt
@@ -1,0 +1,16 @@
+@file:JvmName("Assertions")
+package net.corda.plugins
+
+import com.typesafe.config.Config
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+
+fun assertThatConfig(config: Config) = ConfigAssertions(config)
+
+class ConfigAssertions(private val config: Config) {
+    fun hasPath(path: String, expectedValue: String): ConfigAssertions {
+        assertTrue(config.hasPath(path), "Config does not contain '$path'")
+        assertEquals(expectedValue, config.getString(path))
+        return this
+    }
+}

--- a/cordformation/src/test/kotlin/net/corda/plugins/CordaMockTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/CordaMockTest.kt
@@ -1,0 +1,39 @@
+package net.corda.plugins
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.Project
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class CordaMockTest {
+    @Test
+    fun testEquality() {
+        val mock = cordaMock<Project>()
+        assertEquals(mock, mock)
+        assertNotEquals(mock, cordaMock<Project>())
+    }
+
+    @Test
+    fun testToString() {
+        assertThat(cordaMock<Project>().toString())
+            .isInstanceOf(String::class.java)
+    }
+
+    @Test
+    fun testHashCode() {
+        val mock = cordaMock<Project>()
+        val hash = mock.hashCode()
+        assertEquals(hash, mock.hashCode())
+    }
+
+    @Test
+    fun testMockedFunctions() {
+        val mockProject = cordaMock<Project>()
+        assertNull(mockProject.name)
+        assertNull(mockProject.path)
+        assertEquals(0, mockProject.depth)
+        mockProject.evaluationDependsOnChildren()
+    }
+}

--- a/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
@@ -66,7 +66,7 @@ class CordformTest : BaseformTest() {
 
     @Test
     fun `a node that requires an extra command to create schema`() {
-        val cordaReleaseVersion = "4.6-20200608_123659-1da174c"
+        val cordaReleaseVersion = "4.6"
 
         val runner = getStandardGradleRunnerFor(
             "DeploySingleNodeWithExtraCommandForDbSchema.gradle",

--- a/cordformation/src/test/kotlin/net/corda/plugins/DockerformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/DockerformTest.kt
@@ -1,13 +1,10 @@
 package net.corda.plugins
 
-import com.typesafe.config.ConfigFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Test
 import org.yaml.snakeyaml.Yaml
 import java.nio.file.Path
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class DockerformTest : BaseformTest() {
 
@@ -45,7 +42,6 @@ class DockerformTest : BaseformTest() {
                 "DeployThreeNodeCordappWithExternalDBSettingsWithDocker.gradle",
                 "prepareDockerNodes")
 
-        val bankOfCordaNodeName = "BankOfCorda"
         val bigCorporationNodeName = "BigCorporation"
 
         val result = runner.build()
@@ -54,9 +50,9 @@ class DockerformTest : BaseformTest() {
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile()
         assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile()
-        assertThat(getNodeCordappJar(bankOfCordaNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
-        assertThat(getNodeCordappJar(bankOfCordaNodeName, cordaFinanceContractsJarName)).isRegularFile()
-        assertThat(getNetworkParameterOverrides(bankOfCordaNodeName)).isRegularFile()
+        assertThat(getNodeCordappJar(bankNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
+        assertThat(getNodeCordappJar(bankNodeName, cordaFinanceContractsJarName)).isRegularFile()
+        assertThat(getNetworkParameterOverrides(bankNodeName)).isRegularFile()
         assertThat(getNodeCordappJar(bigCorporationNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
         assertThat(getNodeCordappJar(bigCorporationNodeName, cordaFinanceContractsJarName)).isRegularFile()
         assertThat(getNetworkParameterOverrides(bigCorporationNodeName)).isRegularFile()
@@ -68,7 +64,6 @@ class DockerformTest : BaseformTest() {
                 "DeployThreeNodeCordappWithExternalDBSettingsWithNetworkConfigWithDocker.gradle",
                 "prepareDockerNodes")
 
-        val bankOfCordaNodeName = "BankOfCorda"
         val bigCorporationNodeName = "BigCorporation"
 
         val result = runner.build()
@@ -77,9 +72,9 @@ class DockerformTest : BaseformTest() {
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile()
         assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile()
-        assertThat(getNodeCordappJar(bankOfCordaNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
-        assertThat(getNodeCordappJar(bankOfCordaNodeName, cordaFinanceContractsJarName)).isRegularFile()
-        assertThat(getNetworkParameterOverrides(bankOfCordaNodeName)).isRegularFile()
+        assertThat(getNodeCordappJar(bankNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
+        assertThat(getNodeCordappJar(bankNodeName, cordaFinanceContractsJarName)).isRegularFile()
+        assertThat(getNetworkParameterOverrides(bankNodeName)).isRegularFile()
         assertThat(getNodeCordappJar(bigCorporationNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
         assertThat(getNodeCordappJar(bigCorporationNodeName, cordaFinanceContractsJarName)).isRegularFile()
         assertThat(getNetworkParameterOverrides(bigCorporationNodeName)).isRegularFile()
@@ -108,33 +103,21 @@ class DockerformTest : BaseformTest() {
 
         val result = runner.build()
 
-        val bankOfCordaNodeName = "BankOfCorda"
-
         assertThat(result.task(":prepareDockerNodes")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile()
         assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile()
-        assertThat(getNodeCordappJar(bankOfCordaNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
-        assertThat(getNodeCordappJar(bankOfCordaNodeName, cordaFinanceContractsJarName)).isRegularFile()
-        assertThat(getNetworkParameterOverrides(bankOfCordaNodeName)).isRegularFile()
+        assertThat(getNodeCordappJar(bankNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
+        assertThat(getNodeCordappJar(bankNodeName, cordaFinanceContractsJarName)).isRegularFile()
+        assertThat(getNetworkParameterOverrides(bankNodeName)).isRegularFile()
 
-        val notaryConfigPath = getNodeConfig(notaryNodeName)
-        assertThat(notaryConfigPath).isRegularFile()
+        assertThatConfig(getNodeConfig(notaryNodeName))
+            .hasPath("rpcSettings.address", "notary-service:10003")
+            .hasPath("rpcSettings.adminAddress", "notary-service:10043")
 
-        val notaryConfig = ConfigFactory.parseFile(notaryConfigPath.toFile())
-        assertTrue(notaryConfig.hasPath("rpcSettings.address"))
-        assertTrue(notaryConfig.hasPath("rpcSettings.adminAddress"))
-        assertEquals(10003, ConfigurationUtils.parsePort(notaryConfig.getString("rpcSettings.address")))
-        assertEquals(10043, ConfigurationUtils.parsePort(notaryConfig.getString("rpcSettings.adminAddress")))
-
-        val bankOfCordaConfigPath = getNodeConfig(bankOfCordaNodeName)
-        assertThat(bankOfCordaConfigPath).isRegularFile()
-
-        val bankOfCordaConfig = ConfigFactory.parseFile(bankOfCordaConfigPath.toFile())
-        assertTrue(bankOfCordaConfig.hasPath("rpcSettings.address"))
-        assertTrue(bankOfCordaConfig.hasPath("rpcSettings.adminAddress"))
-        assertEquals(10006, ConfigurationUtils.parsePort(bankOfCordaConfig.getString("rpcSettings.address")))
-        assertEquals(10046, ConfigurationUtils.parsePort(bankOfCordaConfig.getString("rpcSettings.adminAddress")))
+        assertThatConfig(getNodeConfig(bankNodeName))
+            .hasPath("rpcSettings.address", "bankofcorda:10006")
+            .hasPath("rpcSettings.adminAddress", "bankofcorda:10046")
 
         val dockerComposePath = getDockerCompose()
 

--- a/cordformation/src/test/kotlin/net/corda/plugins/KotlinCordformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/KotlinCordformTest.kt
@@ -1,0 +1,75 @@
+package net.corda.plugins
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import org.junit.jupiter.api.Test
+
+class KotlinCordformTest : BaseformTest() {
+    @Test
+    fun `two nodes with cordapp dependency - backwards compatibility`() {
+        val runner = getStandardGradleRunnerFor("CompatibilityKotlinDSL.gradle.kts")
+
+        val result = runner.build()
+
+        // Check task succeeded
+        assertThat(result.task(":deployNodes")!!.outcome)
+            .isEqualTo(SUCCESS)
+
+        // Check Notary node deployment
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName))
+            .isRegularFile()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName))
+            .isRegularFile()
+        assertThat(getNodeCordappConfig(notaryNodeName, cordaFinanceWorkflowsJarName))
+            .isRegularFile()
+        assertThat(getNodeCordappJar(notaryNodeName, localCordappJarName))
+            .doesNotExist()
+        assertThat(getNodeCordappConfig(notaryNodeName, localCordappJarName))
+            .doesNotExist()
+        assertThatConfig(getNodeConfig(notaryNodeName))
+            .hasPath("rpcSettings.address", "localhost:60001")
+            .hasPath("rpcSettings.adminAddress", "localhost:60002")
+
+        // Check Bank node deployment
+        assertThat(getNodeCordappJar(bankNodeName, cordaFinanceContractsJarName))
+            .isRegularFile()
+        assertThat(getNodeCordappJar(bankNodeName, cordaFinanceWorkflowsJarName))
+            .isRegularFile()
+        assertThat(getNodeCordappConfig(bankNodeName, cordaFinanceWorkflowsJarName))
+            .isRegularFile()
+        assertThat(getNodeCordappJar(bankNodeName, localCordappJarName))
+            .isRegularFile()
+        assertThat(getNodeCordappConfig(bankNodeName, localCordappJarName))
+            .isRegularFile()
+        assertThatConfig(getNodeConfig(bankNodeName))
+            .hasPath("rpcSettings.address", "localhost:10001")
+            .hasPath("rpcSettings.adminAddress", "localhost:10002")
+    }
+
+    @Test
+    fun `two nodes with cordapp dependency`() {
+        val runner = getStandardGradleRunnerFor("DeployTwoNodeCordapp.gradle.kts")
+
+        val result = runner.build()
+
+        // Check task succeeded
+        assertThat(result.task(":deployNodes")!!.outcome)
+            .isEqualTo(SUCCESS)
+
+        // Check Notary node deployment
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName))
+            .isRegularFile()
+        assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName))
+            .isRegularFile()
+        assertThat(getNodeCordappConfig(notaryNodeName, cordaFinanceWorkflowsJarName))
+            .isRegularFile()
+
+        // Check Bank node deployment
+        assertThat(getNodeCordappJar(bankNodeName, cordaFinanceContractsJarName))
+            .isRegularFile()
+        assertThat(getNodeCordappJar(bankNodeName, cordaFinanceWorkflowsJarName))
+            .isRegularFile()
+        assertThat(getNodeCordappConfig(bankNodeName, cordaFinanceWorkflowsJarName))
+            .isRegularFile()
+    }
+}

--- a/cordformation/src/test/resources/net/corda/plugins/CompatibilityKotlinDSL.gradle.kts
+++ b/cordformation/src/test/resources/net/corda/plugins/CompatibilityKotlinDSL.gradle.kts
@@ -1,0 +1,77 @@
+import net.corda.plugins.Cordapp
+import net.corda.plugins.Cordform
+import net.corda.plugins.Node
+import net.corda.plugins.RpcSettings
+
+plugins {
+    id("net.corda.plugins.cordformation")
+}
+
+apply(from = "repositories.gradle")
+
+val corda_group: String by project
+val corda_release_version: String by project
+val slf4j_version: String by project
+
+dependencies {
+    cordapp("$corda_group:corda-finance-contracts:$corda_release_version")
+    cordapp("$corda_group:corda-finance-workflows:$corda_release_version")
+    cordaRuntime("$corda_group:corda:$corda_release_version")
+    cordaRuntime("$corda_group:corda-node-api:$corda_release_version")
+    cordaRuntime("org.slf4j:slf4j-simple:$slf4j_version")
+}
+
+tasks.named<Jar>("jar") {
+    archiveBaseName.set("locally-built-cordapp")
+}
+
+tasks.register<Cordform>("deployNodes") {
+    dependsOn.add("jar")
+
+    nodeDefaults {
+        projectCordapp(closureOf<Cordapp> {
+            deploy = false
+        })
+
+        cordapp("$corda_group:corda-finance-contracts:$corda_release_version")
+        cordapp("$corda_group:corda-finance-workflows:$corda_release_version", closureOf<Cordapp> {
+            config("a=b")
+        })
+        runSchemaMigration = false
+    }
+
+    node(closureOf<Node> {
+        name("O=Notary Service,L=Zurich,C=CH")
+        p2pPort(60000)
+
+        notary = mapOf("validating" to false)
+
+        rpcSettings(closureOf<RpcSettings> {
+            address("localhost:60001")
+            adminAddress("localhost:60002")
+        })
+    })
+
+    node(closureOf<Node> {
+        name("O=BankOfCorda,L=London,C=GB")
+        p2pPort(10000)
+
+        rpcSettings(closureOf<RpcSettings> {
+            address("localhost:10001")
+            adminAddress("localhost:10002")
+        })
+
+        rpcUsers = listOf(
+            mapOf(
+                "user" to "user1",
+                "password" to "test",
+                "permissions" to listOf("ALL")
+            )
+        )
+
+        projectCordapp(closureOf<Cordapp> {
+            config("a = b")
+            deploy = true
+        })
+    })
+}

--- a/cordformation/src/test/resources/net/corda/plugins/DeployTwoNodeCordapp.gradle.kts
+++ b/cordformation/src/test/resources/net/corda/plugins/DeployTwoNodeCordapp.gradle.kts
@@ -1,0 +1,68 @@
+import net.corda.plugins.Cordapp
+import net.corda.plugins.Cordform
+import net.corda.plugins.Node
+import net.corda.plugins.RpcSettings
+
+plugins {
+    id("net.corda.plugins.cordformation")
+}
+
+apply(from = "repositories.gradle")
+
+val corda_group: String by project
+val corda_release_version: String by project
+val slf4j_version: String by project
+
+dependencies {
+    cordapp("$corda_group:corda-finance-contracts:$corda_release_version")
+    cordapp("$corda_group:corda-finance-workflows:$corda_release_version")
+    cordaRuntime("$corda_group:corda:$corda_release_version")
+    cordaRuntime("$corda_group:corda-node-api:$corda_release_version")
+    cordaRuntime("org.slf4j:slf4j-simple:$slf4j_version")
+}
+
+tasks.register<Cordform>("deployNodes") {
+    dependsOn.add("jar")
+
+    nodeDefaults {
+        projectCordapp {
+            deploy = false
+        }
+
+        cordapp("$corda_group:corda-finance-contracts:$corda_release_version")
+        cordapp("$corda_group:corda-finance-workflows:$corda_release_version") {
+            config("a=b")
+        }
+        runSchemaMigration = false
+    }
+
+    node {
+        name("O=Notary Service,L=Zurich,C=CH")
+        p2pPort(60000)
+
+        notary = mapOf("validating" to false)
+
+        rpcSettings {
+            address("localhost:60001")
+            adminAddress("localhost:60002")
+        }
+    }
+
+    node {
+        name("O=BankOfCorda,L=London,C=GB")
+        p2pPort(10000)
+
+        rpcSettings {
+            address("localhost:10001")
+            adminAddress("localhost:10002")
+        }
+
+        rpcUsers = listOf(
+            mapOf(
+                "user" to "user1",
+                "password" to "test",
+                "permissions" to listOf("ALL")
+            )
+        )
+    }
+}


### PR DESCRIPTION
Replace `Closure` in `cordformation`'s DSL with modern `Action`. This makes `cordformation` compatible with Gradle's Kotlin DSL as well as with Groovy.

This should fix #403.