### PR TITLE
CORE-1921: Ensure we build the jars required by CPKDependencies XML.

### DIFF
--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappPlugin.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappPlugin.kt
@@ -127,7 +127,7 @@ class CordappPlugin @Inject constructor(private val layouts: ProjectLayout): Plu
 
             // Unlike cordaProvided dependencies, cordaPrivateProvided ones will not be
             // added to the compile classpath of any CPKs that will depend on this CPK.
-            // In other words, they will not included in this CPK's companion POM.
+            // In other words, they will not be included in this CPK's companion POM.
             val cordaPrivate = createCompileConfiguration(CORDA_PRIVATE_CONFIGURATION_NAME)
 
             val allProvided = createCompileConfiguration(CORDA_ALL_PROVIDED_CONFIGURATION_NAME)

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappPlugin.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappPlugin.kt
@@ -11,9 +11,11 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency.ARCHIVES_CONFIGURATION
 import org.gradle.api.artifacts.ModuleDependency
+import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.file.DuplicatesStrategy.FAIL
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.java.archives.Attributes
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.AppliedPlugin
 import org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME
 import org.gradle.api.plugins.JavaPlugin.JAR_TASK_NAME
@@ -101,6 +103,10 @@ class CordappPlugin @Inject constructor(private val layouts: ProjectLayout): Plu
                 dependencies.add(bndDependency)
             }
 
+            // Generator object for variant attributes. We need this to ensure
+            // Gradle resolves project dependencies into the correct artifacts.
+            val attributor = Attributor(project.objects)
+
             val cordappCfg = createCompileConfiguration(CORDAPP_CONFIGURATION_NAME)
 
             // The "cordapp" and "cordaProvided" configurations are "compile only",
@@ -119,6 +125,10 @@ class CordappPlugin @Inject constructor(private val layouts: ProjectLayout): Plu
                         // to our own compile classpath.
                         // WE ARE MUTATING THESE DEPENDENCIES FOR EVERY CONFIGURATION THEY APPEAR IN!
                         dep.isTransitive = false
+
+                        // We also need to GUARANTEE that Gradle uses the jar artifact here.
+                        // Only the jar contains the OSGi metadata we need.
+                        dep.attributes(attributor::forJar)
                     }
                 }
 
@@ -147,27 +157,14 @@ class CordappPlugin @Inject constructor(private val layouts: ProjectLayout): Plu
             create(CORDAPP_PACKAGING_CONFIGURATION_NAME)
                 .setVisible(false)
                 .extendsFrom(cordaEmbedded, getByName(RUNTIME_ELEMENTS_CONFIGURATION_NAME))
-                .attributes { attrs ->
-                    // Dark Gradle Magic which ensures that this configuration
-                    // is resolved exactly like runtimeClasspath.
-                    AttributeFactory(attrs, project.objects)
-                        .withExternalDependencies()
-                        .javaRuntime()
-                        .asLibrary()
-                        .jar()
-                }.isCanBeConsumed = false
+                .attributes(attributor::forRuntimeClasspath)
+                .isCanBeConsumed = false
 
             create(CORDAPP_EXTERNAL_CONFIGURATION_NAME)
                 .setVisible(false)
                 .extendsFrom(allProvided, allCordapps)
-                .attributes { attrs ->
-                    // Dark Gradle Magic which ensures that this configuration
-                    // is resolved exactly like compileClasspath.
-                    AttributeFactory(attrs, project.objects)
-                        .withExternalDependencies()
-                        .asLibrary()
-                        .javaApi()
-                }.isCanBeConsumed = false
+                .attributes(attributor::forCompileClasspath)
+                .isCanBeConsumed = false
         }
 
         // We need to perform some extra work on the root project to support publication.
@@ -404,6 +401,43 @@ class CordappPlugin @Inject constructor(private val layouts: ProjectLayout): Plu
             throw InvalidUserDataException("CorDapp `versionId` must not be smaller than 1.")
         }
         return value
+    }
+}
+
+/**
+ * Generator for Gradle [Configuration][org.gradle.api.artifacts.Configuration]
+ * variant attributes.
+ */
+private class Attributor(private val objects: ObjectFactory) {
+    /**
+     * Dark Gradle Magic which ensures that a configuration
+     * is resolved exactly like compileClasspath.
+     */
+    fun forCompileClasspath(attrs: AttributeContainer) {
+        AttributeFactory(attrs, objects)
+            .withExternalDependencies()
+            .asLibrary()
+            .javaApi()
+    }
+
+    /**
+     * Dark Gradle Magic which ensures that a configuration
+     * is resolved exactly like runtimeClasspath.
+     */
+    fun forRuntimeClasspath(attrs: AttributeContainer) {
+        AttributeFactory(attrs, objects)
+            .withExternalDependencies()
+            .javaRuntime()
+            .asLibrary()
+            .jar()
+    }
+
+    /**
+     * Dark Gradle Magic which ensures that we use a
+     * project's jar artifact and not just its classes.
+     */
+    fun forJar(attrs: AttributeContainer) {
+        AttributeFactory(attrs, objects).jar()
     }
 }
 

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/DependencyCalculator.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/DependencyCalculator.kt
@@ -11,8 +11,6 @@ import org.gradle.api.artifacts.SelfResolvingDependency
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.model.ObjectFactory
-import org.gradle.api.plugins.JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME
-import org.gradle.api.plugins.JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME
 import org.gradle.api.provider.Provider
 import org.gradle.api.specs.Specs.satisfyNone
 import org.gradle.api.tasks.OutputFiles
