### PR TITLE
NOTICK: Fix Gradle deprecations that will become errors later.

### DIFF
--- a/flask/build.gradle
+++ b/flask/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 }
 
 tasks.named("pluginUnderTestMetadata", PluginUnderTestMetadata) {
-    pluginClasspath.from(project.configurations.named("compileOnly"))
+    pluginClasspath.from(configurations.compileClasspath)
 }
 
 tasks.withType(Test).configureEach {

--- a/flask/flask-heartbeat-agent/build.gradle
+++ b/flask/flask-heartbeat-agent/build.gradle
@@ -8,7 +8,8 @@ dependencies {
     implementation project(":flask:flask-common")
 }
 
-jar {
+tasks.named('jar', Jar) {
+    dependsOn project(':flask:flask-common').tasks.named('jar', Jar)
     manifest {
         attributes([
             (Attributes.Name.IMPLEMENTATION_TITLE.toString()) : (project.name),

--- a/flask/flask-launcher/build.gradle
+++ b/flask/flask-launcher/build.gradle
@@ -48,6 +48,7 @@ tasks.register("tar", Tar) {
 }
 
 Provider<Jar> lockFileTestExecutableJar = tasks.register("lockFileTestExecutableJar", Jar) {
+    dependsOn tasks.named('jar', Jar)
     manifest {
         attributes "Main-Class": "net.corda.flask.launcher.LockFileTestMain"
     }


### PR DESCRIPTION
Fix errors and warnings that are highlighted by Gradle 7.0. (Note that we are still using Gradle 6.7.1, but should be upgrading to Gradle 6.8.3 soon.)