### PR TITLE
NOTICK: Update Groovy and Gradle constructs.

### DIFF
--- a/cordapp-cpk/src/test/resources/cordapp-cpb/build.gradle
+++ b/cordapp-cpk/src/test/resources/cordapp-cpb/build.gradle
@@ -46,14 +46,14 @@ dependencies {
 }
 
 
-def cpkDir = file("$buildDir/cpks")
+def cpkDir = layout.buildDirectory.dir('cpks')
 def copyCPKs = tasks.register('copyCPKs', Copy) {
     from configurations.cpks
     into cpkDir
 }
 
 artifacts {
-    archives(file: cpkDir) {
+    archives(cpkDir) {
         builtBy copyCPKs
     }
 }

--- a/cordapp-cpk/src/test/resources/external-cordapp/build.gradle
+++ b/cordapp-cpk/src/test/resources/external-cordapp/build.gradle
@@ -30,7 +30,7 @@ allprojects { p ->
             maven(MavenPublication) {
                 from components.java
                 pluginManager.withPlugin('net.corda.plugins.cordapp-cpk') {
-                    artifact tasks.named('cpk')
+                    artifact tasks.named('cpk', Jar)
                 }
             }
         }
@@ -40,7 +40,6 @@ allprojects { p ->
 
 cordapp {
     targetPlatformVersion = platform_version.toInteger()
-    minimumPlatformVersion = platform_version.toInteger()
 
     contract {
         name = 'External CorDapp'
@@ -51,9 +50,8 @@ cordapp {
 }
 
 dependencies {
-    cordaProvided project(":corda-api")
+    cordaProvided project(':corda-api')
 
-    cordapp project("corda-platform-cordapp")
-    cordapp project("external-cordapp-transitive-dependency")
+    cordapp project('corda-platform-cordapp')
+    cordapp project('external-cordapp-transitive-dependency')
 }
-

--- a/cordapp-cpk/src/test/resources/external-cordapp/corda-platform-cordapp/build.gradle
+++ b/cordapp-cpk/src/test/resources/external-cordapp/corda-platform-cordapp/build.gradle
@@ -3,9 +3,7 @@ plugins {
 }
 
 cordapp {
-
     targetPlatformVersion = platform_version.toInteger()
-    minimumPlatformVersion = platform_version.toInteger()
 
     contract {
         name = 'Corda platform CorDapp'
@@ -16,11 +14,11 @@ cordapp {
 }
 
 dependencies {
-    cordaProvided project(":corda-api")
+    cordaProvided project(':corda-api')
 }
 
 jar {
     manifest {
-        attributes(['Corda-CPK-Type': "corda-api"])
+        attributes(['Corda-CPK-Type': 'corda-api'])
     }
 }

--- a/cordapp-cpk/src/test/resources/external-cordapp/external-cordapp-transitive-dependency/build.gradle
+++ b/cordapp-cpk/src/test/resources/external-cordapp/external-cordapp-transitive-dependency/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 cordapp {
     targetPlatformVersion = platform_version.toInteger()
-    minimumPlatformVersion = platform_version.toInteger()
 
     contract {
         name = 'External CorDapp transitive dependency'
@@ -15,5 +14,5 @@ cordapp {
 }
 
 dependencies {
-    cordaProvided project(":corda-api")
+    cordaProvided project(':corda-api')
 }


### PR DESCRIPTION
Update Groovy and Gradle for Gradle 6+ best practices.

Also remove some unnecessary `minimumPlatformVersion` properties.