### PR TITLE
CORE-2057: Update how the CPK tests publish CPKs.

### DIFF
--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/PublishAfterEvaluationHandler.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/PublishAfterEvaluationHandler.kt
@@ -48,7 +48,7 @@ class PublishAfterEvaluationHandler(rootProject: Project) : Action<Gradle> {
             // Each sub-project can load its plugins into its
             // own classloader, which makes all of the [Plugin]
             // implementation classes different.
-            if (project.plugins.hasPlugin(CORDAPP_CPK_PLUGIN_ID)) {
+            project.plugins.withId(CORDAPP_CPK_PLUGIN_ID) {
                 publishCompanionFor(project)
             }
         }

--- a/cordapp-cpk/src/test/resources/transitive-cordapps/build.gradle
+++ b/cordapp-cpk/src/test/resources/transitive-cordapps/build.gradle
@@ -31,10 +31,10 @@ allprojects {
             publications {
                 maven(MavenPublication) {
                     from components.java
-                    try {
+
+                    // Publish any CPK that this project may have.
+                    pluginManager.withPlugin('net.corda.plugins.cordapp-cpk') {
                         artifact tasks.named('cpk')
-                    } catch (UnknownTaskException) {
-                        // This project has no CPK to publish.
                     }
                 }
             }


### PR DESCRIPTION
The most reliable way to check whether a project has a CPK to publish is to use the plugin manager.