### PR TITLE
CORE-1589: Verify CPK OSGi imports match classpath exports.

### DIFF
--- a/cordapp-cpk/build.gradle
+++ b/cordapp-cpk/build.gradle
@@ -88,6 +88,7 @@ processTestResources {
             'persistence_api_version': test_persistence_api_version,
             'hibernate_version': test_hibernate_version,
             'corda_guava_version': corda_guava_version,
+            'corda_slf4j_version': slf4j_version,
             'osgi_version': osgi_version,
             'kotlin_version': test_kotlin_version,
             'java_home': System.getProperty('java.home'),

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/AttributeFactory.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/AttributeFactory.kt
@@ -1,0 +1,48 @@
+package net.corda.plugins.cpk
+
+import org.gradle.api.attributes.AttributeContainer
+import org.gradle.api.attributes.Bundling
+import org.gradle.api.attributes.Bundling.BUNDLING_ATTRIBUTE
+import org.gradle.api.attributes.Bundling.EXTERNAL
+import org.gradle.api.attributes.Category
+import org.gradle.api.attributes.Category.CATEGORY_ATTRIBUTE
+import org.gradle.api.attributes.Category.LIBRARY
+import org.gradle.api.attributes.LibraryElements
+import org.gradle.api.attributes.LibraryElements.JAR
+import org.gradle.api.attributes.LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE
+import org.gradle.api.attributes.Usage
+import org.gradle.api.attributes.Usage.JAVA_API
+import org.gradle.api.attributes.Usage.JAVA_RUNTIME
+import org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE
+import org.gradle.api.model.ObjectFactory
+
+class AttributeFactory(
+    private val attrs: AttributeContainer,
+    private val objects: ObjectFactory) {
+
+    fun javaRuntime(): AttributeFactory {
+        attrs.attribute(USAGE_ATTRIBUTE, objects.named(Usage::class.java, JAVA_RUNTIME))
+        return this
+    }
+
+    fun javaApi(): AttributeFactory {
+        attrs.attribute(USAGE_ATTRIBUTE, objects.named(Usage::class.java, JAVA_API))
+        return this
+    }
+
+    fun asLibrary(): AttributeFactory {
+        attrs.attribute(CATEGORY_ATTRIBUTE, objects.named(Category::class.java, LIBRARY))
+        return this
+    }
+
+    fun jar(): AttributeFactory {
+        attrs.attribute(LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements::class.java, JAR))
+        return this
+    }
+
+    fun withExternalDependencies(): AttributeFactory {
+        attrs.attribute(BUNDLING_ATTRIBUTE, objects.named(Bundling::class.java, EXTERNAL))
+        return this
+    }
+}
+

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappUtils.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappUtils.kt
@@ -39,6 +39,7 @@ const val CPK_XML_NAMESPACE = "urn:corda-cpk"
 const val CORDAPP_SEALING_SYSTEM_PROPERTY_NAME = "net.corda.cordapp.sealing.enabled"
 
 const val CORDAPP_CONFIGURATION_NAME = "cordapp"
+const val CORDAPP_EXTERNAL_CONFIGURATION_NAME = "cordappExternal"
 const val CORDAPP_PACKAGING_CONFIGURATION_NAME = "cordappPackaging"
 const val CORDA_RUNTIME_ONLY_CONFIGURATION_NAME = "cordaRuntimeOnly"
 const val CORDA_ALL_PROVIDED_CONFIGURATION_NAME = "cordaAllProvided"

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/DependencyCalculator.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/DependencyCalculator.kt
@@ -187,17 +187,16 @@ open class DependencyCalculator @Inject constructor(objects: ObjectFactory) : De
             disallowChanges()
         }
 
-        // Finally, work out which jars from the compile classpath are excluded from the runtime classpath.
+        // Finally, work out which jars we have used that have not been packaged into our CPK.
         // We still ignore anything that was for "compile only", because we only want to validate packages
         // that will be available at runtime.
-        val compileConfiguration = configurations.getByName(COMPILE_CLASSPATH_CONFIGURATION_NAME).resolvedConfiguration
-        val cordaFiles = compileConfiguration.resolveAll(cordaDeps).toFiles()
+        val externalConfiguration = configurations.getByName(CORDAPP_EXTERNAL_CONFIGURATION_NAME).resolvedConfiguration
         val providedDeps = configurations.getByName(CORDA_ALL_PROVIDED_CONFIGURATION_NAME).allDependencies
-        val providedFiles = compileConfiguration.resolveAllFilesFor(providedDeps)
+        val providedFiles = externalConfiguration.resolveAllFilesFor(providedDeps)
         val cordappDeps = configurations.getByName(ALL_CORDAPPS_CONFIGURATION_NAME).allDependencies
