### PR TITLE
CORE-1300: Copy CPKDependencies into the CPK file.

### DIFF
--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CPKDependenciesTask.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CPKDependenciesTask.kt
@@ -32,7 +32,6 @@ import javax.inject.Inject
 @Suppress("UnstableApiUsage", "MemberVisibilityCanBePrivate")
 open class CPKDependenciesTask @Inject constructor(objects: ObjectFactory) : DefaultTask() {
     private companion object {
-        private const val CPK_DEPENDENCIES = "META-INF/CPKDependencies"
         private const val EOF = -1
 
         /**

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappUtils.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappUtils.kt
@@ -14,6 +14,8 @@ import org.gradle.api.specs.Spec
 import org.w3c.dom.Document
 import org.w3c.dom.Element
 import java.io.File
+import java.io.IOException
+import java.io.InputStream
 import java.io.Writer
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
@@ -45,6 +47,9 @@ const val CORDA_PROVIDED_CONFIGURATION_NAME = "cordaProvided"
 const val CORDA_EMBEDDED_CONFIGURATION_NAME = "cordaEmbedded"
 const val ALL_CORDAPPS_CONFIGURATION_NAME = "allCordapps"
 const val CORDA_CPK_CONFIGURATION_NAME = "cordaCPK"
+
+const val DEPENDENCY_CONSTRAINTS = "META-INF/DependencyConstraints"
+const val CPK_DEPENDENCIES = "META-INF/CPKDependencies"
 
 const val CPK_CORDAPP_NAME = "Corda-CPK-Cordapp-Name"
 const val CPK_CORDAPP_VERSION = "Corda-CPK-Cordapp-Version"
@@ -229,6 +234,24 @@ fun digestFor(algorithmName: String): MessageDigest {
     } catch (_ : NoSuchAlgorithmException) {
         throw InvalidUserDataException("Hash algorithm $algorithmName not available")
     }
+}
+
+private const val EOF = -1
+
+/**
+ * Compute hash for contents of [InputStream].
+ */
+@Throws(IOException::class)
+fun MessageDigest.hashFor(input: InputStream): ByteArray {
+    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+    while (true) {
+        val length = input.read(buffer)
+        if (length == EOF) {
+            break
+        }
+        update(buffer, 0, length)
+    }
+    return digest()
 }
 
 /**

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/DependencyConstraintsTask.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/DependencyConstraintsTask.kt
@@ -24,11 +24,6 @@ import javax.inject.Inject
 
 @Suppress("UnstableApiUsage")
 open class DependencyConstraintsTask @Inject constructor(objects: ObjectFactory) : DefaultTask() {
-    private companion object {
-        private const val DEPENDENCY_CONSTRAINTS = "META-INF/DependencyConstraints"
-        private const val EOF = -1
-    }
-
     init {
         description = "Computes the constraints for this CorDapp's library dependencies."
         group = GROUP_NAME
@@ -72,7 +67,7 @@ open class DependencyConstraintsTask @Inject constructor(objects: ObjectFactory)
                 logger.info("CorDapp library dependency: {}", library.name)
                 dependencyConstraints.appendElement("dependencyConstraint").also { constraint ->
                     constraint.appendElement("fileName", library.name)
-                    val jarHash = digest.hashFor(library)
+                    val jarHash = digest.hashOf(library)
                     constraint.appendElement("hash", encoder.encodeToString(jarHash))
                         .setAttribute("algorithm", digest.algorithm)
                 }
@@ -88,17 +83,7 @@ open class DependencyConstraintsTask @Inject constructor(objects: ObjectFactory)
     /**
      * For computing file hashes.
      */
-    private fun MessageDigest.hashFor(file: File): ByteArray {
-        file.inputStream().use {
-            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-            while (true) {
-                val length = it.read(buffer)
-                if (length == EOF) {
-                    break
-                }
-                update(buffer, 0, length)
-            }
-        }
-        return digest()
+    private fun MessageDigest.hashOf(file: File): ByteArray {
+        return file.inputStream().use(::hashFor)
     }
 }

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappTransitiveDependencyTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappTransitiveDependencyTest.kt
@@ -45,14 +45,19 @@ class CordappTransitiveDependencyTest {
             .anyMatch { it.name == "com.example.cordapp" && it.version == toOSGi(cordappVersion) }
             .allMatch { it.signers.allSHA256 }
             .hasSize(1)
+        val cpkDependenciesHash = testProject.cpkDependenciesHash
 
         val artifacts = testProject.artifacts
         assertThat(artifacts).hasSize(2)
 
         val cpk = artifacts.single { it.toString().endsWith(".cpk") }
         assertThat(cpk).isRegularFile()
+        assertThat(cpk.hashOfEntry(CPK_DEPENDENCIES))
+            .isEqualTo(cpkDependenciesHash)
 
         val cordapp = artifacts.single { it.toString().endsWith(".jar") }
         assertThat(cordapp).isRegularFile()
+        assertThat(cordapp.hashOfEntry(CPK_DEPENDENCIES))
+            .isEqualTo(cpkDependenciesHash)
     }
 }

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/SimpleCordappTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/SimpleCordappTest.kt
@@ -50,15 +50,22 @@ class SimpleCordappTest {
             .allMatch { it.hash.isSHA256 }
             .hasSize(1)
         assertThat(testProject.cpkDependencies).isEmpty()
+        val cpkDependenciesHash = testProject.cpkDependenciesHash
 
         val artifacts = testProject.artifacts
         assertThat(artifacts).hasSize(2)
 
         val cpk = artifacts.single { it.toString().endsWith(".cpk") }
         assertThat(cpk).isRegularFile()
+        assertThat(cpk.hashOfEntry(CPK_DEPENDENCIES))
+            .isEqualTo(cpkDependenciesHash)
 
         val cordapp = artifacts.single { it.toString().endsWith(".jar") }
         assertThat(cordapp).isRegularFile()
+        assertThat(cordapp.hashOfEntry(CPK_DEPENDENCIES))
+            .isEqualTo(cpkDependenciesHash)
+        assertThat(cordapp.hashOfEntry(DEPENDENCY_CONSTRAINTS))
+            .isEqualTo(testProject.dependencyConstraintsHash)
 
         val jarManifest = cordapp.manifest
         println(jarManifest.mainAttributes.entries)

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/SimpleKotlinCordappTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/SimpleKotlinCordappTest.kt
@@ -56,15 +56,22 @@ class SimpleKotlinCordappTest {
             .allMatch { it.hash.isSHA256 }
             .hasSizeGreaterThanOrEqualTo(2)
         assertThat(testProject.cpkDependencies).isEmpty()
+        val cpkDependenciesHash = testProject.cpkDependenciesHash
 
         val artifacts = testProject.artifacts
         assertThat(artifacts).hasSize(2)
 
         val cpk = artifacts.single { it.toString().endsWith(".cpk") }
         assertThat(cpk).isRegularFile()
+        assertThat(cpk.hashOfEntry(CPK_DEPENDENCIES))
+            .isEqualTo(cpkDependenciesHash)
 
         val cordapp = artifacts.single { it.toString().endsWith(".jar") }
         assertThat(cordapp).isRegularFile()
+        assertThat(cordapp.hashOfEntry(CPK_DEPENDENCIES))
+            .isEqualTo(cpkDependenciesHash)
+        assertThat(cordapp.hashOfEntry(DEPENDENCY_CONSTRAINTS))
+            .isEqualTo(testProject.dependencyConstraintsHash)
 
         val jarManifest = cordapp.manifest
         println(jarManifest.mainAttributes.entries)

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/TransitiveCordappsTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/TransitiveCordappsTest.kt
@@ -79,15 +79,20 @@ class TransitiveCordappsTest {
             .anyMatch { it.name == "com.example.cpk-three" && it.version == toOSGi(cpk3Version) }
             .allMatch { it.signers.allSHA256 }
             .hasSize(3)
+        val cpkDependenciesHash = testProject.cpkDependenciesHash
 
         val artifacts = testProject.artifacts
         assertThat(artifacts).hasSize(2)
 
         val cpk = artifacts.single { it.toString().endsWith(".cpk") }
         assertThat(cpk).isRegularFile()
+        assertThat(cpk.hashOfEntry(CPK_DEPENDENCIES))
+            .isEqualTo(cpkDependenciesHash)
 
         val cordapp = artifacts.single { it.toString().endsWith(".jar") }
         assertThat(cordapp).isRegularFile()
+        assertThat(cordapp.hashOfEntry(CPK_DEPENDENCIES))
+            .isEqualTo(cpkDependenciesHash)
 
         val jarManifest = cordapp.manifest
         println(jarManifest.mainAttributes.entries)


### PR DESCRIPTION
Modify the `cordapp-cpk` plugin's `PackagingTask` to extract the `CPKDependencies` file from the "main" jar and include it inside the `.cpk` file too.