### PR TITLE
CORE-268: Honour dependency transitivity for cordapp and cordaProvided.

### DIFF
--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CPKDependenciesTask.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CPKDependenciesTask.kt
@@ -106,7 +106,7 @@ open class CPKDependenciesTask @Inject constructor(objects: ObjectFactory) : Def
                     val cpkDependency = cpkDependencies.appendElement("cpkDependency")
                     cpkDependency.appendElement("name", mainAttributes.getValue(BUNDLE_SYMBOLICNAME))
                     cpkDependency.appendElement("version", mainAttributes.getValue(BUNDLE_VERSION))
-                    mainAttributes.getValue(CPK_TYPE_TAG)?.also { cpkType ->
+                    mainAttributes.getValue(CORDA_CPK_TYPE)?.also { cpkType ->
                         cpkDependency.appendElement("type", cpkType)
                     }
 

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappDependencyCollector.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappDependencyCollector.kt
@@ -36,13 +36,13 @@ class CordappDependencyCollector(
     private fun collectFrom(dependencies: DependencySet) {
         for (dependency in dependencies) {
             if (dependency is ProjectDependency) {
-                if (cordappProjects.add(dependency)) {
+                if (cordappProjects.add(dependency) && dependency.isTransitive) {
                     // Resolve a CorDapp dependency from another
                     // module in a multi-module build.
                     collectFrom(dependency)
                 }
             } else if (dependency is ModuleDependency) {
-                if (cordappModules.add(dependency)) {
+                if (cordappModules.add(dependency) && dependency.isTransitive) {
                     val cordapp = dependencyHandler.create(dependency.asMap.toCPK())
                     // Try to resolve the CorDapp's "companion" dependency.
                     // This may not exist, although it's better if it does.

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappUtils.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappUtils.kt
@@ -52,15 +52,16 @@ const val CORDA_CPK_CONFIGURATION_NAME = "cordaCPK"
 const val DEPENDENCY_CONSTRAINTS = "META-INF/DependencyConstraints"
 const val CPK_DEPENDENCIES = "META-INF/CPKDependencies"
 
+// These tags are for the CPK file.
 const val CPK_PLATFORM_VERSION = "Corda-CPK-Built-Platform-Version"
 const val CPK_CORDAPP_NAME = "Corda-CPK-Cordapp-Name"
 const val CPK_CORDAPP_VERSION = "Corda-CPK-Cordapp-Version"
 const val CPK_CORDAPP_LICENCE = "Corda-CPK-Cordapp-Licence"
 const val CPK_CORDAPP_VENDOR = "Corda-CPK-Cordapp-Vendor"
 const val CPK_FORMAT_TAG = "Corda-CPK-Format"
-const val CPK_TYPE_TAG = "Corda-CPK-Type"
 const val CPK_FORMAT = "1.0"
 
+// These tags are for the "main" JAR file.
 const val PLATFORM_VERSION_X = 999
 const val CORDA_CONTRACT_CLASSES = "Corda-Contract-Classes"
 const val CORDA_WORKFLOW_CLASSES = "Corda-Flow-Classes"
@@ -73,6 +74,7 @@ const val CORDAPP_CONTRACT_NAME = "Cordapp-Contract-Name"
 const val CORDAPP_CONTRACT_VERSION = "Cordapp-Contract-Version"
 const val CORDAPP_WORKFLOW_NAME = "Cordapp-Workflow-Name"
 const val CORDAPP_WORKFLOW_VERSION = "Cordapp-Workflow-Version"
+const val CORDA_CPK_TYPE = "Corda-CPK-Type"
 
 @JvmField
 val SEPARATOR: String = System.lineSeparator() + "- "

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithoutTransitiveCordappsTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithoutTransitiveCordappsTest.kt
@@ -1,0 +1,80 @@
+package net.corda.plugins.cpk
+
+import java.io.StringReader
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.TestReporter
+import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.nio.file.Path
+
+/**
+ * Verify that non-transitive cordapp and cordaProvided
+ * dependencies are NOT inherited by downstream CPK projects.
+ */
+class WithoutTransitiveCordappsTest {
+    companion object {
+        private const val cordappVersion = "1.0.1-SNAPSHOT"
+        private const val cpk1Version = "1.0-SNAPSHOT"
+        private const val cpk2Version = "2.0-SNAPSHOT"
+        private const val providedPrefix = "ALL-PROVIDED: "
+
+        private fun buildProject(
+            withPublishing: Boolean,
+            testProjectDir: Path,
+            reporter: TestReporter
+        ): GradleProject {
+            return GradleProject(testProjectDir, reporter)
+                .withTestName("without-transitive-cordapps")
+                .withSubResource("cpk-one/build.gradle")
+                .withSubResource("cpk-two/build.gradle")
+                .build(
+                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                    "-Pcommons_codec_version=$commonsCodecVersion",
+                    "-Pcommons_io_version=$commonsIoVersion",
+                    "-Pcorda_api_version=$cordaApiVersion",
+                    "-Pcordapp_version=$cordappVersion",
+                    "-Pcpk1_version=$cpk1Version",
+                    "-Pcpk2_version=$cpk2Version",
+                    "-Pwith_publishing=$withPublishing"
+                )
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun transitivesTest(
+        withPublishing: Boolean,
+        @TempDir testProjectDir: Path,
+        reporter: TestReporter
+    ) {
+        val testProject = buildProject(withPublishing, testProjectDir, reporter)
+
+        assertThat(testProject.dependencyConstraints)
+            .isEmpty()
+        assertThat(testProject.cpkDependencies)
+            .anyMatch { it.name == "com.example.cpk-two" && it.version == toOSGi(cpk2Version) }
+            .noneMatch { it.name == "com.example.cpk-one" }
+            .allMatch { it.signers.allSHA256 }
+            .hasSize(1)
+
+        val artifacts = testProject.artifacts
+        assertThat(artifacts).hasSize(2)
+
+        val cpk = artifacts.single { it.toString().endsWith(".cpk") }
+        assertThat(cpk).isRegularFile()
+
+        val cordapp = artifacts.single { it.toString().endsWith(".jar") }
+        assertThat(cordapp).isRegularFile()
+        assertThat(cordapp.hashOfEntry(CPK_DEPENDENCIES))
+            .isEqualTo(testProject.cpkDependenciesHash)
+
+        val providedDeps = StringReader(testProject.output)
+            .readLines()
+            .filter { it.startsWith(providedPrefix) }
+            .map { it.removePrefix(providedPrefix) }
+        assertThat(providedDeps)
+            .contains("commons-codec:$commonsCodecVersion")
+            .hasSize(1)
+    }
+}

--- a/cordapp-cpk/src/test/resources/corda-api/src/main/java/net/corda/v5/application/services/lifecycle/package-info.java
+++ b/cordapp-cpk/src/test/resources/corda-api/src/main/java/net/corda/v5/application/services/lifecycle/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package net.corda.v5.application.services.lifecycle;
+
+import org.osgi.annotation.bundle.Export;

--- a/cordapp-cpk/src/test/resources/cordapp-private-deps/build.gradle
+++ b/cordapp-cpk/src/test/resources/cordapp-private-deps/build.gradle
@@ -33,9 +33,6 @@ dependencies {
 
 tasks.named('jar', Jar) {
     archiveBaseName = 'cordapp-private-deps'
-}
-
-def show = tasks.register('show') {
     doLast {
         [ 'cordaPrivateProvided', 'cordaAllProvided' ].forEach { configName ->
             configurations[configName].allDependencies.forEach { dep ->
@@ -43,8 +40,4 @@ def show = tasks.register('show') {
             }
         }
     }
-}
-
-tasks.named('assemble') {
-    dependsOn show
 }

--- a/cordapp-cpk/src/test/resources/cordapp-private-deps/cordapp/build.gradle
+++ b/cordapp-cpk/src/test/resources/cordapp-private-deps/cordapp/build.gradle
@@ -29,9 +29,6 @@ dependencies {
 
 tasks.named('jar', Jar) {
     archiveBaseName = 'cordapp'
-}
-
-def show = tasks.register('show') {
     doLast {
         [ 'cordaPrivateProvided', 'cordaAllProvided' ].forEach { configName ->
             configurations[configName].allDependencies.forEach { dep ->
@@ -39,8 +36,4 @@ def show = tasks.register('show') {
             }
         }
     }
-}
-
-tasks.named('assemble') {
-    dependsOn show
 }

--- a/cordapp-cpk/src/test/resources/transitive-cordapps/cpk-two/build.gradle
+++ b/cordapp-cpk/src/test/resources/transitive-cordapps/cpk-two/build.gradle
@@ -25,9 +25,7 @@ dependencies {
 
 jar {
     archiveBaseName = 'cpk-two'
-    jar {
-        manifest {
-            attributes('Corda-CPK-Type': cpk2_type)
-        }
+    manifest {
+        attributes('Corda-CPK-Type': cpk2_type)
     }
 }

--- a/cordapp-cpk/src/test/resources/without-transitive-cordapps/build.gradle
+++ b/cordapp-cpk/src/test/resources/without-transitive-cordapps/build.gradle
@@ -1,0 +1,54 @@
+plugins {
+    id 'net.corda.plugins.cordapp-cpk'
+    id 'org.jetbrains.kotlin.jvm'
+}
+
+apply from: 'repositories.gradle'
+apply from: 'javaTarget.gradle'
+apply from: 'kotlin.gradle'
+
+allprojects {
+    group = 'com.example'
+}
+
+if (with_publishing.toBoolean()) {
+    allprojects {
+        apply plugin: 'java-library'
+        apply plugin: 'maven-publish'
+
+        publishing {
+            publications {
+                maven(MavenPublication) {
+                    from components.java
+                }
+            }
+        }
+    }
+}
+
+version = cordapp_version
+
+cordapp {
+    targetPlatformVersion = platform_version.toInteger()
+    minimumPlatformVersion = platform_version.toInteger()
+
+    contract {
+        name = 'Without Transitive CorDapps'
+        versionId = cordapp_contract_version.toInteger()
+        licence = 'Test-Licence'
+        vendor = 'R3'
+    }
+}
+
+dependencies {
+    cordaProvided "commons-codec:commons-codec:$commons_codec_version"
+    cordapp project(path: ':cpk-two', transitive: false)
+}
+
+tasks.named('jar', Jar) {
+    doFirst {
+        configurations.cordaAllProvided.allDependencies.forEach { dep ->
+            println "ALL-PROVIDED: ${dep.name}:${dep.version}"
+        }
+    }
+}

--- a/cordapp-cpk/src/test/resources/without-transitive-cordapps/cpk-one/build.gradle
+++ b/cordapp-cpk/src/test/resources/without-transitive-cordapps/cpk-one/build.gradle
@@ -25,7 +25,4 @@ dependencies {
 
 jar {
     archiveBaseName = 'cpk-one'
-    manifest {
-        attributes('Corda-CPK-Type': cpk1_type)
-    }
 }

--- a/cordapp-cpk/src/test/resources/without-transitive-cordapps/cpk-two/build.gradle
+++ b/cordapp-cpk/src/test/resources/without-transitive-cordapps/cpk-two/build.gradle
@@ -5,14 +5,14 @@ plugins {
 apply from: '../repositories.gradle'
 apply from: '../javaTarget.gradle'
 
-version = cpk1_version
+version = cpk2_version
 
 cordapp {
     targetPlatformVersion = platform_version.toInteger()
     minimumPlatformVersion = platform_version.toInteger()
 
     contract {
-        name = 'CPK-1'
+        name = 'CPK-2'
         versionId = cordapp_contract_version.toInteger()
         licence = 'Test-Licence'
         vendor = 'R3'
@@ -20,12 +20,10 @@ cordapp {
 }
 
 dependencies {
-    cordaProvided project(':corda-api')
+    cordapp project(':cpk-one')
+    cordaProvided "commons-io:commons-io:$commons_io_version"
 }
 
 jar {
-    archiveBaseName = 'cpk-one'
-    manifest {
-        attributes('Corda-CPK-Type': cpk1_type)
-    }
+    archiveBaseName = 'cpk-two'
 }

--- a/cordapp-cpk/src/test/resources/without-transitive-cordapps/settings.gradle
+++ b/cordapp-cpk/src/test/resources/without-transitive-cordapps/settings.gradle
@@ -1,0 +1,17 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+    }
+
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version kotlin_version
+    }
+}
+
+rootProject.name = 'without-transitive-cordapps'
+
+include 'cpk-one'
+include 'cpk-two'
+
+include 'corda-api'
+project(':corda-api').projectDir = file('../resources/test/corda-api')

--- a/cordapp-cpk/src/test/resources/xml/corda-cpk-1.0.xsd
+++ b/cordapp-cpk/src/test/resources/xml/corda-cpk-1.0.xsd
@@ -23,8 +23,8 @@
         <xs:all>
             <xs:element name="name" type="xs:token"/>
             <xs:element name="version" type="xs:token"/>
-            <xs:element name="signers" type="cpk:signersType"/>
             <xs:element name="type" type="xs:token" minOccurs="0"/>
+            <xs:element name="signers" type="cpk:signersType"/>
         </xs:all>
     </xs:complexType>
 


### PR DESCRIPTION
CorDapp dependencies that are declared as not being transitive should not be picked up by the `CordappDependenyCollector`, which means that they will not be implicitly added to the CPK. Nor will their `cordaProvided` dependencies be implicitly included in the `cordaAllProvided` configuration.