-        val cordappFiles = compileConfiguration.resolveFirstLevelFilesFor(cordappDeps)
+        val cordappFiles = externalConfiguration.resolveFirstLevelFilesFor(cordappDeps)
         _externalJars.apply {
-            setFrom(providedFiles, cordaFiles, cordappFiles)
+            setFrom(providedFiles, cordappFiles)
             disallowChanges()
         }
 

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/VerifyBundle.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/VerifyBundle.kt
@@ -1,13 +1,20 @@
 package net.corda.plugins.cpk
 
 import aQute.bnd.build.model.EE
+import aQute.bnd.header.Attrs
+import aQute.bnd.header.OSGiHeader
 import aQute.bnd.osgi.Analyzer
+import aQute.bnd.osgi.Constants.EXPORT_PACKAGE
 import aQute.bnd.osgi.Constants.OPTIONAL
 import aQute.bnd.osgi.Constants.RESOLUTION_DIRECTIVE
 import aQute.bnd.osgi.Constants.STRICT
+import aQute.bnd.osgi.Constants.VERSION_ATTRIBUTE
+import aQute.bnd.osgi.Descriptors.PackageRef
 import aQute.bnd.osgi.Descriptors.TypeRef
 import aQute.bnd.osgi.Jar
 import aQute.bnd.osgi.Verifier
+import aQute.bnd.version.Version
+import aQute.bnd.version.VersionRange
 import org.gradle.api.DefaultTask
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.file.ConfigurableFileCollection
@@ -24,6 +31,7 @@ import org.gradle.api.tasks.PathSensitivity.RELATIVE
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import java.io.File
+import java.util.function.Function
 import javax.inject.Inject
 
 @Suppress("UnstableApiUsage", "MemberVisibilityCanBePrivate")
@@ -90,22 +98,61 @@ open class VerifyBundle @Inject constructor(objects: ObjectFactory) : DefaultTas
         analyzer.analyze()
 
         val packageSpace = analyzer.classspace.keys.mapTo(HashSet(), TypeRef::getPackageRef)
-        val classpathPackages = getClasspathPackages()
         val systemPackages = analyzer.highestEE?.let { EE.parse(it.ee) }?.packages ?: emptyMap<String, Any>()
+        val classpathPackages = getClasspathPackages()
+        val exportVersions = mutableMapOf<String, MutableSet<Version>>()
+        fetchClasspathVersions(exportVersions)
 
