### PR TITLE
NOTICK: Annotate Baseform.signing field as "Nested".

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Version 5.0.14
 
 * `cordformation`: Replace `Closure` with `Action` in the DSL.
+* `cordformation`; Annotate `Baseform.signing` as `@Nested` instead of `@Input`.
 
 ### Version 5.0.13
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@
 ### Version 5.0.14
 
 * `cordformation`: Replace `Closure` with `Action` in the DSL.
-* `cordformation`; Annotate `Baseform.signing` as `@Nested` instead of `@Input`.
+* `cordformation`: Annotate `Baseform.signing` as `@Nested` instead of `@Input`.
 
 ### Version 5.0.13
 

--- a/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
@@ -94,7 +94,7 @@ open class Baseform(private val objects: ObjectFactory) : DefaultTask() {
     /**
      * Configuration for keystore generation and JAR signing.
      */
-    @get:Input
+    @get:Nested
     val signing: KeyGenAndSigning = objects.newInstance(KeyGenAndSigning::class.java)
 
     fun signing(action: Action<in KeyGenAndSigning>) {


### PR DESCRIPTION
The `Baseform.signing` field is not an `@Input` property, but its contents are. Annotate `signing` as `@Nested` to instruct Gradle to examine `signing` for task properties.