### PR TITLE
CORE-1300: Revert duplication of CPKDependencies into CPK.

### DIFF
--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/PackagingTask.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/PackagingTask.kt
@@ -2,7 +2,6 @@ package net.corda.plugins.cpk
 
 import org.gradle.api.InvalidUserCodeException
 import org.gradle.api.Task
-import org.gradle.api.file.ArchiveOperations
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DuplicatesStrategy.FAIL
 import org.gradle.api.file.FileCollection
@@ -27,7 +26,7 @@ import java.util.jar.Manifest
 import javax.inject.Inject
 
 @Suppress("UnstableApiUsage", "MemberVisibilityCanBePrivate")
-open class PackagingTask @Inject constructor(objects: ObjectFactory, archiveOps: ArchiveOperations) : Jar() {
+open class PackagingTask @Inject constructor(objects: ObjectFactory) : Jar() {
     private companion object {
         private const val CORDAPP_CLASSIFIER = "cordapp"
         private const val CORDAPP_EXTENSION = "cpk"
@@ -96,21 +95,6 @@ open class PackagingTask @Inject constructor(objects: ObjectFactory, archiveOps:
 
         mainSpec.from(cordapp).from(libraries) { libs ->
             libs.into("lib")
-        }
-
-        /**
-         * Extract the CPKDependencies file from the CorDapp "main" jar.
-         * Ensure that this file is correctly listed with all the other
-         * META-INF artifacts inside the CPK archive, rather than being
-         * added after the libraries.
-         */
-        metaInf.from(project.provider {
-            archiveOps.zipTree(cordapp).matching { it.include(CPK_DEPENDENCIES) }
-        }) { spec ->
-            spec.includeEmptyDirs = false
-            spec.eachFile { file ->
-                file.path = file.path.removePrefix("META-INF/")
-            }
         }
 
         archiveExtension.set(CORDAPP_EXTENSION)

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappTransitiveDependencyTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappTransitiveDependencyTest.kt
@@ -45,19 +45,16 @@ class CordappTransitiveDependencyTest {
             .anyMatch { it.name == "com.example.cordapp" && it.version == toOSGi(cordappVersion) }
             .allMatch { it.signers.allSHA256 }
             .hasSize(1)
-        val cpkDependenciesHash = testProject.cpkDependenciesHash
 
         val artifacts = testProject.artifacts
         assertThat(artifacts).hasSize(2)
 
         val cpk = artifacts.single { it.toString().endsWith(".cpk") }
         assertThat(cpk).isRegularFile()
-        assertThat(cpk.hashOfEntry(CPK_DEPENDENCIES))
-            .isEqualTo(cpkDependenciesHash)
 
         val cordapp = artifacts.single { it.toString().endsWith(".jar") }
         assertThat(cordapp).isRegularFile()
         assertThat(cordapp.hashOfEntry(CPK_DEPENDENCIES))
-            .isEqualTo(cpkDependenciesHash)
+            .isEqualTo(testProject.cpkDependenciesHash)
     }
 }

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/SimpleCordappTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/SimpleCordappTest.kt
@@ -50,20 +50,17 @@ class SimpleCordappTest {
             .allMatch { it.hash.isSHA256 }
             .hasSize(1)
         assertThat(testProject.cpkDependencies).isEmpty()
-        val cpkDependenciesHash = testProject.cpkDependenciesHash
 
         val artifacts = testProject.artifacts
         assertThat(artifacts).hasSize(2)
 
         val cpk = artifacts.single { it.toString().endsWith(".cpk") }
         assertThat(cpk).isRegularFile()
-        assertThat(cpk.hashOfEntry(CPK_DEPENDENCIES))
-            .isEqualTo(cpkDependenciesHash)
 
         val cordapp = artifacts.single { it.toString().endsWith(".jar") }
         assertThat(cordapp).isRegularFile()
         assertThat(cordapp.hashOfEntry(CPK_DEPENDENCIES))
-            .isEqualTo(cpkDependenciesHash)
+            .isEqualTo(testProject.cpkDependenciesHash)
         assertThat(cordapp.hashOfEntry(DEPENDENCY_CONSTRAINTS))
             .isEqualTo(testProject.dependencyConstraintsHash)
 

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/SimpleKotlinCordappTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/SimpleKotlinCordappTest.kt
@@ -56,20 +56,17 @@ class SimpleKotlinCordappTest {
             .allMatch { it.hash.isSHA256 }
             .hasSizeGreaterThanOrEqualTo(2)
         assertThat(testProject.cpkDependencies).isEmpty()
-        val cpkDependenciesHash = testProject.cpkDependenciesHash
 
         val artifacts = testProject.artifacts
         assertThat(artifacts).hasSize(2)
 
         val cpk = artifacts.single { it.toString().endsWith(".cpk") }
         assertThat(cpk).isRegularFile()
-        assertThat(cpk.hashOfEntry(CPK_DEPENDENCIES))
-            .isEqualTo(cpkDependenciesHash)
 
         val cordapp = artifacts.single { it.toString().endsWith(".jar") }
         assertThat(cordapp).isRegularFile()
         assertThat(cordapp.hashOfEntry(CPK_DEPENDENCIES))
-            .isEqualTo(cpkDependenciesHash)
+            .isEqualTo(testProject.cpkDependenciesHash)
         assertThat(cordapp.hashOfEntry(DEPENDENCY_CONSTRAINTS))
             .isEqualTo(testProject.dependencyConstraintsHash)
 

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/TransitiveCordappsTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/TransitiveCordappsTest.kt
@@ -79,20 +79,17 @@ class TransitiveCordappsTest {
             .anyMatch { it.name == "com.example.cpk-three" && it.version == toOSGi(cpk3Version) }
             .allMatch { it.signers.allSHA256 }
             .hasSize(3)
-        val cpkDependenciesHash = testProject.cpkDependenciesHash
 
         val artifacts = testProject.artifacts
         assertThat(artifacts).hasSize(2)
 
         val cpk = artifacts.single { it.toString().endsWith(".cpk") }
         assertThat(cpk).isRegularFile()
-        assertThat(cpk.hashOfEntry(CPK_DEPENDENCIES))
-            .isEqualTo(cpkDependenciesHash)
 
         val cordapp = artifacts.single { it.toString().endsWith(".jar") }
         assertThat(cordapp).isRegularFile()
         assertThat(cordapp.hashOfEntry(CPK_DEPENDENCIES))
-            .isEqualTo(cpkDependenciesHash)
+            .isEqualTo(testProject.cpkDependenciesHash)
 
         val jarManifest = cordapp.manifest
         println(jarManifest.mainAttributes.entries)


### PR DESCRIPTION
Remove the duplicate `CPKDependencies` from the `.cpk` file. We do not want this "convenient" duplicate to become the de-facto "master" copy.

Keep the extra tests though :grinning:.