### PR TITLE
NOTICK: Clear some trivial technical debt.

### DIFF
--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CPKDependenciesTask.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CPKDependenciesTask.kt
@@ -47,8 +47,9 @@ open class CPKDependenciesTask @Inject constructor(objects: ObjectFactory) : Def
 
         @Throws(IOException::class)
         private fun consume(input: InputStream, buffer: ByteArray) {
-            @Suppress("ControlFlowWithEmptyBody")
-            while (input.read(buffer) != EOF) {}
+            while (input.read(buffer) != EOF) {
+                continue
+            }
         }
 
         private val JarEntry.isSignable: Boolean get() {

--- a/jar-filter/build.gradle
+++ b/jar-filter/build.gradle
@@ -41,6 +41,11 @@ pluginBundle {
     }
 }
 
+jacoco {
+    // Upgrade to a version that is compatible with Java 16.
+    toolVersion = '0.8.7'
+}
+
 configurations {
     jacocoRuntime
 }

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DummyJar.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DummyJar.kt
@@ -21,7 +21,7 @@ import java.util.zip.ZipEntry.*
  * - An uncompressed text file
  * - A directory entry
  *
- * The compression level is set to NO_COMPRESSION
+ * The compression level is set to [NO_COMPRESSION]
  * in order to force the Gradle task to compress
  * the entries properly.
  */
@@ -33,10 +33,11 @@ class DummyJar(
     private companion object {
         private const val DATA_SIZE = 512
 
+        @Suppress("SameParameterValue")
         private fun uncompressed(name: String, data: ByteArray) = ZipEntry(name).apply {
-            method = STORED
-            compressedSize = data.size.toLong()
             size = data.size.toLong()
+            compressedSize = size
+            method = STORED
             crc = CRC32().let { crc ->
                 crc.update(data)
                 crc.value
@@ -65,7 +66,7 @@ class DummyJar(
                 main[MANIFEST_VERSION] = "1.0"
             }
         }
-        _path = projectDir.pathOf("$name.jar")
+        _path = projectDir.pathOf("${name}.jar")
         JarOutputStream(Files.newOutputStream(_path).buffered(), manifest).use { jar ->
             jar.setComment(testClass.name)
             jar.setLevel(NO_COMPRESSION)


### PR DESCRIPTION
- Resolve some compiler warnings.
- Improve KDocs slightly.
- JarFilter project now uses JaCoCo 0.8.7.