-        analyzer.imports.forEach { importPackage ->
-            val packageRef = importPackage.key
-            val packageName = packageRef.fqn
-            if (!packageSpace.contains(packageRef)
-                    && !systemPackages.containsKey(packageName)
-                    && !classpathPackages.contains(packageName)
-                    && (importPackage.value[RESOLUTION_DIRECTIVE] != OPTIONAL)) {
-                verifier.error("Import Package clause found for missing package [%s]", packageName)
+        analyzer.exports.forEach { exportPackage ->
+            exportPackage.mapVersionsTo(exportVersions, Function(PackageRef::getFQN))
+        }
+        analyzer.imports
+            .filterKeys { packageRef -> !systemPackages.contains(packageRef.fqn) }
+            .filterValues { value -> value[RESOLUTION_DIRECTIVE] != OPTIONAL }
+            .forEach { importPackage ->
+                val packageRef = importPackage.key
+                val packageName = packageRef.fqn
+                if (!packageSpace.contains(packageRef)
+                        && !classpathPackages.contains(packageName)) {
+                    verifier.error("Import Package clause found for missing package [%s]", packageName)
+                }
+
+                val importVersion = importPackage.value[VERSION_ATTRIBUTE]
+                val exportVersion = exportVersions[packageName]
+                if (importVersion != null
+                        && (exportVersion == null || exportVersion.none(VersionRange(importVersion)::includes))) {
+                    verifier.error("Import Package clause requires package [%s] with version '%s', but version(s) '%s' exported",
+                        packageName, importVersion, exportVersion?.joinToString())
+                }
+            }
+    }
+
+    private fun getClasspathPackages(): Set<String> {
+        return classpath.flatMapTo(HashSet(), File::packages)
+    }
+
+    private fun fetchClasspathVersions(exportVersions: MutableMap<String, MutableSet<Version>>) {
+        classpath.forEach { file ->
+            val exportPackage = file.manifest.mainAttributes.getValue(EXPORT_PACKAGE)
+            if (exportPackage != null) {
+                OSGiHeader.parseHeader(exportPackage).forEach { header ->
+                    header.mapVersionsTo(exportVersions, Function.identity())
+                }
             }
         }
     }
 
-    private fun getClasspathPackages(): Set<String> {
-        return classpath.files.flatMapTo(HashSet(), File::packages)
+    private fun <T> Map.Entry<T, Attrs>.mapVersionsTo(
+        target: MutableMap<String, MutableSet<Version>>,
+        keyMapping: Function<T, String>
+    ) {
+        target.compute(keyMapping.apply(key)) { _, packageVersions ->
+            (packageVersions ?: mutableSetOf()).also { versions ->
+                val packageVersion = value[VERSION_ATTRIBUTE]
+                if (packageVersion != null) {
+                    versions.add(Version(packageVersion))
+                }
+            }
+        }
     }
 }

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithEmbeddedTransitivesTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithEmbeddedTransitivesTest.kt
@@ -22,10 +22,11 @@ class CordappWithEmbeddedTransitivesTest {
     companion object {
         private const val cordappVersion = "2.3.4-SNAPSHOT"
         private const val hostVersion = "1.2.3-SNAPSHOT"
+        private const val slf4jVersion = "2.0.0-alpha1"
 
         private const val kotlinOsgiVersion = "version=\"[1.4,2)\""
         private const val commonsIoOsgiVersion = "version=\"[1.4,2)\""
-        private const val slf4jOsgiVersion = "version=\"[1.7,2)\""
+        private const val slf4jOsgiVersion = "version=\"[2.0,3)\""
         private const val cordaOsgiVersion = "version=\"[5.0,6)\""
         private const val cordappOsgiVersion = "version=\"[2.3,3)\""
         private const val hostOsgiVersion = "version=\"1.2.3\""

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithLoggingTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithLoggingTest.kt
@@ -1,0 +1,44 @@
+package net.corda.plugins.cpk
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.TaskOutcome.FAILED
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestReporter
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class CordappWithLoggingTest {
+    companion object {
+        private const val cordappVersion = "1.0.1-SNAPSHOT"
+        private const val slf4jVersion = "2.0.0-alpha1"
+
+        private lateinit var testProject: GradleProject
+
+        @Suppress("unused")
+        @BeforeAll
+        @JvmStatic
+        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+            testProject = GradleProject(testProjectDir, reporter)
+                .withTestName("cordapp-with-logging")
+                .withSubResource("src/main/java/com/example/contract/LoggingContract.java")
+                .buildAndFail(
+                    "-Pcordapp_version=$cordappVersion",
+                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                    "-Pcorda_api_version=$cordaApiVersion",
+                    "-Pslf4j_version=$slf4jVersion"
+                )
+        }
+    }
+
+    @Test
+    fun conflictingLoggingVersionsTest() {
+        assertThat(testProject.dependencyConstraints).isEmpty()
+        assertThat(testProject.cpkDependencies).isEmpty()
+        assertThat(testProject.outcomeOf("verifyBundle")).isEqualTo(FAILED)
+        assertThat(testProject.output).contains(
+            "Bundle cordapp-with-logging-${cordappVersion}.jar has validation errors:",
+            "Import Package clause requires package [org.slf4j] with version '[2.0,3)', but version(s) '1.7.30' exported"
+        )
+    }
+}

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/GradleProject.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/GradleProject.kt
@@ -42,7 +42,6 @@ const val annotationsVersion = "1.0.1"
 const val commonsCollectionsVersion = "3.2.2"
 const val commonsCodecVersion = "1.15"
 const val commonsIoVersion = "2.8.0"
-const val slf4jVersion = "1.7.30"
 
 private val GRADLE_7 = GradleVersion.version("7.0")
 

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithEmbeddedJarTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithEmbeddedJarTest.kt
@@ -22,6 +22,8 @@ import java.util.jar.JarFile
 
 class WithEmbeddedJarTest {
     companion object {
+        private const val RESOLUTION_OPTIONAL = "resolution:=optional"
+        private const val SUPPRESS_VERSION = "version=[0,0)"
         private const val cordappVersion = "1.0.2-SNAPSHOT"
         private const val guavaVersion = "29.0-jre"
         private lateinit var testProject: GradleProject
@@ -83,7 +85,11 @@ class WithEmbeddedJarTest {
                 .containsPackageWithAttributes("lib")
                 .containsPackageWithAttributes("com.example.library")
                 .containsPackageWithAttributes("com.google.common.base")
-            assertThat(getValue(IMPORT_PACKAGE)).isNotNull()
+            assertThatHeader(getValue(IMPORT_PACKAGE))
+                .containsPackageWithAttributes("sun.misc", "version=[0,9999)", RESOLUTION_OPTIONAL)
+                .containsPackageWithAttributes("com.google.apphosting.api", SUPPRESS_VERSION, RESOLUTION_OPTIONAL)
+                .containsPackageWithAttributes("com.google.appengine.api", SUPPRESS_VERSION, RESOLUTION_OPTIONAL)
+                .containsPackageWithAttributes("com.google.appengine.api", SUPPRESS_VERSION, RESOLUTION_OPTIONAL)
             assertThat(getValue(EXPORT_PACKAGE)).isNull()
             assertThat(getValue(BUNDLE_CLASSPATH))
                 .startsWith(".,")

--- a/cordapp-cpk/src/test/resources/corda-api/build.gradle
+++ b/cordapp-cpk/src/test/resources/corda-api/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     compileOnly "org.osgi:osgi.annotation:$osgi_version"
     api "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
     api "javax.persistence:javax.persistence-api:$persistence_api_version"
+    api "org.slf4j:slf4j-api:$corda_slf4j_version"
     runtimeOnly "com.google.guava:guava:$corda_guava_version"
 }
 

--- a/cordapp-cpk/src/test/resources/cordapp-with-logging/build.gradle
+++ b/cordapp-cpk/src/test/resources/cordapp-with-logging/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+    id 'net.corda.plugins.cordapp-cpk'
+}
+
+apply from: 'repositories.gradle'
+apply from: 'javaTarget.gradle'
+
+group = 'com.example'
+version = cordapp_version
+
+cordapp {
+    targetPlatformVersion = platform_version.toInteger()
+    minimumPlatformVersion = platform_version.toInteger()
+
+    contract {
+        name = 'CorDapp With Logging'
+        versionId = cordapp_contract_version.toInteger()
+        licence = 'Test-Licence'
+        vendor = 'R3'
+    }
+}
+
+dependencies {
+    cordaProvided project(':corda-api')
+    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    implementation "org.slf4j:slf4j-api:$slf4j_version"
+}
+
+tasks.named('jar', Jar) {
+    archiveBaseName = 'cordapp-with-logging'
+}

--- a/cordapp-cpk/src/test/resources/cordapp-with-logging/settings.gradle
+++ b/cordapp-cpk/src/test/resources/cordapp-with-logging/settings.gradle
@@ -1,0 +1,16 @@
+// Common settings for all Gradle test projects.
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+    }
+
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version kotlin_version
+        id 'biz.aQute.bnd.builder' version bnd_version
+    }
+}
+
+rootProject.name = 'cordapp-with-logging'
+
+include 'corda-api'
+project(':corda-api').projectDir = file('../resources/test/corda-api')

