### PR TITLE
NOTICK: Upgrade to Gradle 6.9.1.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -239,6 +239,6 @@ artifactory {
 }
 
 wrapper {
-    gradleVersion = '6.9'
+    gradleVersion = '6.9.1'
     distributionType = Wrapper.DistributionType.ALL
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://gradleproxy:gradleproxy@software.r3.com/artifactory/gradle-proxy/gradle-6.9-all.zip
+distributionUrl=https\://gradleproxy:gradleproxy@software.r3.com/artifactory/gradle-proxy/gradle-6.9.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
[Gradle 6.9.1 has been released.](https://docs.gradle.org/6.9.1/release-notes.html)

This contains fixes back-ported from Gradle 7.