### PR TITLE
NOTICK: Test using OSGi 8.0.0, which is what Bnd 5.3 supports.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ lombok_version=1.18.16
 slf4j_version=1.7.30
 docker_client_version=8.15.1
 javax_annotations_version=1.3.2
-osgi_version=7.0.0
+osgi_version=8.0.0
 bnd_version=5.3.0
 
 bintray_version=1.8.5


### PR DESCRIPTION
The `biz.aQute.bnd.annotation:5.3.0` artifact actually depends on OSGi 8.0.0, so upgrade our test dependency to match.