### PR TITLE
NOTICK Fix shutdown hook execution on flask jars

### DIFF
--- a/flask/flask-common/src/main/java/net/corda/flask/common/Flask.java
+++ b/flask/flask-common/src/main/java/net/corda/flask/common/Flask.java
@@ -23,6 +23,7 @@ public class Flask {
         public static final String CLI_JVM_PARAMETERS_PREFIX = "-flaskJvmArg=";
         public static final int BUFFER_SIZE = 0x10000;
         public static final String GRADLE_TASK_GROUP = "Flask";
+        public static final String DEFAULT_KILL_TIMEOUT_MILLIS = "10000";
 
         /**
          * This value is used as a default file timestamp for all the zip entries when
@@ -65,6 +66,12 @@ public class Flask {
          * This property will contain the name of the main class the child process Launcher will start
          */
         public static final String MAIN_CLASS = "net.corda.flask.main.class";
+
+        /**
+         * This property will contain the amount of time the parent process will wait
+         * for the child process termination before killing it forcibly
+         */
+        public static final String KILL_TIMEOUT_MILLIS = "net.corda.flask.kill.timeout.millis";
     }
 
     @SneakyThrows

--- a/flask/flask-launcher/build.gradle
+++ b/flask/flask-launcher/build.gradle
@@ -71,4 +71,3 @@ test {
         systemProperty("lockFileTest.executable.jar", lockFileTestExecutableJar.get().outputs.files.singleFile.toString())
     }
 }
-

--- a/flask/flask-launcher/src/main/java/net/corda/flask/launcher/JavaProcessBuilder.java
+++ b/flask/flask-launcher/src/main/java/net/corda/flask/launcher/JavaProcessBuilder.java
@@ -99,23 +99,6 @@ public class JavaProcessBuilder {
     }
 
     @SneakyThrows
-    public int exec() {
-        Process[] process = new Process[1];
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            if(process[0] != null) {
-                if (process[0].isAlive()) {
-                    process[0].destroy();
-                }
-                if (process[0].isAlive()) {
-                    process[0].destroyForcibly();
-                }
-            }
-        }));
-        process[0] = build().inheritIO().start();
-        return process[0].waitFor();
-    }
-
-    @SneakyThrows
     public ProcessBuilder build() {
         ArrayList<String> cmd = new ArrayList<>();
         Path javaBin = Paths.get(javaHome, "bin", "java");

--- a/flask/src/main/groovy/net/corda/gradle/flask/FlaskPlugin.groovy
+++ b/flask/src/main/groovy/net/corda/gradle/flask/FlaskPlugin.groovy
@@ -1,11 +1,9 @@
 package net.corda.gradle.flask
 
 import net.corda.flask.common.Flask
-import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
-import org.gradle.api.plugins.JavaApplication
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.provider.Provider
@@ -19,6 +17,7 @@ class FlaskPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         project.getPluginManager().apply(JavaPlugin.class)
+        project.ext['FlaskJarTask'] = FlaskJarTask.class
         Provider<Directory> flaskDir = project.layout.buildDirectory.dir("classes/flask-launcher")
         Provider<Copy> extractLauncherTarProvider = project.tasks.register("extractLauncherTar", Copy) {
             group = Flask.Constants.GRADLE_TASK_GROUP
@@ -50,12 +49,6 @@ class FlaskPlugin implements Plugin<Project> {
             }
             includeLibraries(project.tasks.named(JavaPlugin.JAR_TASK_NAME, Jar).map {it.outputs })
             includeLibraries(project.configurations.named(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME))
-
-            project.pluginManager.withPlugin('application') {
-                String result = project.extensions.findByType(JavaApplication.class)?.mainClassName
-                if(!result) throw new GradleException("mainClassName property from \"${JavaApplication.class.name}\" extension is not set")
-                mainClassName = result
-            }
         }
         project.tasks.register('flaskRun', JavaExec) {
             group = Flask.Constants.GRADLE_TASK_GROUP

--- a/flask/src/main/java/net/corda/gradle/flask/FlaskJarTask.java
+++ b/flask/src/main/java/net/corda/gradle/flask/FlaskJarTask.java
@@ -39,6 +39,7 @@ import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
+
 import static java.util.zip.Deflater.BEST_COMPRESSION;
 import static java.util.zip.Deflater.NO_COMPRESSION;
 import static net.corda.flask.common.Flask.Constants.BUFFER_SIZE;
@@ -244,8 +245,13 @@ public class FlaskJarTask extends AbstractArchiveTask {
                 mainAttributes.put(Attributes.Name.MAIN_CLASS, DEFAULT_LAUNCHER_NAME);
                 mainAttributes.putValue(Flask.ManifestAttributes.LAUNCHER_CLASS, launcherClassName.get());
                 mainAttributes.putValue(Flask.ManifestAttributes.PREMAIN_CLASS, DEFAULT_LAUNCHER_NAME);
-                Optional.ofNullable(mainClassName.getOrNull()).ifPresent(it ->
-                        mainAttributes.putValue(Flask.ManifestAttributes.APPLICATION_CLASS, it));
+
+                /**
+                 * {@link mainClassName} can never be null as its getter is annotated with @Input and
+                 * task invocation fails if a non {@link org.gradle.api.tasks.Optional} annotated task input is null
+                 */
+                String mainClass = mainClassName.getOrNull();
+                mainAttributes.putValue(Flask.ManifestAttributes.APPLICATION_CLASS, mainClass);
                 MessageDigest md = MessageDigest.getInstance("SHA-256");
                 byte[] buffer = new byte[BUFFER_SIZE];
                 mainAttributes.putValue(Flask.ManifestAttributes.HEARTBEAT_AGENT_HASH,

--- a/flask/src/test/resources/testProject/build.gradle
+++ b/flask/src/test/resources/testProject/build.gradle
@@ -50,3 +50,10 @@ tasks.register("flaskRunMainClassOverride", JavaExec) {
         'net.corda.flask.main.class' : "net.corda.gradle.flask.test.AlternativeMain",
     ])
 }
+
+tasks.register("shutdownHookTestJar", FlaskJarTask) {
+    Provider<Jar> jarTaskProvider = project.tasks.named('jar', Jar)
+    mainClassName = "net.corda.gradle.flask.test.HangingMain"
+    archiveFileName = "shutdownHookTest.jar"
+    includeLibraries(jarTaskProvider.map {it.outputs })
+}

--- a/flask/src/test/resources/testProject/src/main/java/net/corda/gradle/flask/test/HangingMain.java
+++ b/flask/src/test/resources/testProject/src/main/java/net/corda/gradle/flask/test/HangingMain.java
@@ -1,0 +1,25 @@
+package net.corda.gradle.flask.test;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.EnumSet;
+
+public class HangingMain {
+    public static void main(String[] args) throws Exception {
+        Path file = Paths.get("shutdown-hook-executed");
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            try {
+                Files.delete(file);
+            } catch (IOException ioe) {
+                throw new RuntimeException(ioe);
+            }
+        }));
+        Files.createFile(file);
+        while(true) Thread.sleep(1000);
+    }
+}


### PR DESCRIPTION
The current version of flask calls `Process.destroyForcibly` on the child process immediately after calling `Process.destroy` and without waiting for a graceful shutdown of the child process.
I've also added the `net.corda.flask.kill.timeout.millis` JVM property to set the timeout before forcibly killing the child process if it doesn't gracefully terminate.

