### PR TITLE
CORE-1161: Upgrade to Gradle 6.8.3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ fields from the compiled byte-code inside a jar file. It can also rewrite
 Kotlin classes' `@kotlin.Metadata` annotations to make them consistent 
 again with their revised byte-code. It is currently used in Corda's
 `core-deterministic` and `serialization-deterministic` modules, and has
-been successfully tested with Kotlin 1.2.x - 1.3.72.
+been successfully tested with Kotlin 1.2.x - 1.4.32.
 
-    <sup>Requires Gradle 5.6</sup>
+    <sup>Requires Gradle 6.8</sup>
 
 - [`net.corda.plugins.publish-utils`](publish-utils/README.rst)\
 **_Here be Dragons!_**

--- a/api-scanner/src/test/java/net/corda/plugins/apiscanner/KotlinAnnotationsTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/apiscanner/KotlinAnnotationsTest.java
@@ -31,7 +31,8 @@ class KotlinAnnotationsTest {
         "public final class net.corda.example.HasJvmField extends java.lang.Object",
         "  public <init>()",
         "  @NotNull",
-        "  public final String stringValue = \"Hello World\"",
+        // Kotlin 1.4 no longer includes the field's constant value here.
+        "  public final String stringValue",
         "##"
     };
 
@@ -39,6 +40,7 @@ class KotlinAnnotationsTest {
         "public final class net.corda.example.HasJvmStaticFunction extends java.lang.Object",
         "  public <init>()",
         "  public static final void doThing(String)",
+        "  @NotNull",
         "  public static final net.corda.example.HasJvmStaticFunction$Companion Companion",
         "##"
     };