--- a/cordapp-cpk/src/test/resources/cordapp-with-logging/src/main/java/com/example/contract/LoggingContract.java
+++ b/cordapp-cpk/src/test/resources/cordapp-with-logging/src/main/java/com/example/contract/LoggingContract.java
@@ -1,0 +1,14 @@
+package com.example.contract;
+
+import net.corda.v5.ledger.contracts.Contract;
+import net.corda.v5.ledger.transactions.LedgerTransaction;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+
+public class LoggingContract implements Contract {
+    private static final Logger LOG = LoggerFactory.getLogger(LoggingContract.class);
+    @Override
+    public void verify(LedgerTransaction ltx) {
+        LOG.info("Transaction: {}", ltx);
+    }
+}

--- a/cordapp-cpk/src/test/resources/gradle.properties
+++ b/cordapp-cpk/src/test/resources/gradle.properties
@@ -10,6 +10,7 @@ kotlin.stdlib.default.dependency=false
 platform_version=999
 
 corda_guava_version=$corda_guava_version
+corda_slf4j_version=$corda_slf4j_version
 persistence_api_version=$persistence_api_version
 hibernate_version=$hibernate_version
 kotlin_version=$kotlin_version

--- a/cordapp-cpk/src/test/resources/with-dependent-cordapp/build.gradle
+++ b/cordapp-cpk/src/test/resources/with-dependent-cordapp/build.gradle
@@ -27,6 +27,9 @@ jar {
         configurations.compileClasspath.forEach { dep ->
             println "COMPILE-WORKFLOW> ${dep.name}"
         }
+        configurations.cordappExternal.forEach { dep ->
+            println "EXTERNAL-WORKFLOW> ${dep.name}"
+        }
     }
 }
 

--- a/cordapp-cpk/src/test/resources/with-dependent-cordapp/cordapp/build.gradle
+++ b/cordapp-cpk/src/test/resources/with-dependent-cordapp/cordapp/build.gradle
@@ -23,6 +23,9 @@ jar {
         configurations.compileClasspath.forEach { dep ->
             println "COMPILE-CONTRACT> ${dep.name}"
         }
+        configurations.cordappExternal.forEach { dep ->
+            println "EXTERNAL-CONTRACT> ${dep.name}"
+        }
     }
 }
 


### PR DESCRIPTION
Add an extra validation step to the CPK `verifyBundle` task to check that the package imports align with the package exports. Also resolve the (`cordapp`, `cordaProvided`) configurations separately from `compileClasspath` for this, so that their transitive dependencies are not affected by the contents of the CPK. (We need this to make the `verifyBundle` task meaningful.)