### PR TITLE
CORE-2087: Allow cordapp-cpk to apply OSGi "consumer policy" to Corda packages.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,28 @@ subprojects {
                 languageVersion = of(8)
             }
         }
+
+        if (parent == rootProject) {
+            // Add a META-INF/pluginVersion.properties resource into each plugin jar.
+            def generateResources = tasks.register('generateResources') {
+                def versionFile = layout.buildDirectory.dir('generated').map { dir ->
+                    dir.file('pluginVersion.properties')
+                }
+
+                outputs.file versionFile
+                doLast {
+                    versionFile.get().asFile.withWriter { out ->
+                        out.println "version=${version}"
+                    }
+                }
+            }
+
+            tasks.named("processResources", ProcessResources) {
+                from(files(generateResources)) {
+                    into 'META-INF'
+                }
+            }
+        }
     }
 
     tasks.withType(JavaCompile).configureEach {

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappUtils.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappUtils.kt
@@ -36,6 +36,9 @@ const val CORDAPP_CPK_PLUGIN_ID = "net.corda.plugins.cordapp-cpk"
 const val CORDAPP_TASK_GROUP = "Cordapp"
 const val CPK_XML_NAMESPACE = "urn:corda-cpk"
 
+const val CORDA_API_GROUP = "net.corda"
+const val ENTERPRISE_API_GROUP = "com.r3.corda"
+
 const val CORDAPP_SEALING_SYSTEM_PROPERTY_NAME = "net.corda.cordapp.sealing.enabled"
 
 const val CPK_TASK_NAME = "cpk"
@@ -71,6 +74,7 @@ const val CORDA_CONTRACT_CLASSES = "Corda-Contract-Classes"
 const val CORDA_WORKFLOW_CLASSES = "Corda-Flow-Classes"
 const val CORDA_MAPPED_SCHEMA_CLASSES = "Corda-MappedSchema-Classes"
 const val CORDA_SERVICE_CLASSES = "Corda-Service-Classes"
+const val IMPORT_POLICY_PACKAGES = "Import-Policy-Packages"
 const val REQUIRED_PACKAGES = "Required-Packages"
 
 const val CORDAPP_PLATFORM_VERSION = "Cordapp-Built-Platform-Version"

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/DependencyCalculator.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/DependencyCalculator.kt
@@ -137,7 +137,7 @@ open class DependencyCalculator @Inject constructor(objects: ObjectFactory) : De
 
     @TaskAction
     fun calculate() {
-        // Compute the (unresolved) dependencies on the runtime classpath
+        // Compute the (unresolved) dependencies on the packaging classpath
         // that the user has selected for this CPK archive. We ignore any
         // dependencies from the cordaRuntimeOnly configuration because
         // these will be provided by Corda. Also ignore anything from the
@@ -228,8 +228,8 @@ open class DependencyCalculator @Inject constructor(objects: ObjectFactory) : De
             .filterNot { artifact -> isCordaProvided(artifact.moduleVersion.id) }
             .also { artifacts ->
                 // Corda artifacts should not be included, either directly or transitively.
-                warnAboutCordaArtifacts("net.corda", artifacts)
-                warnAboutCordaArtifacts("com.r3.corda", artifacts)
+                warnAboutCordaArtifacts(CORDA_API_GROUP, artifacts)
+                warnAboutCordaArtifacts(ENTERPRISE_API_GROUP, artifacts)
             }
     }
 

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/OsgiExtension.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/OsgiExtension.kt
@@ -61,9 +61,13 @@ open class OsgiExtension(objects: ObjectFactory, useImportPolicy: Provider<Boole
             "org.hibernate.proxy"
         ))
 
