### PR TITLE
NOTICK: Remove obsolete Bintray Gradle plugin.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ plugins {
     id 'org.jetbrains.kotlin.jvm' apply false
     id 'com.gradle.plugin-publish' apply false
     id 'com.jfrog.artifactory' apply false
-    id 'com.jfrog.bintray' apply false
 }
 
 ext {
@@ -107,7 +106,6 @@ def publishProjects = project.childProjects.values()
 configure(publishProjects) { Project subproject ->
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'
-    apply plugin: 'com.jfrog.bintray'
     apply plugin: 'com.jfrog.artifactory'
     apply plugin: 'com.gradle.plugin-publish'
 
@@ -191,26 +189,6 @@ configure(publishProjects) { Project subproject ->
                             dependency.appendNode('version', subproject.version)
                         }
                     }
-                }
-            }
-        }
-    }
-
-    bintray {
-        user = System.getenv('CORDA_BINTRAY_USER') ?: System.getProperty('corda.bintray.user')
-        key = System.getenv('CORDA_BINTRAY_KEY') ?: System.getProperty('corda.bintray.key')
-        publications = [subproject.name]
-        dryRun = (System.getenv('CORDA_BINTRAY_DRYRUN') != null || System.getProperty('corda.bintray.dryrun') != null)
-        pkg {
-            repo = 'corda'
-            name = subproject.name
-            userOrg = 'r3'
-            licenses = ['Apache-2.0']
-
-            version {
-                gpg {
-                    sign = true
-                    passphrase = System.getenv('CORDA_BINTRAY_GPG_PASSPHRASE')
                 }
             }
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,6 @@ javax_annotations_version=1.3.2
 osgi_version=8.0.0
 bnd_version=5.3.0
 
-bintray_version=1.8.5
 artifactory_version=4.21.0
 gradle_publish_version=0.15.0
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,7 +9,6 @@ pluginManagement {
         id 'biz.aQute.bnd.builder' version bnd_version
         id 'com.gradle.plugin-publish' version gradle_publish_version
         id 'com.jfrog.artifactory' version artifactory_version
-        id 'com.jfrog.bintray' version bintray_version
         id 'org.owasp.dependencycheck' version '5.3.2.1'
         id 'com.gradle.enterprise' version '3.6.1'
     }


### PR DESCRIPTION
Bintray has closed, so we can no longer publish to it. Remove the `com.jfrog.bintray` Gradle plugin from the build.