### PR TITLE
CORE-1335: Validate the CPK XML against a schema XSD.

### DIFF
--- a/cordapp-cpk/build.gradle
+++ b/cordapp-cpk/build.gradle
@@ -96,6 +96,10 @@ processTestResources {
     }
 }
 
+tasks.withType(Javadoc).configureEach {
+    options.showFromPackage()
+}
+
 tasks.withType(Test).configureEach {
     javaLauncher = javaToolchains.launcherFor {
         languageVersion = of(11)

--- a/cordapp-cpk/src/main/java/net/corda/plugins/cpk/XMLFactory.java
+++ b/cordapp-cpk/src/main/java/net/corda/plugins/cpk/XMLFactory.java
@@ -1,0 +1,81 @@
+package net.corda.plugins.cpk;
+
+import org.jetbrains.annotations.NotNull;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerFactory;
+
+import static javax.xml.XMLConstants.ACCESS_EXTERNAL_DTD;
+import static javax.xml.XMLConstants.ACCESS_EXTERNAL_SCHEMA;
+import static javax.xml.XMLConstants.ACCESS_EXTERNAL_STYLESHEET;
+import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
+
+/**
+ * Workaround for a Kotlin compiler bug.
+ * When Gradle runs on Java 11, the Kotlin compiler finds the {@link XMLConstants}
+ * class inside {@code gradle-api-$version.jar} rather than the JDK's built-in
+ * class. Unfortunately, Gradle's version predates JAXP 1.5, and so is missing
+ * {@link XMLConstants#ACCESS_EXTERNAL_DTD}, {@link XMLConstants#ACCESS_EXTERNAL_SCHEMA}
+ * and {@link XMLConstants#ACCESS_EXTERNAL_STYLESHEET}.
+ * The Java compiler does not have this problem.
+ */
+final class XMLFactory {
+    /**
+     * Create a JAXP DocumentBuilderFactory.
+     * Disable any features that may be flagged by a security audit.
+     * @return a namespace-aware DocumentBuilderFactory.
+     * @throws ParserConfigurationException if JAXP does not support "secure processing".
+     */
+    @NotNull
+    static DocumentBuilderFactory createDocumentBuilderFactory() throws ParserConfigurationException  {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(FEATURE_SECURE_PROCESSING, true);
+        disableProperty(factory, ACCESS_EXTERNAL_SCHEMA);
+        disableProperty(factory, ACCESS_EXTERNAL_DTD);
+        factory.setExpandEntityReferences(false);
+        factory.setIgnoringComments(true);
+        factory.setNamespaceAware(true);
+        return factory;
+    }
+
+    private static void disableProperty(@NotNull DocumentBuilderFactory factory, String propertyName) {
+        try {
+            factory.setAttribute(propertyName, "");
+        } catch (IllegalArgumentException e) {
+            // Property not supported.
+        }
+    }
+
+    /**
+     * Create a JAXP TransformerFactory.
+     * Disable any features that may be flagged by a security audit.
+     * @return a TransformerFactory.
+     * @throws TransformerConfigurationException if JAXP does not support "secure processing".
+     */
+    @NotNull
+    static TransformerFactory createTransformerFactory() throws TransformerConfigurationException  {
+        TransformerFactory factory = TransformerFactory.newInstance();
+        factory.setFeature(FEATURE_SECURE_PROCESSING, true);
+        disableProperty(factory, ACCESS_EXTERNAL_STYLESHEET);
+        disableProperty(factory, ACCESS_EXTERNAL_DTD);
+        try {
+            // Set XML indentation to 4 spaces.
+            // This does not seem to be a standard JAXP property!
+            factory.setAttribute("indent-number", 4);
+        } catch (IllegalArgumentException e) {
+            // Property not supported.
+        }
+        return factory;
+    }
+
+    private static void disableProperty(@NotNull TransformerFactory factory, String propertyName) {
+        try {
+            factory.setAttribute(propertyName, "");
+        } catch (IllegalArgumentException e) {
+            // Property not supported.
+        }
+    }
+}

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CPKDependenciesTask.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CPKDependenciesTask.kt
@@ -62,7 +62,7 @@ open class CPKDependenciesTask @Inject constructor(objects: ObjectFactory) : Def
 
     init {
         description = "Records this CorDapp's CPK dependencies."
-        group = GROUP_NAME
+        group = CORDAPP_TASK_GROUP
     }
 
     @get:Input
@@ -96,7 +96,7 @@ open class CPKDependenciesTask @Inject constructor(objects: ObjectFactory) : Def
 
         try {
             val xmlDocument = createXmlDocument()
-            val cpkDependencies = xmlDocument.createRootElement(XML_NAMESPACE, "cpkDependencies")
+            val cpkDependencies = xmlDocument.createRootElement(CPK_XML_NAMESPACE, "cpkDependencies")
             val encoder = Base64.getEncoder()
 
             cpks.forEach { cpk ->

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappUtils.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappUtils.kt
@@ -21,20 +21,16 @@ import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
 import java.util.Collections.unmodifiableSet
 import java.util.jar.JarFile
-import javax.xml.XMLConstants.ACCESS_EXTERNAL_DTD
-import javax.xml.XMLConstants.ACCESS_EXTERNAL_SCHEMA
-import javax.xml.XMLConstants.ACCESS_EXTERNAL_STYLESHEET
-import javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING
-import javax.xml.parsers.DocumentBuilderFactory
 import javax.xml.transform.OutputKeys.ENCODING
 import javax.xml.transform.OutputKeys.INDENT
 import javax.xml.transform.OutputKeys.METHOD
 import javax.xml.transform.OutputKeys.OMIT_XML_DECLARATION
 import javax.xml.transform.OutputKeys.STANDALONE
 import javax.xml.transform.TransformerException
-import javax.xml.transform.TransformerFactory
 import javax.xml.transform.dom.DOMSource
 import javax.xml.transform.stream.StreamResult
+import net.corda.plugins.cpk.XMLFactory.createDocumentBuilderFactory
+import net.corda.plugins.cpk.XMLFactory.createTransformerFactory
 
 const val CORDAPP_CPK_PLUGIN_ID = "net.corda.plugins.cordapp-cpk"
 const val CORDAPP_TASK_GROUP = "Cordapp"
@@ -261,22 +257,8 @@ fun MessageDigest.hashFor(input: InputStream): ByteArray {
 /**
  * Helper functions for XML documents.
  * Note that creating factories is EXPENSIVE.
- * Disable any JAXP features that may be flagged by a security audit.
  */
-private val documentBuilderFactory = DocumentBuilderFactory.newInstance().apply {
-    setFeature(FEATURE_SECURE_PROCESSING, true)
-    disableProperty(ACCESS_EXTERNAL_SCHEMA)
-    disableProperty(ACCESS_EXTERNAL_DTD)
-    isNamespaceAware = true
-}
-
-fun DocumentBuilderFactory.disableProperty(propertyName: String) {
-    try {
-        setAttribute(propertyName, "")
-    } catch (_: IllegalArgumentException) {
-        // Property not supported.
-    }
-}
+private val documentBuilderFactory = createDocumentBuilderFactory()
 
 fun createXmlDocument(): Document {
     return documentBuilderFactory.newDocumentBuilder().newDocument().apply {
@@ -284,19 +266,7 @@ fun createXmlDocument(): Document {
     }
 }
 
-private val transformerFactory = TransformerFactory.newInstance().apply {
-    setFeature(FEATURE_SECURE_PROCESSING, true)
-    disableProperty(ACCESS_EXTERNAL_STYLESHEET)
-    disableProperty(ACCESS_EXTERNAL_DTD)
-}
-
-private fun TransformerFactory.disableProperty(propertyName: String) {
-    try {
-        setAttribute(propertyName, "")
-    } catch (_: IllegalArgumentException) {
-        // Property not supported.
-    }
-}
+private val transformerFactory = createTransformerFactory()
 
 @Throws(TransformerException::class)
 fun Document.writeTo(writer: Writer) {

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappUtils.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappUtils.kt
@@ -21,6 +21,10 @@ import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
 import java.util.Collections.unmodifiableSet
 import java.util.jar.JarFile
+import javax.xml.XMLConstants.ACCESS_EXTERNAL_DTD
+import javax.xml.XMLConstants.ACCESS_EXTERNAL_SCHEMA
+import javax.xml.XMLConstants.ACCESS_EXTERNAL_STYLESHEET
+import javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING
 import javax.xml.parsers.DocumentBuilderFactory
 import javax.xml.transform.OutputKeys.ENCODING
 import javax.xml.transform.OutputKeys.INDENT
@@ -33,8 +37,8 @@ import javax.xml.transform.dom.DOMSource
 import javax.xml.transform.stream.StreamResult
 
 const val CORDAPP_CPK_PLUGIN_ID = "net.corda.plugins.cordapp-cpk"
-const val GROUP_NAME = "Cordapp"
-const val XML_NAMESPACE = "corda-cpk"
+const val CORDAPP_TASK_GROUP = "Cordapp"
+const val CPK_XML_NAMESPACE = "urn:corda-cpk"
 
 const val CORDAPP_SEALING_SYSTEM_PROPERTY_NAME = "net.corda.cordapp.sealing.enabled"
 
@@ -256,16 +260,47 @@ fun MessageDigest.hashFor(input: InputStream): ByteArray {
 
 /**
  * Helper functions for XML documents.
+ * Note that creating factories is EXPENSIVE.
+ * Disable any JAXP features that may be flagged by a security audit.
  */
+private val documentBuilderFactory = DocumentBuilderFactory.newInstance().apply {
+    setFeature(FEATURE_SECURE_PROCESSING, true)
+    disableProperty(ACCESS_EXTERNAL_SCHEMA)
+    disableProperty(ACCESS_EXTERNAL_DTD)
+    isNamespaceAware = true
+}
+
+fun DocumentBuilderFactory.disableProperty(propertyName: String) {
+    try {
+        setAttribute(propertyName, "")
+    } catch (_: IllegalArgumentException) {
+        // Property not supported.
+    }
+}
+
 fun createXmlDocument(): Document {
-    return DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument().also { doc ->
-        doc.xmlStandalone = true
+    return documentBuilderFactory.newDocumentBuilder().newDocument().apply {
+        xmlStandalone = true
+    }
+}
+
+private val transformerFactory = TransformerFactory.newInstance().apply {
+    setFeature(FEATURE_SECURE_PROCESSING, true)
+    disableProperty(ACCESS_EXTERNAL_STYLESHEET)
+    disableProperty(ACCESS_EXTERNAL_DTD)
+}
+
+private fun TransformerFactory.disableProperty(propertyName: String) {
+    try {
+        setAttribute(propertyName, "")
+    } catch (_: IllegalArgumentException) {
+        // Property not supported.
     }
 }
 
 @Throws(TransformerException::class)
 fun Document.writeTo(writer: Writer) {
-    val transformer = TransformerFactory.newInstance().newTransformer()
+    val transformer = transformerFactory.newTransformer()
     transformer.setOutputProperty(METHOD, "xml")
     transformer.setOutputProperty(ENCODING, "UTF-8")
     transformer.setOutputProperty(INDENT, "yes")

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/DependencyCalculator.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/DependencyCalculator.kt
@@ -41,7 +41,7 @@ open class DependencyCalculator @Inject constructor(objects: ObjectFactory) : De
 
     init {
         description = "Computes this CorDapp's dependencies."
-        group = GROUP_NAME
+        group = CORDAPP_TASK_GROUP
 
         // Force this task to execute!
         outputs.upToDateWhen(satisfyNone())

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/DependencyConstraintsTask.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/DependencyConstraintsTask.kt
@@ -26,7 +26,7 @@ import javax.inject.Inject
 open class DependencyConstraintsTask @Inject constructor(objects: ObjectFactory) : DefaultTask() {
     init {
         description = "Computes the constraints for this CorDapp's library dependencies."
-        group = GROUP_NAME
+        group = CORDAPP_TASK_GROUP
     }
 
     private val _libraries: ConfigurableFileCollection = objects.fileCollection()
@@ -60,7 +60,7 @@ open class DependencyConstraintsTask @Inject constructor(objects: ObjectFactory)
 
         try {
             val xmlDocument = createXmlDocument()
-            val dependencyConstraints = xmlDocument.createRootElement(XML_NAMESPACE, "dependencyConstraints")
+            val dependencyConstraints = xmlDocument.createRootElement(CPK_XML_NAMESPACE, "dependencyConstraints")
             val encoder = Base64.getEncoder()
 
             libraries.forEach { library ->

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/PackagingTask.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/PackagingTask.kt
@@ -81,7 +81,7 @@ open class PackagingTask @Inject constructor(objects: ObjectFactory) : Jar() {
 
     init {
         description = "Builds the CorDapp CPK package."
-        group = GROUP_NAME
+        group = CORDAPP_TASK_GROUP
 
         manifest {
             it.attributes(linkedMapOf(

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/SignJar.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/SignJar.kt
@@ -81,7 +81,7 @@ open class SignJar @Inject constructor(objects: ObjectFactory) : DefaultTask() {
 
     init {
         description = "Signs the given jars using the configuration from cordapp.signing.options."
-        group = GROUP_NAME
+        group = CORDAPP_TASK_GROUP
         inputs.nested("signing", signing)
     }
 

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/VerifyBundle.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/VerifyBundle.kt
@@ -30,7 +30,7 @@ import javax.inject.Inject
 open class VerifyBundle @Inject constructor(objects: ObjectFactory) : DefaultTask() {
     init {
         description = "Verifies that a bundle's OSGi meta-data is consistent."
-        group = GROUP_NAME
+        group = CORDAPP_TASK_GROUP
     }
 
     @get:PathSensitive(RELATIVE)

--- a/cordapp-cpk/src/test/java/net/corda/plugins/cpk/xml/XMLFactory.java
+++ b/cordapp-cpk/src/test/java/net/corda/plugins/cpk/xml/XMLFactory.java
@@ -1,0 +1,44 @@
+package net.corda.plugins.cpk.xml;
+
+import org.jetbrains.annotations.NotNull;
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import javax.xml.validation.SchemaFactory;
+
+import static javax.xml.XMLConstants.ACCESS_EXTERNAL_DTD;
+import static javax.xml.XMLConstants.ACCESS_EXTERNAL_SCHEMA;
+import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
+import static javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI;
+
+/**
+ * Workaround for a Kotlin compiler bug.
+ * When Gradle runs on Java 11, the Kotlin compiler finds the {@link XMLConstants}
+ * class inside {@code gradle-api-$version.jar} rather than the JDK's built-in
+ * class. Unfortunately, Gradle's version predates JAXP 1.5, and so is missing
+ * {@link XMLConstants#ACCESS_EXTERNAL_DTD}, {@link XMLConstants#ACCESS_EXTERNAL_SCHEMA}
+ * and {@link XMLConstants#ACCESS_EXTERNAL_STYLESHEET}.
+ * The Java compiler does not have this problem.
+ */
+final class XMLFactory {
+    /**
+     * Create a JAXP SchemaFactory.
+     * Disable any features that may be flagged by a security audit.
+     */
+    @NotNull
+    static SchemaFactory createSchemaFactory() throws SAXException {
+        SchemaFactory factory = SchemaFactory.newInstance(W3C_XML_SCHEMA_NS_URI);
+        factory.setFeature(FEATURE_SECURE_PROCESSING, true);
+        disableProperty(factory, ACCESS_EXTERNAL_SCHEMA);
+        disableProperty(factory, ACCESS_EXTERNAL_DTD);
+        return factory;
+    }
+
+    private static void disableProperty(@NotNull SchemaFactory factory, String propertyName) {
+        try {
+            factory.setProperty(propertyName, "");
+        } catch (SAXException e) {
+            // Property not supported.
+        }
+    }
+}

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/GradleProject.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/GradleProject.kt
@@ -54,6 +54,8 @@ fun toOSGiRange(version: String): String {
         .toString().replace(".0","")
 }
 
+fun createDocumentBuilderFactory() = XMLFactory.createDocumentBuilderFactory()
+
 val Path.manifest: Manifest get() = JarFile(toFile()).use(JarFile::getManifest)
 
 val List<HashValue>.allSHA256: Boolean get() = isNotEmpty() && all(HashValue::isSHA256)

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/xml/XmlSchema.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/xml/XmlSchema.kt
@@ -1,17 +1,59 @@
 @file:JvmName("XmlSchema")
 package net.corda.plugins.cpk.xml
 
+import net.corda.plugins.cpk.disableProperty
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.fail
 import org.w3c.dom.Document
 import org.w3c.dom.Element
 import org.w3c.dom.Node
 import org.w3c.dom.NodeList
+import org.xml.sax.ErrorHandler
+import org.xml.sax.SAXNotRecognizedException
+import org.xml.sax.SAXParseException
 import java.io.InputStream
+import java.lang.invoke.MethodHandles
 import java.util.Base64
 import java.util.Collections.emptyIterator
 import java.util.Collections.unmodifiableList
+import javax.xml.XMLConstants.ACCESS_EXTERNAL_DTD
+import javax.xml.XMLConstants.ACCESS_EXTERNAL_SCHEMA
+import javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING
+import javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI
 import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.validation.SchemaFactory
+
+private const val CORDA_CPK_V1 = "/xml/corda-cpk-1.0.xsd"
+
+/**
+ * Create expensive [DocumentBuilderFactory] once, for all tests.
+ * Disable any JAXP features that may be flagged by a security audit.
+ */
+private val documentBuilderFactory = DocumentBuilderFactory.newInstance().also { dbf ->
+    dbf.setFeature(FEATURE_SECURE_PROCESSING, true)
+    dbf.disableProperty(ACCESS_EXTERNAL_SCHEMA)
+    dbf.disableProperty(ACCESS_EXTERNAL_DTD)
+    dbf.isExpandEntityReferences = false
+    dbf.isIgnoringComments = true
+    dbf.isNamespaceAware = true
+
+    val cpkSchema = SchemaFactory.newInstance(W3C_XML_SCHEMA_NS_URI).also { sf ->
+        sf.setFeature(FEATURE_SECURE_PROCESSING, true)
+        sf.disableProperty(ACCESS_EXTERNAL_SCHEMA)
+        sf.disableProperty(ACCESS_EXTERNAL_DTD)
+    }.newSchema(
+        MethodHandles.lookup().lookupClass().getResource(CORDA_CPK_V1) ?: fail("Corda CPK schema missing")
+    )
+    dbf.schema = cpkSchema
+}
+
+private fun SchemaFactory.disableProperty(propertyName: String) {
+    try {
+        setProperty(propertyName, "")
+    } catch(_: SAXNotRecognizedException) {
+        // Property not supported.
+    }
+}
 
 private class ElementIterator(private val nodes: NodeList) : Iterator<Element> {
     private var index = 0
@@ -195,7 +237,23 @@ class DependencyConstraintsBuilder(private val node: Node): AbstractBuilder<List
 }
 
 private fun loadDocumentFrom(input: InputStream): Document {
-    return DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(input)
+    return documentBuilderFactory.newDocumentBuilder().apply {
+        setErrorHandler(UnforgivingErrorHandler())
+    }.parse(input)
+}
+
+private class UnforgivingErrorHandler : ErrorHandler {
+    override fun warning(ex: SAXParseException) {
+        fail(ex.message)
+    }
+
+    override fun error(ex: SAXParseException) {
+        fail(ex.message)
+    }
+
+    override fun fatalError(ex: SAXParseException) {
+        fail(ex.message)
+    }
 }
 
 fun loadCPKDependencies(input: InputStream): List<CPKDependency> {

--- a/cordapp-cpk/src/test/resources/xml/corda-cpk-1.0.xsd
+++ b/cordapp-cpk/src/test/resources/xml/corda-cpk-1.0.xsd
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema elementFormDefault="qualified" targetNamespace="urn:corda-cpk" version="1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:cpk="urn:corda-cpk">
+    <xs:element name="cpkDependencies" type="cpk:cpkDependenciesType"/>
+    <xs:element name="dependencyConstraints" type="cpk:dependencyConstraintsType"/>
+
+    <xs:complexType name="hashType">
+        <xs:simpleContent>
+            <xs:extension base="xs:base64Binary">
+                <xs:attribute name="algorithm" type="xs:token" use="required"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="cpkDependenciesType">
+        <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="cpkDependency" type="cpk:cpkDependencyType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="cpkDependencyType">
+        <xs:all>
+            <xs:element name="name" type="xs:token"/>
+            <xs:element name="version" type="xs:token"/>
+            <xs:element name="signers" type="cpk:signersType"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="signersType">
+        <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="signer" type="cpk:hashType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="dependencyConstraintsType">
+        <xs:sequence>
+            <xs:element maxOccurs="unbounded" minOccurs="0" name="dependencyConstraint" type="cpk:dependencyConstraintType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="dependencyConstraintType">
+        <xs:all>
+            <xs:element name="fileName" type="xs:token"/>
+            <xs:element name="hash" type="cpk:hashType"/>
+        </xs:all>
+    </xs:complexType>
+</xs:schema>


### PR DESCRIPTION
- Create a schema XSD describing the CorDapp `CPKDependencies` and `DependencyConstraints` XML documents, and update tests to validate them both against it.
- Prefix XML namespace with `urn:` to make a valid URI (as required).
- Apply "best practices" for JAXP.
- Rewrite JAXP factories in Java to work around a problem with the Kotlin compiler.