### PR TITLE
Optimize NetworkBootstrapper performance when generating member infos

### DIFF
--- a/flask/flask-launcher/src/main/java/net/corda/flask/launcher/Launcher.java
+++ b/flask/flask-launcher/src/main/java/net/corda/flask/launcher/Launcher.java
@@ -123,9 +123,18 @@ public class Launcher {
             JavaProcessBuilder builder = new JavaProcessBuilder();
             builder.setMainClassName(Optional.ofNullable(System.getProperty(Flask.JvmProperties.MAIN_CLASS))
                     .orElse(manifest.getMainAttributes().getValue(Flask.ManifestAttributes.APPLICATION_CLASS)));
+
+            // Following block optimizes networkbootstrapper elapsed time to launch node when merely generating node member info
+            String disableQuasar = System.getProperty("net.corda.flask.launcher.disableQuasarAgent", "false");
+            if (disableQuasar.equalsIgnoreCase("true")) {
+                log.info("System property net.corda.flask.launcher.disableQuasarAgent is true -> removing quasar java agent");
+                javaAgents=null;
+            }
+
             if(jvmArgs != null) {
                 builder.getJvmArgs().addAll(jvmArgs);
             }
+
             if(javaAgents != null) {
                 for(String javaAgentString : javaAgents) {
                     int equalCharPosition = javaAgentString.indexOf('=');


### PR DESCRIPTION
👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻

The goal of this change is to optimize the Network Bootstrapper performance. Profiling node startup initiated by bootstrapper to run migration scripts and then to generate member infos indicates around 40% of the time is spent in class instrumentation. When running without the quasar agent we see a significant improvement in bootstrapper performance. It appears that quasar instrumentation is not necessary when nodes are started briefly to run specific subcommands - such as to migrate the db and/or generate member infos. 

The proposal is to allow callers to disable the quasar agent by setting System property net.corda.flask.launcher.disableQuasarAgent to true (default is false) this will 

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described here? https://docs.corda.net/head/testing.html
- [ ] If you added/changed public APIs, did you write/update the JavaDocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially release notes?
- [ ] If you are contributing for the first time, please read the agreement in CONTRIBUTING.md now and add to this Pull Request that you agree to it.

Thanks for your code, it's appreciated! :)
