### PR TITLE
CORE-1998: Ensure that cordapp-cpk plugin always compiles against jars.

### DIFF
--- a/cordapp-cpk/build.gradle
+++ b/cordapp-cpk/build.gradle
@@ -10,6 +10,7 @@ plugins {
 description 'Configures this project to create a CPK CorDapp'
 
 ext {
+    osgi_service_component_version = '1.4.0'
     test_persistence_api_version = '2.2'
     test_hibernate_version = '5.4.30.Final'
     test_kotlin_version = '1.4.32'
@@ -85,6 +86,7 @@ dependencies {
 processTestResources {
     filesMatching('gradle.properties') {
         expand([
+            'osgi_service_component_version': osgi_service_component_version,
             'persistence_api_version': test_persistence_api_version,
             'hibernate_version': test_hibernate_version,
             'corda_guava_version': corda_guava_version,

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/AttributeFactory.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/AttributeFactory.kt
@@ -16,7 +16,7 @@ import org.gradle.api.attributes.Usage.JAVA_RUNTIME
 import org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE
 import org.gradle.api.model.ObjectFactory
 
-class AttributeFactory(
+internal class AttributeFactory(
     private val attrs: AttributeContainer,
     private val objects: ObjectFactory) {
 
@@ -37,6 +37,11 @@ class AttributeFactory(
 
     fun jar(): AttributeFactory {
         attrs.attribute(LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements::class.java, JAR))
+        return this
+    }
+
+    fun cpk(): AttributeFactory {
+        attrs.attribute(LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements::class.java, "cpk"))
         return this
     }
 

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/Attributor.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/Attributor.kt
@@ -1,0 +1,50 @@
+package net.corda.plugins.cpk
+
+import org.gradle.api.attributes.AttributeContainer
+import org.gradle.api.model.ObjectFactory
+
+/**
+ * Generator for Gradle [Configuration][org.gradle.api.artifacts.Configuration]
+ * variant attributes.
+ */
+internal class Attributor(private val objects: ObjectFactory) {
+    /**
+     * Dark Gradle Magic which ensures that a configuration
+     * is resolved exactly like compileClasspath.
+     */
+    fun forCompileClasspath(attrs: AttributeContainer) {
+        AttributeFactory(attrs, objects)
+            .withExternalDependencies()
+            .asLibrary()
+            .javaApi()
+            .jar()
+    }
+
+    /**
+     * Dark Gradle Magic which ensures that a configuration
+     * is resolved exactly like runtimeClasspath.
+     */
+    fun forRuntimeClasspath(attrs: AttributeContainer) {
+        AttributeFactory(attrs, objects)
+            .withExternalDependencies()
+            .javaRuntime()
+            .asLibrary()
+            .jar()
+    }
+
+    /**
+     * Dark Gradle Magic which ensures that we use a
+     * project's jar artifact and not just its classes.
+     */
+    fun forJar(attrs: AttributeContainer) {
+        AttributeFactory(attrs, objects).jar()
+    }
+
+    /**
+     * Dark Gradle Magic to declare that we
+     * consume or produce a CPK artifact.
+     */
+    fun forCpk(attrs: AttributeContainer) {
+        AttributeFactory(attrs, objects).cpk()
+    }
+}

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappDependencyCollector.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappDependencyCollector.kt
@@ -11,9 +11,10 @@ import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.logging.Logger
 import java.util.Collections.unmodifiableSet
 
-class CordappDependencyCollector(
+internal class CordappDependencyCollector(
     private val configurations: ConfigurationContainer,
     private val dependencyHandler: DependencyHandler,
+    private val attributor: Attributor,
     private val logger: Logger
 ) {
     private val cordappProjects = mutableSetOf<ProjectDependency>()
@@ -63,7 +64,10 @@ class CordappDependencyCollector(
     }
 
     private fun collectFrom(cordapp: Dependency) {
-        val resolved = configurations.detachedConfiguration(cordapp).resolvedConfiguration
+        val resolved = configurations.detachedConfiguration(cordapp)
+            .attributes(attributor::forCompileClasspath)
+            .setVisible(false)
+            .resolvedConfiguration
         if (resolved.hasError()) {
             logger.warn("CorDapp has unresolved dependencies:{}",
                 resolved.lenientConfiguration.unresolvedModuleDependencies.joinToString(SEPARATOR, SEPARATOR))

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappClassesDependencyTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappClassesDependencyTest.kt
@@ -1,0 +1,67 @@
+package net.corda.plugins.cpk
+
+import java.io.StringReader
+import java.nio.file.Path
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestReporter
+import org.junit.jupiter.api.io.TempDir
+import org.osgi.framework.Constants.IMPORT_PACKAGE
+
+/**
+ * Our library is an OSGi bundle, and so Gradle must compile
+ * our CorDapp against library.jar. It MUST NOT use library's
+ * unpackaged classes, which have no OSGi metadata.
+ */
+class CordappClassesDependencyTest {
+    companion object {
+        private const val CORDAPP_VERSION = "1.1.1-SNAPSHOT"
+        private const val LIBRARY_VERSION = "2.2.2-SNAPSHOT"
+        private const val compilePrefix = "COMPILE "
+        private lateinit var testProject: GradleProject
+
+        @Suppress("unused")
+        @BeforeAll
+        @JvmStatic
+        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+            testProject = GradleProject(testProjectDir, reporter)
+                .withTestName("cordapp-classes-dep")
+                .withSubResource("src/main/kotlin/com/example/host/CordappHostContract.kt")
+                .withSubResource("library/src/main/java/com/example/library/package-info.java")
+                .withSubResource("library/src/main/java/com/example/library/ExternalLibrary.java")
+                .withSubResource("library/src/main/java/com/example/library/impl/ExternalLibraryImpl.java")
+                .withSubResource("library/build.gradle")
+                .build(
+                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                    "-Pcorda_api_version=$cordaApiVersion",
+                    "-Pcordapp_version=$CORDAPP_VERSION",
+                    "-Plibrary_version=$LIBRARY_VERSION"
+                )
+        }
+    }
+
+    @Test
+    fun testCordappWithLibraryDependency() {
+        val compileDeps = StringReader(testProject.output)
+            .readLines()
+            .filter { it.startsWith(compilePrefix) }
+            .map { it.removePrefix(compilePrefix) }
+        assertThat(compileDeps)
+            .contains("library-$LIBRARY_VERSION.jar")
+
+        val artifacts = testProject.artifacts
+        assertThat(artifacts).hasSize(2)
+
+        val cordapp = artifacts.single { it.toString().endsWith(".jar") }
+        assertThat(cordapp).isRegularFile()
+
+        val jarManifest = cordapp.manifest
+        println(jarManifest.mainAttributes.entries)
+
+        with(jarManifest.mainAttributes) {
+            assertThatHeader(getValue(IMPORT_PACKAGE))
+                .containsPackageWithAttributes("com.example.library", "version=${toOSGiRange(LIBRARY_VERSION)}")
+        }
+    }
+}

--- a/cordapp-cpk/src/test/resources/cordapp-classes-dep/build.gradle
+++ b/cordapp-cpk/src/test/resources/cordapp-classes-dep/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id 'net.corda.plugins.cordapp-cpk'
+    id 'org.jetbrains.kotlin.jvm'
+}
+
+apply from: 'repositories.gradle'
+apply from: 'javaTarget.gradle'
+apply from: 'kotlin.gradle'
+
+group = 'com.example'
+version = cordapp_version
+
+cordapp {
+    targetPlatformVersion = platform_version.toInteger()
+
+    contract {
+        name = 'CorDapp Classes Dependency'
+        versionId = cordapp_contract_version.toInteger()
+        licence = 'Test-Licence'
+        vendor = 'R3'
+    }
+}
+
+dependencies {
+    compileOnly "org.osgi:org.osgi.service.component.annotations:$osgi_service_component_version"
+    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordaProvided project(':corda-api')
+    implementation project(':library')
+}
+
+tasks.named('jar', Jar) {
+    doFirst {
+        configurations.compileClasspath.forEach {
+            println("COMPILE ${it.name}")
+        }
+    }
+}

--- a/cordapp-cpk/src/test/resources/cordapp-classes-dep/library/build.gradle
+++ b/cordapp-cpk/src/test/resources/cordapp-classes-dep/library/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+    id 'biz.aQute.bnd.builder'
+}
+
+apply from: '../repositories.gradle'
+apply from: '../javaTarget.gradle'
+
+group = 'com.example'
+version = library_version
+
+dependencies {
+    compileOnly "org.osgi:org.osgi.service.component.annotations:$osgi_service_component_version"
+    compileOnly "org.osgi:osgi.annotation:$osgi_version"
+    implementation "org.slf4j:slf4j-api:$corda_slf4j_version"
+}

--- a/cordapp-cpk/src/test/resources/cordapp-classes-dep/library/src/main/java/com/example/library/ExternalLibrary.java
+++ b/cordapp-cpk/src/test/resources/cordapp-classes-dep/library/src/main/java/com/example/library/ExternalLibrary.java
@@ -1,0 +1,8 @@
+package com.example.library;
+
+import java.util.function.Function;
+
+public interface ExternalLibrary extends Function<String, String> {
+    @Override
+    String apply(String data);
+}

--- a/cordapp-cpk/src/test/resources/cordapp-classes-dep/library/src/main/java/com/example/library/impl/ExternalLibraryImpl.java
+++ b/cordapp-cpk/src/test/resources/cordapp-classes-dep/library/src/main/java/com/example/library/impl/ExternalLibraryImpl.java
@@ -1,0 +1,17 @@
+package com.example.library.impl;
+
+import com.example.library.ExternalLibrary;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Component
+public class ExternalLibraryImpl implements ExternalLibrary {
+    private static final Logger LOG = LoggerFactory.getLogger(ExternalLibraryImpl.class);
+
+    @Override
+    public String apply(String data) {
+        LOG.info("Message: {}", data);
+        return data;
+    }
+}

--- a/cordapp-cpk/src/test/resources/cordapp-classes-dep/library/src/main/java/com/example/library/package-info.java
+++ b/cordapp-cpk/src/test/resources/cordapp-classes-dep/library/src/main/java/com/example/library/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package com.example.library;
+
+import org.osgi.annotation.bundle.Export;

--- a/cordapp-cpk/src/test/resources/cordapp-classes-dep/settings.gradle
+++ b/cordapp-cpk/src/test/resources/cordapp-classes-dep/settings.gradle
@@ -1,0 +1,11 @@
+pluginManagement {
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version kotlin_version
+        id 'biz.aQute.bnd.builder' version bnd_version
+    }
+}
+
+rootProject.name = 'cordapp-classes-dep'
+include 'library'
+include 'corda-api'
+project(':corda-api').projectDir = file('../resources/test/corda-api')

--- a/cordapp-cpk/src/test/resources/cordapp-classes-dep/src/main/kotlin/com/example/host/CordappHostContract.kt
+++ b/cordapp-cpk/src/test/resources/cordapp-classes-dep/src/main/kotlin/com/example/host/CordappHostContract.kt
@@ -1,0 +1,19 @@
+@file:Suppress("PackageDirectoryMismatch")
+package com.example.host
+
+import com.example.library.ExternalLibrary;
+import net.corda.v5.ledger.contracts.Contract
+import net.corda.v5.ledger.transactions.LedgerTransaction
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+
+@Component
+class CordappHostContract @Activate constructor(
+    @Reference
+    private val library: ExternalLibrary
+) : Contract {
+    override fun verify(ltx: LedgerTransaction) {
+        library.apply(ltx.toString())
+    }
+}

--- a/cordapp-cpk/src/test/resources/gradle.properties
+++ b/cordapp-cpk/src/test/resources/gradle.properties
@@ -12,6 +12,7 @@ platform_version=999
 corda_guava_version=$corda_guava_version
 corda_slf4j_version=$corda_slf4j_version
 persistence_api_version=$persistence_api_version
+osgi_service_component_version=$osgi_service_component_version
 hibernate_version=$hibernate_version
 kotlin_version=$kotlin_version
 osgi_version=$osgi_version


### PR DESCRIPTION
Bnd _must_ compile against jars, and not against directories of classes. Set the `LibraryElements.JAR` variant attribute on the correct resolvable configurations to ensure that Gradle does this.

Bnd sets Gradle's `LibraryElements.JAR` attribute on the `compileClasspath` configuration for us already, but there's no harm in us setting it too. We also need to set this attribute on the `cordappExternal` configuration in order to be consistent with `compileClasspath`, and to configure any "detached configuration" used when tracing transitive CorDapp dependencies.