### PR TITLE
CORE-1390: Compute the highest platform version used by the CorDapp.

### DIFF
--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappApiLibraryTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappApiLibraryTest.kt
@@ -1,0 +1,87 @@
+package net.corda.plugins.cpk
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestReporter
+import org.junit.jupiter.api.io.TempDir
+import org.osgi.framework.Constants.BUNDLE_LICENSE
+import org.osgi.framework.Constants.BUNDLE_NAME
+import org.osgi.framework.Constants.BUNDLE_SYMBOLICNAME
+import org.osgi.framework.Constants.BUNDLE_VENDOR
+import org.osgi.framework.Constants.BUNDLE_VERSION
+import org.osgi.framework.Constants.IMPORT_PACKAGE
+import java.nio.file.Path
+
+class CordappApiLibraryTest {
+    companion object {
+        private const val CONTRACT_CORDAPP_VERSION = "1.1.5-SNAPSHOT"
+        private const val WORKFLOW_CORDAPP_VERSION = "2.6.3-SNAPSHOT"
+        private const val expectedContractGuavaVersion = "29.0-jre"
+        private const val expectedWorkflowGuavaVersion = "19.0"
+        private lateinit var testProject: GradleProject
+
+        @Suppress("unused")
+        @BeforeAll
+        @JvmStatic
+        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+            // Check that the Workflow CorDapp is using a lower version
+            // of Guava than the Contract CorDapp.
+            assertThat(osgiVersion(expectedWorkflowGuavaVersion))
+                .isLessThan(osgiVersion(expectedContractGuavaVersion))
+
+            testProject = GradleProject(testProjectDir, reporter)
+                .withTestName("cordapp-api-library")
+                .withSubResource("src/main/kotlin/com/example/workflow/ExampleWorkflow.kt")
+                .withSubResource("cordapp/build.gradle")
+                .build(
+                    "-Pcorda_api_version=$cordaApiVersion",
+                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                    "-Pcordapp_workflow_version=$expectedCordappWorkflowVersion",
+                    "-Pcontract_cordapp_version=$CONTRACT_CORDAPP_VERSION",
+                    "-Pcontract_guava_version=$expectedContractGuavaVersion",
+                    "-Pworkflow_cordapp_version=$WORKFLOW_CORDAPP_VERSION",
+                    "-Pworkflow_guava_version=$expectedWorkflowGuavaVersion"
+                )
+        }
+    }
+
+    @Test
+    fun hasCordappApiLibrary() {
+        assertThat(testProject.dependencyConstraints)
+            .anyMatch { it.fileName == "guava-${expectedWorkflowGuavaVersion}.jar" }
+            .allMatch { it.hash.isSHA256 }
+            .hasSizeGreaterThanOrEqualTo(1)
+        assertThat(testProject.cpkDependencies)
+            .anyMatch { it.name == "com.example.cordapp" && it.version == toOSGi(CONTRACT_CORDAPP_VERSION) }
+            .allMatch { it.signers.allSHA256 }
+            .hasSize(1)
+
+        val artifacts = testProject.artifacts
+        assertThat(artifacts).hasSize(2)
+
+        val cpk = artifacts.single { it.toString().endsWith(".cpk") }
+        assertThat(cpk).isRegularFile()
+
+        val cordapp = artifacts.single { it.toString().endsWith(".jar") }
+        assertThat(cordapp).isRegularFile()
+
+        val jarManifest = cordapp.manifest
+        println(jarManifest.mainAttributes.entries)
+
+        with(jarManifest.mainAttributes) {
+            assertEquals("Cordapp API Library", getValue(CORDAPP_WORKFLOW_NAME))
+            assertEquals("Cordapp API Library", getValue(BUNDLE_NAME))
+            assertEquals("com.example.cordapp-api-library", getValue(BUNDLE_SYMBOLICNAME))
+            assertEquals(toOSGi(WORKFLOW_CORDAPP_VERSION), getValue(BUNDLE_VERSION))
+            assertEquals("Test-Licence", getValue(BUNDLE_LICENSE))
+            assertEquals("R3", getValue(BUNDLE_VENDOR))
+            assertEquals("true", getValue("Sealed"))
+
+            assertThatHeader(getValue(IMPORT_PACKAGE)).containsPackageWithAttributes(
+                "com.google.common.collect", "version=${toOSGiRange(expectedWorkflowGuavaVersion)}"
+            )
+        }
+    }
+}

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/SimpleCordappTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/SimpleCordappTest.kt
@@ -68,6 +68,7 @@ class SimpleCordappTest {
         println(jarManifest.mainAttributes.entries)
 
         with(jarManifest.mainAttributes) {
+            assertEquals(testPlatformVersion, getValue(CORDAPP_PLATFORM_VERSION))
             assertEquals("Simple Java", getValue(BUNDLE_NAME))
             assertEquals("com.example.simple-cordapp", getValue(BUNDLE_SYMBOLICNAME))
             assertEquals(toOSGi(cordappVersion), getValue(BUNDLE_VERSION))

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/SimpleKotlinCordappTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/SimpleKotlinCordappTest.kt
@@ -74,6 +74,7 @@ class SimpleKotlinCordappTest {
         println(jarManifest.mainAttributes.entries)
 
         with(jarManifest.mainAttributes) {
+            assertEquals(testPlatformVersion, getValue(CORDAPP_PLATFORM_VERSION))
             assertEquals("Simple Kotlin", getValue(BUNDLE_NAME))
             assertEquals("com.example.simple-kotlin-cordapp", getValue(BUNDLE_SYMBOLICNAME))
             assertEquals(toOSGi(cordappVersion), getValue(BUNDLE_VERSION))

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithCordaMetadataTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithCordaMetadataTest.kt
@@ -75,6 +75,8 @@ class WithCordaMetadataTest {
         val contractJar = testProject.artifacts.single { it.toString().endsWith("contracts-$CONTRACT_CORDAPP_VERSION.jar") }
         assertThat(contractJar).isRegularFile()
         with(contractJar.manifest.mainAttributes) {
+            assertThat(getValue(CORDAPP_PLATFORM_VERSION))
+                .isEqualTo(testPlatformVersion)
             assertThat(getValue(CORDA_CONTRACT_CLASSES))
                 .isEqualTo("com.example.metadata.contracts.ExampleContract,com.example.metadata.contracts.ExampleContract\$NestedContract")
             assertThat(getValue(CORDA_MAPPED_SCHEMA_CLASSES))
@@ -112,6 +114,7 @@ class WithCordaMetadataTest {
             assertThat(getValue(CPK_CORDAPP_VERSION)).isEqualTo(toOSGi(CONTRACT_CORDAPP_VERSION))
             assertThat(getValue(CPK_CORDAPP_LICENCE)).isEqualTo(TEST_LICENCE)
             assertThat(getValue(CPK_CORDAPP_VENDOR)).isEqualTo(TEST_VENDOR)
+            assertThat(getValue(CPK_PLATFORM_VERSION)).isEqualTo(testPlatformVersion)
         }
     }
 
@@ -120,6 +123,8 @@ class WithCordaMetadataTest {
         val workflowJar = testProject.artifacts.single { it.toString().endsWith("workflows-$WORKFLOW_CORDAPP_VERSION.jar") }
         assertThat(workflowJar).isRegularFile()
         with(workflowJar.manifest.mainAttributes) {
+            assertThat(getValue(CORDAPP_PLATFORM_VERSION))
+                .isEqualTo(testPlatformVersion)
             assertThat(getValue(CORDA_WORKFLOW_CLASSES))
                 .isEqualTo("com.example.metadata.workflows.ExampleFlow,com.example.metadata.workflows.ExampleFlow\$NestedFlow")
             assertThat(getValue(CORDA_CONTRACT_CLASSES)).isNull()
@@ -155,6 +160,7 @@ class WithCordaMetadataTest {
             assertThat(getValue(CPK_CORDAPP_VERSION)).isEqualTo(toOSGi(WORKFLOW_CORDAPP_VERSION))
             assertThat(getValue(CPK_CORDAPP_LICENCE)).isEqualTo(TEST_LICENCE)
             assertThat(getValue(CPK_CORDAPP_VENDOR)).isEqualTo(TEST_VENDOR)
+            assertThat(getValue(CPK_PLATFORM_VERSION)).isEqualTo(testPlatformVersion)
         }
     }
 
@@ -163,6 +169,8 @@ class WithCordaMetadataTest {
         val serviceJar = testProject.artifacts.single { it.toString().endsWith("services-$SERVICE_CORDAPP_VERSION.jar") }
         assertThat(serviceJar).isRegularFile()
         with(serviceJar.manifest.mainAttributes) {
+            assertThat(getValue(CORDAPP_PLATFORM_VERSION))
+                .isEqualTo(testPlatformVersion)
             assertThat(getValue(CORDA_SERVICE_CLASSES))
                 .isEqualTo("com.example.metadata.services.ExampleService")
             assertThat(getValue(CORDA_WORKFLOW_CLASSES)).isNull()
@@ -198,6 +206,7 @@ class WithCordaMetadataTest {
             assertThat(getValue(CPK_CORDAPP_VERSION)).isEqualTo(toOSGi(SERVICE_CORDAPP_VERSION))
             assertThat(getValue(CPK_CORDAPP_LICENCE)).isEqualTo(TEST_LICENCE)
             assertThat(getValue(CPK_CORDAPP_VENDOR)).isEqualTo(TEST_VENDOR)
+            assertThat(getValue(CPK_PLATFORM_VERSION)).isEqualTo(testPlatformVersion)
         }
     }
 }

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithProvidedLibraryTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithProvidedLibraryTest.kt
@@ -1,0 +1,63 @@
+package net.corda.plugins.cpk
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestReporter
+import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.osgi.framework.Constants.BUNDLE_LICENSE
+import org.osgi.framework.Constants.BUNDLE_NAME
+import org.osgi.framework.Constants.BUNDLE_SYMBOLICNAME
+import org.osgi.framework.Constants.BUNDLE_VENDOR
+import org.osgi.framework.Constants.BUNDLE_VERSION
+import java.nio.file.Path
+
+class WithProvidedLibraryTest {
+    companion object {
+        private const val cordappVersion = "1.0.2-SNAPSHOT"
+        private lateinit var testProject: GradleProject
+
+        @Suppress("unused")
+        @BeforeAll
+        @JvmStatic
+        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+            testProject = GradleProject(testProjectDir, reporter)
+                .withTestName("with-provided-library")
+                .withSubResource("library/build.gradle")
+                .build(
+                    "-Pcordapp_version=$cordappVersion",
+                    "-Pcorda_api_version=$cordaApiVersion",
+                    "-Pcordapp_contract_version=$expectedCordappContractVersion"
+                )
+        }
+    }
+
+    @Test
+    fun hasProvidedLibrary() {
+        assertThat(testProject.dependencyConstraints).isEmpty()
+        assertThat(testProject.cpkDependencies).isEmpty()
+
+        val artifacts = testProject.artifacts
+        assertThat(artifacts).hasSize(2)
+
+        val cpk = artifacts.single { it.toString().endsWith(".cpk") }
+        assertThat(cpk).isRegularFile()
+
+        val cordapp = artifacts.single { it.toString().endsWith(".jar") }
+        assertThat(cordapp).isRegularFile()
+
+        val jarManifest = cordapp.manifest
+        println(jarManifest.mainAttributes.entries)
+
+        with(jarManifest.mainAttributes) {
+            assertEquals("1500", getValue(CORDAPP_PLATFORM_VERSION))
+            assertEquals("With Provided Library", getValue(BUNDLE_NAME))
+            assertEquals("com.example.with-provided-library", getValue(BUNDLE_SYMBOLICNAME))
+            assertEquals(toOSGi(cordappVersion), getValue(BUNDLE_VERSION))
+            assertEquals("Test-Licence", getValue(BUNDLE_LICENSE))
+            assertEquals("R3", getValue(BUNDLE_VENDOR))
+            assertEquals("true", getValue("Sealed"))
+        }
+    }
+}

--- a/cordapp-cpk/src/test/resources/corda-api/build.gradle
+++ b/cordapp-cpk/src/test/resources/corda-api/build.gradle
@@ -18,12 +18,16 @@ repositories {
 
 dependencies {
     compileOnly "org.osgi:osgi.annotation:$osgi_version"
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    api "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
     api "javax.persistence:javax.persistence-api:$persistence_api_version"
     runtimeOnly "com.google.guava:guava:$corda_guava_version"
 }
 
 tasks.named('jar', Jar) {
+    manifest {
+        attributes('Corda-Platform-Version': 1000)
+    }
+
     bnd """\
 Bundle-SymbolicName: net.corda.api
 Bundle-Name: Fake Corda APIs

--- a/cordapp-cpk/src/test/resources/cordapp-api-library/build.gradle
+++ b/cordapp-cpk/src/test/resources/cordapp-api-library/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id 'net.corda.plugins.cordapp-cpk'
+    id 'org.jetbrains.kotlin.jvm'
+}
+
+apply from: 'repositories.gradle'
+apply from: 'javaTarget.gradle'
+apply from: 'kotlin.gradle'
+
+version = workflow_cordapp_version
+
+allprojects {
+    group = 'com.example'
+}
+
+cordapp {
+    targetPlatformVersion = platform_version.toInteger()
+    minimumPlatformVersion = platform_version.toInteger()
+
+    workflow {
+        name = 'Cordapp API Library'
+        versionId = cordapp_workflow_version.toInteger()
+        licence = 'Test-Licence'
+        vendor = 'R3'
+    }
+}
+
+jar {
+    archiveBaseName = 'cordapp-api-library'
+}
+
+dependencies {
+    cordaProvided project(':corda-api')
+    cordapp project(':cordapp')
+    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    implementation "com.google.guava:guava:$workflow_guava_version"
+}

--- a/cordapp-cpk/src/test/resources/cordapp-api-library/cordapp/build.gradle
+++ b/cordapp-cpk/src/test/resources/cordapp-api-library/cordapp/build.gradle
@@ -5,12 +5,14 @@ plugins {
 apply from: '../repositories.gradle'
 apply from: '../javaTarget.gradle'
 
+version = contract_cordapp_version
+
 cordapp {
     targetPlatformVersion = platform_version.toInteger()
     minimumPlatformVersion = platform_version.toInteger()
 
     contract {
-        name = 'Cordapp'
+        name = 'Contract Cordapp'
         versionId = cordapp_contract_version.toInteger()
         licence = 'Test-Licence'
         vendor = 'R3'
@@ -19,15 +21,9 @@ cordapp {
 
 jar {
     archiveBaseName = 'cordapp'
-    doFirst {
-        configurations.compileClasspath.forEach { dep ->
-            println "COMPILE-CONTRACT> ${dep.name}"
-        }
-    }
 }
 
 dependencies {
     cordaProvided project(':corda-api')
-    implementation "commons-io:commons-io:$commons_io_version"
-    implementation project(':library')
+    api "com.google.guava:guava:$contract_guava_version"
 }

--- a/cordapp-cpk/src/test/resources/cordapp-api-library/settings.gradle
+++ b/cordapp-cpk/src/test/resources/cordapp-api-library/settings.gradle
@@ -1,0 +1,12 @@
+pluginManagement {
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version kotlin_version
+        id 'biz.aQute.bnd.builder' version bnd_version
+    }
+}
+
+rootProject.name = 'cordapp-api-library'
+
+include 'cordapp'
+include 'corda-api'
+project(':corda-api').projectDir = file('../resources/test/corda-api')

--- a/cordapp-cpk/src/test/resources/cordapp-api-library/src/main/kotlin/com/example/workflow/ExampleWorkflow.kt
+++ b/cordapp-cpk/src/test/resources/cordapp-api-library/src/main/kotlin/com/example/workflow/ExampleWorkflow.kt
@@ -1,0 +1,11 @@
+@file:Suppress("PackageDirectoryMismatch")
+package com.example.workflow
+
+import com.google.common.collect.ImmutableSet
+import net.corda.v5.application.flows.Flow
+
+class ExampleWorkflow : Flow<Set<String>> {
+    override fun call(): Set<String> {
+        return ImmutableSet.of("Hello World!")
+    }
+}

--- a/cordapp-cpk/src/test/resources/with-dependent-cordapp/build.gradle
+++ b/cordapp-cpk/src/test/resources/with-dependent-cordapp/build.gradle
@@ -23,10 +23,25 @@ cordapp {
 
 jar {
     archiveBaseName = 'with-dependent-cordapp'
+    doFirst {
+        configurations.compileClasspath.forEach { dep ->
+            println "COMPILE-WORKFLOW> ${dep.name}"
+        }
+    }
 }
 
 dependencies {
     cordapp project(':cordapp')
     cordaProvided project(':corda-api')
     implementation "com.google.guava:guava:$guava_version"
+}
+
+// Copy the DependencyConstraints XML from ':cordapp' into our build directory.
+def copy = tasks.register('copy', Copy) {
+    into project.layout.buildDirectory
+    from project(':cordapp').tasks.named('cordappDependencyConstraints')
+}
+
+tasks.named('assemble') {
+    dependsOn copy
 }

--- a/cordapp-cpk/src/test/resources/with-dependent-cordapp/library/build.gradle
+++ b/cordapp-cpk/src/test/resources/with-dependent-cordapp/library/build.gradle
@@ -14,5 +14,5 @@ dependencies {
     implementation "com.google.guava:guava:$library_guava_version"
 
     // Corda depends on a more recent version of SLF4J API.
-    implementation "org.slf4j:slf4j-api:1.7.21"
+    api "org.slf4j:slf4j-api:$slf4j_version"
 }

--- a/cordapp-cpk/src/test/resources/with-provided-library/build.gradle
+++ b/cordapp-cpk/src/test/resources/with-provided-library/build.gradle
@@ -2,15 +2,21 @@ plugins {
     id 'net.corda.plugins.cordapp-cpk'
 }
 
-apply from: '../repositories.gradle'
-apply from: '../javaTarget.gradle'
+apply from: 'repositories.gradle'
+apply from: 'javaTarget.gradle'
+
+version = cordapp_version
+
+allprojects {
+    group = 'com.example'
+}
 
 cordapp {
     targetPlatformVersion = platform_version.toInteger()
     minimumPlatformVersion = platform_version.toInteger()
 
     contract {
-        name = 'Cordapp'
+        name = 'With Provided Library'
         versionId = cordapp_contract_version.toInteger()
         licence = 'Test-Licence'
         vendor = 'R3'
@@ -18,16 +24,10 @@ cordapp {
 }
 
 jar {
-    archiveBaseName = 'cordapp'
-    doFirst {
-        configurations.compileClasspath.forEach { dep ->
-            println "COMPILE-CONTRACT> ${dep.name}"
-        }
-    }
+    archiveBaseName = 'with-provided-library'
 }
 
 dependencies {
     cordaProvided project(':corda-api')
-    implementation "commons-io:commons-io:$commons_io_version"
-    implementation project(':library')
+    cordaProvided project(':library')
 }

--- a/cordapp-cpk/src/test/resources/with-provided-library/library/build.gradle
+++ b/cordapp-cpk/src/test/resources/with-provided-library/library/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+    id 'java-library'
+}
+
+apply from: '../repositories.gradle'
+apply from: '../javaTarget.gradle'
+
+jar {
+    archiveBaseName = 'library'
+    manifest {
+        attributes('Corda-Platform-Version': 1500)
+    }
+}

--- a/cordapp-cpk/src/test/resources/with-provided-library/settings.gradle
+++ b/cordapp-cpk/src/test/resources/with-provided-library/settings.gradle
@@ -1,0 +1,12 @@
+pluginManagement {
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version kotlin_version
+        id 'biz.aQute.bnd.builder' version bnd_version
+    }
+}
+
+rootProject.name = 'with-provided-library'
+
+include 'library'
+include 'corda-api'
+project(':corda-api').projectDir = file('../resources/test/corda-api')


### PR DESCRIPTION
- Compute `Cordapp-Built-Platform-Version` manifest tag for each "main" jar.
- Copy `Cordapp-Built-Platform-Version` into CPK manifest as `Corda-CPK-Built-Platform-Version`.
- Remove any transitive dependencies belonging to dependent CPKs from our compile classpath. This
allows us to simplify how we create the Gradle configurations.

Also extend the test coverage to examine the compile classpaths when building CorDapps.