@@ -92,6 +94,7 @@ class KotlinAnnotationsTest {
                 "  public <init>()",
                 "  @NotNull",
                 "  public static final String getStringValue()",
+                "  @NotNull",
                 "  public static final net.corda.example.HasJvmStaticField$Companion Companion",
                 "##"
             ).containsSequence(

--- a/api-scanner/src/test/java/net/corda/plugins/apiscanner/KotlinConstantTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/apiscanner/KotlinConstantTest.java
@@ -25,6 +25,7 @@ class KotlinConstantTest {
             .containsSequence(
                 "public final class net.corda.example.HasConstantField extends java.lang.Object",
                 "  public <init>()",
+                "  @NotNull",
                 "  public static final net.corda.example.HasConstantField$Companion Companion",
                 "  @NotNull",
                 "  public static final String stringValue = \"Goodbye, Cruel World\"",

--- a/api-scanner/src/test/resources/gradle.properties
+++ b/api-scanner/src/test/resources/gradle.properties
@@ -1,4 +1,6 @@
 org.gradle.jvmargs=-XX:+UseG1GC -Xmx512m -javaagent:"$jacocoAgent"=destfile="$buildDir/jacoco/test.exec",includes=net/corda/plugins/**
+org.gradle.java.installations.auto-download=false
 org.gradle.caching=false
 
+kotlin.stdlib.default.dependency=false
 kotlin_version=$kotlin_version

--- a/api-scanner/src/test/resources/kotlin.gradle
+++ b/api-scanner/src/test/resources/kotlin.gradle
@@ -3,8 +3,8 @@ import static org.gradle.api.JavaVersion.VERSION_1_8
 tasks.named('compileKotlin', AbstractCompile) {
     kotlinOptions {
         jvmTarget = VERSION_1_8
-        apiVersion = '1.3'
-        languageVersion = '1.3'
-        freeCompilerArgs = ['-Xjvm-default=enable']
+        apiVersion = '1.4'
+        languageVersion = '1.4'
+        freeCompilerArgs = ['-Xjvm-default=all']
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ subprojects {
             jvmTarget = VERSION_1_8
             apiVersion = '1.3'
             languageVersion = '1.3'
-            freeCompilerArgs = ['-Xjvm-default=enable']
+            freeCompilerArgs = ['-Xjvm-default=all']
         }
     }
 
@@ -223,6 +223,6 @@ artifactory {
 }
 
 wrapper {
-    gradleVersion = '6.7.1'
+    gradleVersion = '6.8.3'
     distributionType = Wrapper.DistributionType.ALL
 }

--- a/cordapp/src/test/resources/gradle.properties
+++ b/cordapp/src/test/resources/gradle.properties
@@ -1,3 +1,5 @@
 # Placeholder for common Gradle properties.
+org.gradle.java.installations.auto-download=false
 org.gradle.jvmargs=-XX:+UseG1GC -Xmx512m
 org.gradle.caching=false
+kotlin.stdlib.default.dependency=false

--- a/cordformation/src/test/resources/gradle.properties
+++ b/cordformation/src/test/resources/gradle.properties
@@ -1,4 +1,5 @@
 # Placeholder for common Gradle properties.
+org.gradle.java.installations.auto-download=false
 org.gradle.jvmargs=-XX:+UseG1GC -Xmx512m
 org.gradle.caching=false
 corda_group=net.corda

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,11 +7,10 @@ org.gradle.caching=false
 gradle_plugins_version=6.0.0-SNAPSHOT
 typesafe_config_version=1.3.1
 classgraph_version=4.8.78
-kotlin_version=1.3.72
+kotlin_version=1.4.20
 snake_yaml_version=1.19
-commons_io_version=2.6
 assertj_version=3.16.1
-junit_jupiter_version=5.7.0
+junit_jupiter_version=5.7.1
 hamcrest_version=2.1
 asm_version=9.0
 lombok_version=1.18.16
@@ -20,8 +19,8 @@ docker_client_version=8.15.1
 javax_annotations_version=1.3.2
 
 bintray_version=1.8.5
-artifactory_version=4.20.0
-gradle_publish_version=0.12.0
+artifactory_version=4.21.0
+gradle_publish_version=0.14.0
 
 artifactory_contextUrl=https://software.r3.com/artifactory
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://gradleproxy:gradleproxy@software.r3.com/artifactory/gradle-proxy/gradle-6.7.1-all.zip
+distributionUrl=https\://gradleproxy:gradleproxy@software.r3.com/artifactory/gradle-proxy/gradle-6.8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jar-filter/build.gradle
+++ b/jar-filter/build.gradle
@@ -13,8 +13,9 @@ repositories {
 }
 
 ext {
-    kotlin_metadata_version = '0.1.0'
-    test_kotlin_api_version = '1.3'
+    kotlin_metadata_version = '0.2.0'
+    test_kotlin_api_version = '1.4'
+    test_kotlin_version = '1.4.32'
 }
 
 gradlePlugin {
@@ -66,12 +67,19 @@ dependencies {
     jacocoRuntime "org.jacoco:org.jacoco.agent:${jacoco.toolVersion}:runtime"
 }
 
+tasks.named('compileTestKotlin') {
+    kotlinOptions {
+        apiVersion = test_kotlin_api_version
+        languageVersion = test_kotlin_api_version
+    }
+}
+
 processTestResources {
     filesMatching('gradle.properties') {
         expand(['jacocoAgent': configurations.jacocoRuntime.asPath.replace('\\', '/'),
                 'javax_annotations_version': javax_annotations_version,
                 'kotlin_api_version': test_kotlin_api_version,
-                'kotlin_version': kotlin_version,
+                'kotlin_version': test_kotlin_version,
                 'buildDir': buildDir])
     }
 }

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/KotlinAwareVisitor.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/KotlinAwareVisitor.kt
@@ -77,7 +77,7 @@ abstract class KotlinAwareVisitor(
         val kmClass = processClassMetadata(metadata.toKmClass()) ?: return null
         return KotlinClassMetadata.Class.Writer()
             .apply(kmClass::accept)
-            .write(header.metadataVersion, header.bytecodeVersion, header.extraInt)
+            .write(header.metadataVersion, header.extraInt)
             .header
     }
 
@@ -85,7 +85,7 @@ abstract class KotlinAwareVisitor(
         val kmPackage = processPackageMetadata(metadata.toKmPackage()) ?: return null
         return KotlinClassMetadata.FileFacade.Writer()
             .apply(kmPackage::accept)
-            .write(header.metadataVersion, header.bytecodeVersion, header.extraInt)
+            .write(header.metadataVersion, header.extraInt)
             .header
     }
 
@@ -93,7 +93,7 @@ abstract class KotlinAwareVisitor(
         val kmPackage = processPackageMetadata(metadata.toKmPackage()) ?: return null
         return KotlinClassMetadata.MultiFileClassPart.Writer()
             .apply(kmPackage::accept)
-            .write(metadata.facadeClassName, header.metadataVersion, header.bytecodeVersion, header.extraInt)
+            .write(metadata.facadeClassName, header.metadataVersion, header.extraInt)
             .header
     }
 

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetadataTransformer.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/MetadataTransformer.kt
@@ -1,7 +1,7 @@
 package net.corda.gradle.jarfilter
 
 import kotlinx.metadata.ClassName
-import kotlinx.metadata.Flag.Constructor.IS_PRIMARY
+import kotlinx.metadata.Flag.Constructor.IS_SECONDARY
 import kotlinx.metadata.KmClass
 import kotlinx.metadata.KmDeclarationContainer
 import kotlinx.metadata.KmFunction
@@ -296,10 +296,10 @@ class ClassMetadataTransformer(
             val constructor = constructors[idx]
             val signature = (constructor.signature ?: continue).toMethodElement()
             if (signature == deleted) {
-                if (IS_PRIMARY(constructor.flags)) {
-                    logger.warn("Removing primary constructor: {}{}", className, deleted.descriptor)
-                } else {
+                if (IS_SECONDARY(constructor.flags)) {
                     logger.info("-- removing constructor: {}", deleted.signature)
+                } else {
+                    logger.warn("Removing primary constructor: {}{}", className, deleted.descriptor)
                 }
                 constructors.removeAt(idx)
                 return true

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/SanitisingTransformer.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/SanitisingTransformer.kt
@@ -1,7 +1,7 @@
 package net.corda.gradle.jarfilter
 
 import kotlinx.metadata.ClassName
-import kotlinx.metadata.Flag.Constructor.IS_PRIMARY
+import kotlinx.metadata.Flag.Constructor.IS_SECONDARY
 import kotlinx.metadata.KmClass
 import kotlinx.metadata.KmPackage
 import kotlinx.metadata.jvm.signature
@@ -41,7 +41,7 @@ class SanitisingTransformer(
 
     override fun processClassMetadata(kmClass: KmClass): KmClass? {
         for (constructor in kmClass.constructors) {
-            if (IS_PRIMARY(constructor.flags)) {
+            if (!IS_SECONDARY(constructor.flags)) {
                 val signature = constructor.signature ?: break
                 primaryConstructor = signature.toMethodElement()
                 hasDefaultValues = constructor.valueParameters.hasAnyDefaultValues

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DummyJar.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DummyJar.kt
@@ -89,7 +89,7 @@ class DummyJar(
             jar.putNextEntry(uncompressed("comment.txt", text))
             jar.write(text)
         }
-        assertThat(_path).isRegularFile()
+        assertThat(_path).isRegularFile
         return this
     }
 }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterProject.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterProject.kt
@@ -40,10 +40,10 @@ class JarFilterProject(private val projectDir: Path, private val name: String) {
         assertEquals(SUCCESS, jarFilter.outcome)
 
         _sourceJar = projectDir.pathOf("build", "libs", "$name.jar")
-        assertThat(sourceJar).isRegularFile()
+        assertThat(sourceJar).isRegularFile
 
         _filteredJar = projectDir.pathOf("build", "filtered-libs", "$name-filtered.jar")
-        assertThat(filteredJar).isRegularFile()
+        assertThat(filteredJar).isRegularFile
 
         return this
     }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterTimestampTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterTimestampTest.kt
@@ -62,7 +62,7 @@ class JarFilterTimestampTest {
             assertEquals(SUCCESS, jarFilter.outcome)
 
             val filtered = testProjectDir.pathOf("build", "filtered-libs", "timestamps-filtered.jar")
-            assertThat(filtered).isRegularFile()
+            assertThat(filtered).isRegularFile
             return filtered
         }
 

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixAnnotationTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixAnnotationTest.kt
@@ -16,7 +16,7 @@ class MetaFixAnnotationTest {
         )
         private val valueCon = isKonstructor(
             returnType = AnnotationWithValue::class,
-            parameters = *arrayOf(String::class)
+            parameters = arrayOf(String::class)
         )
     }
 

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixProject.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixProject.kt
@@ -41,10 +41,10 @@ class MetaFixProject(private val projectDir: Path, private val name: String) {
         assertEquals(SUCCESS, metafix.outcome)
 
         _sourceJar = projectDir.pathOf("build", "libs", "$name.jar")
-        assertThat(sourceJar).isRegularFile()
+        assertThat(sourceJar).isRegularFile
 
         _metafixedJar = projectDir.pathOf("build", "metafixer-libs", "$name-metafixed.jar")
-        assertThat(metafixedJar).isRegularFile()
+        assertThat(metafixedJar).isRegularFile
 
         return this
     }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixTimestampTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixTimestampTest.kt
@@ -63,7 +63,7 @@ class MetaFixTimestampTest {
             assertEquals(SUCCESS, metafix.outcome)
 
             val metaFixed = testProjectDir.pathOf("build", "metafixer-libs", "timestamps-metafixed.jar")
-            assertThat(metaFixed).isRegularFile()
+            assertThat(metaFixed).isRegularFile
             return metaFixed
         }
 

--- a/jar-filter/src/test/resources/gradle.properties
+++ b/jar-filter/src/test/resources/gradle.properties
@@ -1,6 +1,9 @@
 org.gradle.jvmargs=-XX:+UseG1GC -Xmx512m -javaagent:"$jacocoAgent"=destfile="$buildDir/jacoco/test.exec",includes=net/corda/gradle/jarfilter/**
+org.gradle.java.installations.auto-download=false
 org.gradle.caching=false
+
 kotlin.incremental=false
+kotlin.stdlib.default.dependency=false
 
 kotlin_api_version=$kotlin_api_version
 kotlin_version=$kotlin_version

--- a/jar-filter/src/test/resources/kotlin.gradle
+++ b/jar-filter/src/test/resources/kotlin.gradle
@@ -5,6 +5,6 @@ tasks.named('compileKotlin', AbstractCompile) {
         jvmTarget = VERSION_1_8
         apiVersion = kotlin_api_version
         languageVersion = kotlin_api_version
-        freeCompilerArgs = ['-Xjvm-default=enable']
+        freeCompilerArgs = ['-Xjvm-default=all']
     }
 }

--- a/jar-filter/unwanteds/build.gradle
+++ b/jar-filter/unwanteds/build.gradle
@@ -13,6 +13,6 @@ dependencies {
     api 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 }
 
-jar {
+tasks.named('jar', Jar) {
     archiveFileName = "${project.name}.jar"
 }

--- a/quasar-utils/src/test/resources/gradle.properties
+++ b/quasar-utils/src/test/resources/gradle.properties
@@ -1,3 +1,4 @@
 # Placeholder for common Gradle properties.
+org.gradle.java.installations.auto-download=false
 org.gradle.jvmargs=-XX:+UseG1GC -Xmx512m
 org.gradle.caching=false

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,7 +9,7 @@ pluginManagement {
         id 'com.jfrog.artifactory' version artifactory_version
         id 'com.jfrog.bintray' version bintray_version
         id 'org.owasp.dependencycheck' version '5.3.2.1'
-        id 'com.gradle.enterprise' version '3.6'
+        id 'com.gradle.enterprise' version '3.6.1'
     }
 }
 


### PR DESCRIPTION
Plugins written in Kotlin are still compiled to use the Kotlin 1.3 API, despite Gradle 6.8.3 using the Kotlin 1.4 runtime libraries. This should allow Gradle versions < 6.8 to continue using them.

JarFilter uses the `kotlinx-metadata-jvm` library, the latest version of which now _requires_ Kotlin 1.4. So JarFilter 6 now requires Gradle 6.8+. (This shouldn't be an issue for Corda.)

Also upgrade the following:
- JUnit 5.7.0 -> 5.7.1
- Artifactory plugin 4.20.0 -> 4.21.0
- Gradle Publish plugin 0.12.0 -> 0.14.0
- Gradle Enterprise Plugin 3.6 -> 3.6.1