@@ -46,8 +44,8 @@ open class DependencyCalculator @Inject constructor(objects: ObjectFactory) : De
              * configurations. Hence every [ProjectDependency][org.gradle.api.artifacts.ProjectDependency]
              * needed to build this CorDapp should exist somewhere beneath their umbrella.
              */
-            RUNTIME_CLASSPATH_CONFIGURATION_NAME,
-            COMPILE_CLASSPATH_CONFIGURATION_NAME
+            CORDAPP_PACKAGING_CONFIGURATION_NAME,
+            CORDAPP_EXTERNAL_CONFIGURATION_NAME
         ))
     }
 

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappJarForCPKDependenciesTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappJarForCPKDependenciesTest.kt
@@ -1,0 +1,55 @@
+package net.corda.plugins.cpk
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import org.junit.jupiter.api.TestReporter
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+
+/**
+ * Generating the CPKDependencies file requires that Gradle
+ * also build the "main" jar file for any dependent CPKs.
+ */
+class CordappJarForCPKDependenciesTest {
+    companion object {
+        private const val CPK_DEPENDENCIES_TASK_NAME = "cordappCPKDependencies"
+        private const val cordappVersion = "1.2.1-SNAPSHOT"
+        private const val hostVersion = "2.0.1-SNAPSHOT"
+
+        private lateinit var testProject: GradleProject
+
+        @Suppress("unused")
+        @BeforeAll
+        @JvmStatic
+        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+            testProject = GradleProject(testProjectDir, reporter)
+                .withTestName("cordapp-transitive-deps")
+                .withSubResource("cordapp/build.gradle")
+                .withTaskName(CPK_DEPENDENCIES_TASK_NAME)
+                .build(
+                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                    "-Pcommons_collections_version=$commonsCollectionsVersion",
+                    "-Pcommons_codec_version=$commonsCodecVersion",
+                    "-Pannotations_version=$annotationsVersion",
+                    "-Pcommons_io_version=$commonsIoVersion",
+                    "-Pcorda_api_version=$cordaApiVersion",
+                    "-Pcordapp_version=$cordappVersion",
+                    "-Phost_version=$hostVersion"
+                )
+        }
+    }
+
+    @Test
+    fun testCPKDependenciesBuildsDependentJar() {
+        assertThat(testProject.outcomeOf(CPK_DEPENDENCIES_TASK_NAME))
+            .isEqualTo(SUCCESS)
+        assertThat(testProject.artifactDir)
+            .doesNotExist()
+        assertThat(testProject.cpkDependencies)
+            .anyMatch { it.name == "com.example.cordapp" && it.version == toOSGi(cordappVersion) }
+            .allMatch { it.signers.allSHA256 }
+            .hasSize(1)
+    }
+}

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/GradleProject.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/GradleProject.kt
@@ -172,7 +172,10 @@ class GradleProject(private val projectDir: Path, private val reporter: TestRepo
     val artifactDir: Path = buildDir.resolve("libs")
     val artifacts: List<Path>
         @Throws(IOException::class)
-        get() = Files.list(artifactDir).collect(toList())
+        get() {
+            assertThat(artifactDir).isDirectory()
+            return Files.list(artifactDir).collect(toList())
+        }
 
     val dependencyConstraintsFile: Path = buildDir.resolve("generated-constraints")
         .resolve(META_INF_DIR).resolve("DependencyConstraints")
@@ -237,7 +240,6 @@ class GradleProject(private val projectDir: Path, private val reporter: TestRepo
     fun build(vararg args: String): GradleProject {
         configureGradle(GradleRunner::build, args)
         assertThat(buildDir).isDirectory()
-        assertThat(artifactDir).isDirectory()
         assertEquals(SUCCESS, resultFor(taskName).outcome)
         return this
     }

--- a/cordapp-cpk/src/test/resources/cordapp-transitive-deps/build.gradle
+++ b/cordapp-cpk/src/test/resources/cordapp-transitive-deps/build.gradle
@@ -15,7 +15,6 @@ version = host_version
 
 cordapp {
     targetPlatformVersion = platform_version.toInteger()
-    minimumPlatformVersion = platform_version.toInteger()
 
     contract {
         name = 'CorDapp Transitive Dependencies'
@@ -32,6 +31,6 @@ dependencies {
     cordapp project(':cordapp')
 }
 
-jar {
+tasks.named('jar', Jar) {
     archiveBaseName = 'cordapp-transitive-deps'
 }


### PR DESCRIPTION
Gradle's dependency graph for the `cordaCPKDependencies` task needs to include the `jar` tasks for any transitive CorDapp  projects. Replace the build dependencies from the `runtimeClasspath` and `compileClasspath` configurations with the `cordapp-cpk` plugin's `cordappPackaging` and `cordappExternal` configurations respectively, which are their "OSGi-aware" replacements.

This has also exposed a more subtle problem where Gradle sometimes resolves dependent CorDapp projects to their `build/classes/*/main` directories instead of their "main" jars. This is _**toxic**_ to OSGi because it deprives Bnd of those CorDapps' OSGi metadata, which in turn means that Bnd generates broken OSGi metadata for the new "main" jar. I have _hopefully_ resolved this by setting the `LibraryElements` variant attribute to `JAR` on each CorDapp dependency.