### PR TITLE
NOTICK: Upgrade to Gradle 6.9.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ subprojects {
             // ourselves to the same Kotlin API that Gradle itself uses.
             // Gradle 4.10.x uses Kotlin 1.2.
             // Gradle 5.x - 6.7.1 uses Kotlin 1.3.
-            // Gradle 6.8 uses Kotlin 1.3, but with the Kotlin 1.4 libraries.
+            // Gradle 6.8+ uses Kotlin 1.3, but with the Kotlin 1.4 libraries.
             jvmTarget = VERSION_1_8
             apiVersion = '1.3'
             languageVersion = '1.3'
@@ -223,6 +223,6 @@ artifactory {
 }
 
 wrapper {
-    gradleVersion = '6.8.3'
+    gradleVersion = '6.9'
     distributionType = Wrapper.DistributionType.ALL
 }

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappGradleConfigurationsTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappGradleConfigurationsTest.kt
@@ -13,7 +13,7 @@ import java.util.zip.ZipFile
 
 class CordappGradleConfigurationsTest {
     companion object {
-        private val GRADLE_6_8 = GradleVersion.version("6.8.3")
+        private val GRADLE_6_9 = GradleVersion.version("6.9")
         private lateinit var testProject: GradleProject
         private lateinit var dependencies: List<ZipEntry>
 
@@ -22,7 +22,7 @@ class CordappGradleConfigurationsTest {
         @JvmStatic
         fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
             testProject = GradleProject(testProjectDir, reporter)
-                .withGradleVersion(GRADLE_6_8)
+                .withGradleVersion(GRADLE_6_9)
                 .withBuildScript("""\
                     |plugins {
                     |    id 'net.corda.plugins.cordapp-cpk'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://gradleproxy:gradleproxy@software.r3.com/artifactory/gradle-proxy/gradle-6.8.3-all.zip
+distributionUrl=https\://gradleproxy:gradleproxy@software.r3.com/artifactory/gradle-proxy/gradle-6.9-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This release backports important fixes from Gradle 7.0.