### PR TITLE
CORE-268: Improve message for CPK validation errors.

### DIFF
--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/VerifyBundle.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/VerifyBundle.kt
@@ -76,6 +76,9 @@ open class VerifyBundle @Inject constructor(objects: ObjectFactory) : DefaultTas
                 for (error in verifier.errors) {
                     logger.error("{}: {}", jarName, error)
                 }
+                logger.error(
+                    "Ensure that dependencies are OSGi bundles, and that they export every package {} needs to import.",
+                        jarName)
                 throw InvalidUserDataException("Bundle $jarName has validation errors:"
                     + verifier.errors.joinToString(System.lineSeparator(), System.lineSeparator()))
             }


### PR DESCRIPTION
Bnd generates the validation error messages, but we can add some general advice afterwards about the probable cause of the underlying problems.