### PR TITLE
CORE-1434: Warn if `@Suspendable` not configured for quasar-utils.

### DIFF
--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappPlugin.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappPlugin.kt
@@ -92,6 +92,7 @@ class CordappPlugin @Inject constructor(private val layouts: ProjectLayout): Plu
         cordapp = project.extensions.create(CORDAPP_EXTENSION_NAME, CordappExtension::class.java, bndVersion)
 
         project.configurations.apply {
+            // This definition of cordaRuntimeOnly must be kept aligned with the one in the quasar-utils plugin.
             createRuntimeOnlyConfiguration(CORDA_RUNTIME_ONLY_CONFIGURATION_NAME)
             maybeCreate(CORDA_CPK_CONFIGURATION_NAME).isCanBeResolved = false
 
@@ -121,6 +122,7 @@ class CordappPlugin @Inject constructor(private val layouts: ProjectLayout): Plu
                     }
                 }
 
+            // This definition of cordaProvided must be kept aligned with the one in the quasar-utils plugin.
             val cordaProvided = createCompileConfiguration(CORDA_PROVIDED_CONFIGURATION_NAME)
 
             // Unlike cordaProvided dependencies, cordaPrivateProvided ones will not be

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappUtils.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappUtils.kt
@@ -84,16 +84,14 @@ fun Dependency.toMaven(): String {
 }
 
 private fun ConfigurationContainer.createChildConfiguration(name: String, parent: Configuration): Configuration {
-    return findByName(name) ?: run {
-        val configuration = create(name) {
-            it.isCanBeConsumed = false
-            it.isCanBeResolved = false
-            it.isTransitive = false
-            it.isVisible = false
+    return maybeCreate(name)
+        .setTransitive(false)
+        .setVisible(false)
+        .also { configuration ->
+            configuration.isCanBeConsumed = false
+            configuration.isCanBeResolved = false
+            parent.extendsFrom(configuration)
         }
-        parent.extendsFrom(configuration)
-        configuration
-    }
 }
 
 fun ConfigurationContainer.createRuntimeOnlyConfiguration(name: String): Configuration {
@@ -110,17 +108,16 @@ fun ConfigurationContainer.createCompileConfiguration(name: String): Configurati
 }
 
 private fun ConfigurationContainer.createCompileConfiguration(name: String, testSuffix: String): Configuration {
-    return findByName(name) ?: run {
-        val configuration = maybeCreate(name).setVisible(false).apply {
-            isCanBeConsumed = false
-            isCanBeResolved = false
+    return maybeCreate(name)
+        .setVisible(false)
+        .also { configuration ->
+            configuration.isCanBeConsumed = false
+            configuration.isCanBeResolved = false
+            getByName(COMPILE_ONLY_CONFIGURATION_NAME).extendsFrom(configuration)
+            matching { it.name.endsWith(testSuffix) }.configureEach { cfg ->
+                cfg.extendsFrom(configuration)
+            }
         }
-        getByName(COMPILE_ONLY_CONFIGURATION_NAME).extendsFrom(configuration)
-        matching { it.name.endsWith(testSuffix) }.configureEach { cfg ->
-            cfg.extendsFrom(configuration)
-        }
-        configuration
-    }
 }
 
 /**

--- a/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarExtension.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarExtension.groovy
@@ -5,8 +5,9 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-
 import javax.inject.Inject
+
+import static net.corda.plugins.quasar.QuasarPlugin.QUASAR_ARTIFACT_NAME
 
 class QuasarExtension {
 
@@ -65,7 +66,7 @@ class QuasarExtension {
         group = objects.property(String).convention(defaultGroup)
         version = objects.property(String).convention(defaultVersion)
         dependency = group.zip(version) { grp, ver ->
-            [ group: grp, name: 'quasar-core-osgi', version: ver, ext: 'jar' ]
+            [ group: grp, name: QUASAR_ARTIFACT_NAME, version: ver, ext: 'jar' ]
         }
         agent = dependency.map {
             it['classifier'] = 'agent'

--- a/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarPlugin.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarPlugin.groovy
@@ -126,15 +126,12 @@ class QuasarPlugin implements Plugin<Project> {
     }
 
     private static Configuration createRuntimeOnlyConfiguration(String name, ConfigurationContainer configurations) {
-        Configuration configuration = configurations.findByName(name)
-        if (configuration == null) {
-            configuration = configurations.create(name)
-            configuration.canBeConsumed = false
-            configuration.canBeResolved = false
-            configuration.transitive = false
-            configuration.visible = false
-            configurations.getByName(RUNTIME_ONLY_CONFIGURATION_NAME).extendsFrom(configuration)
-        }
+        Configuration configuration = configurations.maybeCreate(name)
+            .setTransitive(false)
+            .setVisible(false)
+        configuration.canBeConsumed = false
+        configuration.canBeResolved = false
+        configurations.getByName(RUNTIME_ONLY_CONFIGURATION_NAME).extendsFrom(configuration)
         return configuration
     }
 
@@ -143,15 +140,13 @@ class QuasarPlugin implements Plugin<Project> {
     }
 
     private static Configuration createCompileConfiguration(String name, String testSuffix, ConfigurationContainer configurations) {
-        Configuration configuration = configurations.findByName(name)
-        if (configuration == null) {
-            configuration = configurations.maybeCreate(name).setVisible(false)
-            configuration.canBeConsumed = false
-            configuration.canBeResolved = false
-            configurations.getByName(COMPILE_ONLY_CONFIGURATION_NAME).extendsFrom(configuration)
-            configurations.matching { it.name.endsWith(testSuffix) }.configureEach { cfg ->
-                cfg.extendsFrom(configuration)
-            }
+        Configuration configuration = configurations.maybeCreate(name)
+            .setVisible(false)
+        configuration.canBeConsumed = false
+        configuration.canBeResolved = false
+        configurations.getByName(COMPILE_ONLY_CONFIGURATION_NAME).extendsFrom(configuration)
+        configurations.matching { it.name.endsWith(testSuffix) }.configureEach { cfg ->
+            cfg.extendsFrom(configuration)
         }
         return configuration
     }

--- a/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarPlugin.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarPlugin.groovy
@@ -8,31 +8,34 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.DependencySet
 import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.logging.Logger
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.testing.Test
 import org.gradle.util.GradleVersion
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
 
 import static org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME
 import static org.gradle.api.plugins.JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME
-import org.gradle.api.tasks.JavaExec
-import org.gradle.api.tasks.testing.Test
-
-import javax.inject.Inject
 
 /**
  * QuasarPlugin creates "quasar" and "quasarAgent" configurations and adds Quasar as a dependency.
  */
 class QuasarPlugin implements Plugin<Project> {
 
-    private static final String QUASAR = "quasar"
-    private static final String QUASAR_AGENT = "quasarAgent"
-    private static final String MINIMUM_GRADLE_VERSION = "6.6"
-    private static final String CORDA_PROVIDED_CONFIGURATION_NAME = "cordaProvided"
-    private static final String CORDA_RUNTIME_ONLY_CONFIGURATION_NAME = "cordaRuntimeOnly"
-    @PackageScope static final String defaultGroup = "co.paralleluniverse"
-    @PackageScope static final String defaultVersion = "0.8.5_r3"
+    private static final String QUASAR = 'quasar'
+    private static final String QUASAR_AGENT = 'quasarAgent'
+    private static final String MINIMUM_GRADLE_VERSION = '6.6'
+    private static final String CORDA_PROVIDED_CONFIGURATION_NAME = 'cordaProvided'
+    private static final String CORDA_RUNTIME_ONLY_CONFIGURATION_NAME = 'cordaRuntimeOnly'
+    @PackageScope static final String QUASAR_ARTIFACT_NAME = 'quasar-core-osgi'
+    @PackageScope static final String defaultGroup = 'co.paralleluniverse'
+    @PackageScope static final String defaultVersion = '0.8.5_r3'
 
     private final ObjectFactory objects
 
@@ -62,22 +65,25 @@ class QuasarPlugin implements Plugin<Project> {
         def quasarExtension = project.extensions.create(QUASAR, QuasarExtension, objects,
             quasarGroup, quasarVersion, quasarSuspendable, quasarPackageExclusions, quasarClassLoaderExclusions)
 
-        addQuasarDependencies(project, quasarExtension)
-        configureQuasarTasks(project, quasarExtension)
+        QuasarAdapter quasarAdapter = new QuasarAdapter(quasarExtension, project.dependencies, project.logger)
+        addQuasarDependencies(project, quasarAdapter)
+        configureQuasarTasks(project, quasarAdapter)
     }
 
-    private void addQuasarDependencies(Project project, QuasarExtension extension) {
+    private void addQuasarDependencies(Project project, QuasarAdapter adapter) {
         def quasar = project.configurations.create(QUASAR)
+        quasar.visible = false
         quasar.withDependencies { dependencies ->
-            def quasarDependency = project.dependencies.create(extension.dependency.get()) { dep ->
+            def quasarDependency = adapter.createDependency { dep ->
                 dep.transitive = false
             }
             dependencies.add(quasarDependency)
         }
 
         def quasarAgent = project.configurations.create(QUASAR_AGENT)
+        quasarAgent.visible = false
         quasarAgent.withDependencies { dependencies ->
-            def quasarAgentDependency = project.dependencies.create(extension.agent.get()) { dep ->
+            def quasarAgentDependency = adapter.createAgent { dep ->
                 dep.transitive = false
             }
             dependencies.add(quasarAgentDependency)
@@ -86,25 +92,34 @@ class QuasarPlugin implements Plugin<Project> {
         // If we're building a JAR then also add the Quasar bundle to the appropriate configurations.
         project.pluginManager.withPlugin('java') {
             // Add Quasar bundle to the compile classpath WITHOUT any of its transitive dependencies.
+            // This definition of cordaProvided must be kept aligned with the one in the corda-cpk plugin.
             def cordaProvided = createCompileConfiguration(CORDA_PROVIDED_CONFIGURATION_NAME, project.configurations)
-            cordaProvided.withDependencies(new QuasarAction(project.dependencies, extension, false))
+            cordaProvided.withDependencies(new QuasarAction(adapter, false))
 
             // Instrumented code needs both the Quasar bundle and its transitive dependencies at runtime.
+            // The definition of cordaRuntimeOnly must be kept aligned with the one in the corda-cpk plugin.
             def cordaRuntimeOnly = createRuntimeOnlyConfiguration(CORDA_RUNTIME_ONLY_CONFIGURATION_NAME, project.configurations)
-            cordaRuntimeOnly.withDependencies(new QuasarAction(project.dependencies, extension, true))
+            cordaRuntimeOnly.withDependencies(new QuasarAction(adapter, true))
         }
     }
 
-    private void configureQuasarTasks(Project project, QuasarExtension extension) {
+    private void configureQuasarTasks(Project project, QuasarAdapter adapter) {
+        def quasarAgent = project.configurations[QUASAR_AGENT]
         project.tasks.withType(Test).configureEach {
             doFirst {
-                jvmArgs "-javaagent:${project.configurations[QUASAR_AGENT].singleFile}${extension.options.get()}",
+                if (adapter.withoutSuspendableAnnotation) {
+                    adapter.warnNoSuspendableAnnotation()
+                }
+                jvmArgs "-javaagent:${quasarAgent.singleFile}${adapter.options}",
                         "-Dco.paralleluniverse.fibers.verifyInstrumentation"
             }
         }
         project.tasks.withType(JavaExec).configureEach {
             doFirst {
-                jvmArgs "-javaagent:${project.configurations[QUASAR_AGENT].singleFile}${extension.options.get()}",
+                if (adapter.withoutSuspendableAnnotation) {
+                    adapter.warnNoSuspendableAnnotation()
+                }
+                jvmArgs "-javaagent:${quasarAgent.singleFile}${adapter.options}",
                         "-Dco.paralleluniverse.fibers.verifyInstrumentation"
             }
         }
@@ -114,7 +129,10 @@ class QuasarPlugin implements Plugin<Project> {
         Configuration configuration = configurations.findByName(name)
         if (configuration == null) {
             configuration = configurations.create(name)
+            configuration.canBeConsumed = false
+            configuration.canBeResolved = false
             configuration.transitive = false
+            configuration.visible = false
             configurations.getByName(RUNTIME_ONLY_CONFIGURATION_NAME).extendsFrom(configuration)
         }
         return configuration
@@ -127,7 +145,9 @@ class QuasarPlugin implements Plugin<Project> {
     private static Configuration createCompileConfiguration(String name, String testSuffix, ConfigurationContainer configurations) {
         Configuration configuration = configurations.findByName(name)
         if (configuration == null) {
-            configuration = configurations.create(name)
+            configuration = configurations.maybeCreate(name).setVisible(false)
+            configuration.canBeConsumed = false
+            configuration.canBeResolved = false
             configurations.getByName(COMPILE_ONLY_CONFIGURATION_NAME).extendsFrom(configuration)
             configurations.matching { it.name.endsWith(testSuffix) }.configureEach { cfg ->
                 cfg.extendsFrom(configuration)
@@ -136,29 +156,73 @@ class QuasarPlugin implements Plugin<Project> {
         return configuration
     }
 
-    private static class QuasarAction implements Action<DependencySet> {
-        private final DependencyHandler handler
-        private final QuasarExtension extension
-        private final boolean isTransitive
+    /**
+     * Define operations to perform using {@link QuasarExtension}
+     * once Gradle's configuration phase is complete.
+     */
+    private static final class QuasarAdapter {
+        private final AtomicBoolean warnFlag
+        private final QuasarExtension quasar
+        private final DependencyHandler dependencies
+        private final Logger logger
 
-        QuasarAction(DependencyHandler handler, QuasarExtension extension, boolean isTransitive) {
-            this.handler = handler
-            this.extension = extension
-            this.isTransitive = isTransitive
+        @PackageScope
+        QuasarAdapter(QuasarExtension quasar, DependencyHandler dependencies, Logger logger) {
+            this.warnFlag = new AtomicBoolean()
+            this.quasar = quasar
+            this.dependencies = dependencies
+            this.logger = logger
         }
 
-        @Override
-        void execute(DependencySet dependencies) {
-            if (isEmpty(extension.suspendableAnnotation)) {
-                def quasarDependency = handler.create(extension.dependency.get()) { dep ->
-                    dep.transitive = isTransitive
-                }
-                dependencies.add(quasarDependency)
+        String getOptions() {
+            quasar.options.get()
+        }
+
+        Dependency createAgent(Closure closure) {
+            dependencies.create(quasar.agent.get(), closure)
+        }
+
+        Dependency createDependency(Closure closure) {
+            dependencies.create(quasar.dependency.get(), closure)
+        }
+
+        boolean isWithoutSuspendableAnnotation() {
+            isEmpty(quasar.suspendableAnnotation)
+        }
+
+        void warnNoSuspendableAnnotation() {
+            if (!warnFlag.getAndSet(true)) {
+                logger.warn("""\
+WARNING: Quasar's @Suspendable annotation has not been configured!
+Define Gradle property 'quasar_suspendable_annotation' to be the class name of the @Suspendable annotation your project uses.
+Adding ${QUASAR_ARTIFACT_NAME} to the classpath, to make Quasar's built-in @Suspendable annotation available.""")
             }
         }
 
         private static boolean isEmpty(Property<String> property) {
             !property.isPresent() || property.get().isBlank()
+        }
+    }
+
+    private static final class QuasarAction implements Action<DependencySet> {
+        private final QuasarAdapter adapter
+        private final boolean isTransitive
+
+        @PackageScope
+        QuasarAction(QuasarAdapter adapter, boolean isTransitive) {
+            this.adapter = adapter
+            this.isTransitive = isTransitive
+        }
+
+        @Override
+        void execute(DependencySet dependencies) {
+            if (adapter.withoutSuspendableAnnotation) {
+                adapter.warnNoSuspendableAnnotation()
+                def quasarDependency = adapter.createDependency { dep ->
+                    dep.transitive = isTransitive
+                }
+                dependencies.add(quasarDependency)
+            }
         }
     }
 }

--- a/quasar-utils/src/test/groovy/net/corda/plugins/quasar/QuasarPluginTest.groovy
+++ b/quasar-utils/src/test/groovy/net/corda/plugins/quasar/QuasarPluginTest.groovy
@@ -185,7 +185,12 @@ apply plugin: 'net.corda.plugins.quasar-utils'
 
 task show {
     doFirst {
-        def configs = configurations.matching { it.name in ['quasar', 'quasarAgent', 'cordaRuntimeOnly', 'compileClasspath', 'cordaProvided', 'compileOnly', 'runtimeClasspath'] }
+        def configs = configurations.matching { it.name in [
+            'quasar',
+            'quasarAgent',
+            'compileClasspath',
+            'runtimeClasspath'
+        ] }
         configs.collectEntries { [(it.name):it] }.each { name, files ->
             files.each { file ->
                 println "\$name: \${file.name}"
@@ -196,9 +201,6 @@ task show {
 """, "show"
         assertThat(output.findAll { it.startsWith("quasar:") }).hasSize(1)
         assertThat(output.findAll { it.startsWith("quasarAgent:") }).hasSize(1)
-        assertThat(output.findAll { it.startsWith("cordaRuntimeOnly:") }).hasSize(1)
-        assertThat(output.findAll { it.startsWith("compileOnly:") }).hasSize(1)
-        assertThat(output.findAll { it.startsWith("cordaProvided:") }).hasSize(1)
         assertThat(output.findAll { it.startsWith("compileClasspath:") }).hasSize(1)
         assertThat(output.findAll { it.startsWith("runtimeClasspath:") }.size()).isGreaterThan(1)
     }


### PR DESCRIPTION
- Log a warning if the `quasar-utils` plugin has not been configured with an explicit `@Suspendable` annotation - either via the `quasar_suspendable_annotation` property or via the `quasar` DSL extension. This warning will only be displayed once per project.
- Ensure that the `cordaProvided` and `cordaRuntimeOnly` configurations defined by `quasar-utils` exactly match the same configurations created by the `cordapp-cpk` plugin. The point is that it shouldn't matter which plugin creates these configurations in practice.