-        private val Array<String>.packageRange: IntRange get() {
-            val firstIdx = if (size > 2 && this[0] == "META-INF" && this[1] == "versions") { 3 } else { 0 }
-            return firstIdx..size - 2
+        private fun getPackageRange(packages: Array<String>): IntRange {
+            val firstIdx = if (packages.size > 2 && packages[0] == "META-INF" && packages[1] == "versions") {
+                3
+            } else {
+                0
+            }
+            return firstIdx..packages.size - 2
         }
 
         @Throws(IOException::class)
@@ -273,7 +277,7 @@ open class OsgiExtension(objects: ObjectFactory, useImportPolicy: Provider<Boole
         jar.rootSpec.eachFile { file ->
             if (!file.isDirectory) {
                 val elements = file.relativePath.segments
-                val packageRange = elements.packageRange
+                val packageRange = getPackageRange(elements)
                 if (!packageRange.isEmpty()) {
                     val packageName = elements.slice(packageRange)
                     if (packageName[0] != "META-INF" && packageName[0] != "OSGI-INF" && packageName.isJavaIdentifiers) {

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/ConfigureCordaMetadataTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/ConfigureCordaMetadataTest.kt
@@ -14,6 +14,8 @@ class ConfigureCordaMetadataTest {
         private const val CORDAPP_VERSION = "1.1.1-SNAPSHOT"
         private const val HIBERNATE_ANNOTATIONS_PACKAGE = "org.hibernate.annotations"
         private const val HIBERNATE_PROXY_PACKAGE = "org.hibernate.proxy"
+        private const val CORDA_OSGI_VERSION = "version=[5,6)"
+
         private lateinit var testProject: GradleProject
 
         @Suppress("unused")
@@ -51,6 +53,9 @@ class ConfigureCordaMetadataTest {
                 .isEqualTo("com.example.metadata.custom.ExampleContract,com.example.metadata.custom.ExampleContract\$NestedContract")
             assertThatHeader(getValue(IMPORT_PACKAGE))
                 .doesNotContainPackage(HIBERNATE_ANNOTATIONS_PACKAGE, HIBERNATE_PROXY_PACKAGE)
+                .containsPackageWithAttributes("net.corda.v5.application.identity", CORDA_OSGI_VERSION)
+                .containsPackageWithAttributes("net.corda.v5.ledger.contracts", CORDA_OSGI_VERSION)
+                .containsPackageWithAttributes("net.corda.v5.ledger.transactions", CORDA_OSGI_VERSION)
             assertThatHeader(getValue(DYNAMICIMPORT_PACKAGE))
                 .doesNotContainPackage(HIBERNATE_ANNOTATIONS_PACKAGE, HIBERNATE_PROXY_PACKAGE)
                 .containsPackageWithAttributes("org.testing")

--- a/cordapp-cpk/src/test/resources/configure-corda-metadata/build.gradle
+++ b/cordapp-cpk/src/test/resources/configure-corda-metadata/build.gradle
@@ -9,6 +9,7 @@ subprojects {
 
 configurations {
     testArtifacts {
+        canBeConsumed = false
         transitive = false
     }
 }
@@ -17,11 +18,14 @@ dependencies {
     testArtifacts project(':cordapp')
 }
 
+def artifactDir = layout.buildDirectory.dir('libs')
 def copy = tasks.register('copy', Copy) {
-    into layout.buildDirectory.dir('libs')
+    into artifactDir
     from configurations.testArtifacts
 }
 
-tasks.named('assemble') {
-    dependsOn copy
+artifacts {
+    archives(artifactDir) {
+        builtBy copy
+    }
 }

--- a/cordapp-cpk/src/test/resources/configure-corda-metadata/cordapp/build.gradle
+++ b/cordapp-cpk/src/test/resources/configure-corda-metadata/cordapp/build.gradle
@@ -9,7 +9,6 @@ apply from: '../kotlin.gradle'
 
 cordapp {
     targetPlatformVersion = platform_version.toInteger()
-    minimumPlatformVersion = platform_version.toInteger()
 
     contract {
         name = contract_name
@@ -21,7 +20,7 @@ cordapp {
 
 version = cordapp_version
 
-jar {
+tasks.named('jar', Jar) {
     archiveBaseName = 'cordapp'
 }
 

--- a/cordapp-cpk/src/test/resources/cordapp-configuration/src/main/resources/net/corda/cordapp/cordapp-configuration.properties
+++ b/cordapp-cpk/src/test/resources/cordapp-configuration/src/main/resources/net/corda/cordapp/cordapp-configuration.properties
@@ -1,3 +1,7 @@
 Corda-Other-Contract-Classes=IMPLEMENTS;net.corda.v5.ledger.contracts.Contract
 Required-Packages=org.testing,\
   com.foo.bar
+
+# Deliberately using two wildcard packages here, for test purposes.
+Import-Policy-Packages=net.corda.v5.application.*,\
+  net.corda.v5.ledger.*

--- a/cordapp-cpk/src/test/resources/with-corda-metadata/build.gradle
+++ b/cordapp-cpk/src/test/resources/with-corda-metadata/build.gradle
@@ -8,6 +8,7 @@ subprojects {
 
 configurations {
     testArtifacts {
+        canBeConsumed = false
         transitive = false
     }
 }
@@ -21,11 +22,14 @@ dependencies {
     testArtifacts project(path: ':services', configuration: 'cordaCPK')
 }
 
+def artifactDir = layout.buildDirectory.dir('libs')
 def copy = tasks.register('copy', Copy) {
-    into project.layout.buildDirectory.dir('libs')
+    into artifactDir
     from configurations.testArtifacts
 }
 
-tasks.named('assemble') {
-    dependsOn copy
+artifacts {
+    archives(artifactDir) {
+        builtBy copy
+    }
 }


### PR DESCRIPTION
Corda's APIs currently all live under this package mask:
```
net.corda.v5.*
```
We expect to add other masks over time. Add a new `Import-Policy-Packages` property to `cordapp-configuration.properties` containing these package masks as a comma-separated list. The `cordapp-cpk` plugin will uses these masks to create extra `Import-Package` instructions for Bnd:
```
net.corda.v5.*;version='${range;[=,+);${@}}'
```
The `${range}` macro here will ensure that OSGi will only check the Corda API major version number when loading CorDapps, e.g.:
```
5 <= version < 6
```