### PR TITLE
CORDA-4157: Upgrade quasar-utils to use Quasar 0.8.6_r3.

### DIFF
--- a/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarPlugin.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarPlugin.groovy
@@ -35,7 +35,7 @@ class QuasarPlugin implements Plugin<Project> {
     private static final String CORDA_RUNTIME_ONLY_CONFIGURATION_NAME = 'cordaRuntimeOnly'
     @PackageScope static final String QUASAR_ARTIFACT_NAME = 'quasar-core-osgi'
     @PackageScope static final String defaultGroup = 'co.paralleluniverse'
-    @PackageScope static final String defaultVersion = '0.8.5_r3'
+    @PackageScope static final String defaultVersion = '0.8.6_r3'
 
     private final ObjectFactory objects
 


### PR DESCRIPTION
Use the latest version of Quasar by default.