### PR TITLE
CORE-2336: Use jar task as convention for CPK and CPB tasks.

### DIFF
--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpb/CpbPlugin.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpb/CpbPlugin.kt
@@ -17,8 +17,10 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency.ARCHIVES_CONFIGURATION
 import org.gradle.api.artifacts.ExternalDependency
 import org.gradle.api.artifacts.ModuleDependency
+import org.gradle.api.plugins.JavaPlugin.JAR_TASK_NAME
+import org.gradle.api.tasks.bundling.Jar
 
-@Suppress("UnstableApiUsage")
+@Suppress("Unused", "UnstableApiUsage")
 class CpbPlugin : Plugin<Project> {
 
     companion object {
@@ -92,6 +94,13 @@ class CpbPlugin : Plugin<Project> {
             val cordappExtension = project.extensions.findByType(CordappExtension::class.java)
                 ?: throw GradleException("Cordapp extension not found")
             cpbTask.inputs.nested("cordappSigning", cordappExtension.signing)
+
+            // Basic configuration of the CPB task.
+            val jarTask = project.tasks.named(JAR_TASK_NAME, Jar::class.java)
+            cpbTask.destinationDirectory.convention(jarTask.flatMap(Jar::getDestinationDirectory))
+            cpbTask.archiveBaseName.convention(jarTask.flatMap(Jar::getArchiveBaseName))
+            cpbTask.archiveAppendix.convention(jarTask.flatMap(Jar::getArchiveAppendix))
+
             cpbTask.doLast {
                 if (cordappExtension.signing.enabled.get()) {
                     cpbTask.sign(cordappExtension.signing, cpbTask.archiveFile.get().asFile)

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappPlugin.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappPlugin.kt
@@ -324,9 +324,9 @@ class CordappPlugin @Inject constructor(private val layouts: ProjectLayout): Plu
             task.mustRunAfter(verifyBundle)
 
             // Basic configuration of the packaging task.
-            task.destinationDirectory.set(jarTask.flatMap(Jar::getDestinationDirectory))
-            task.archiveBaseName.set(jarTask.flatMap(Jar::getArchiveBaseName))
-            task.archiveAppendix.set(jarTask.flatMap(Jar::getArchiveAppendix))
+            task.destinationDirectory.convention(jarTask.flatMap(Jar::getDestinationDirectory))
+            task.archiveBaseName.convention(jarTask.flatMap(Jar::getArchiveBaseName))
+            task.archiveAppendix.convention(jarTask.flatMap(Jar::getArchiveAppendix))
 
             // Configure the CPK archive contents.
             task.setLibrariesFrom(constraintsTask)


### PR DESCRIPTION
When CorDapp developers set `archiveBaseName` and/or `archiveAppendix` for the `jar` task, also use these values as the defaults for both `cpk` and `cpb` tasks.

This doesn't prevent developers from _explicitly_ setting these values for `cpk` and `cpb` tasks. It only guarantees that they will both match the `jar` task unless explicitly set differently.