### PR TITLE
NOTICK: Either generate KDocs or Javadocs, but not both.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,7 +162,11 @@ configure(publishProjects) { Project subproject ->
                 groupId subproject.group
                 artifactId subproject.name
                 artifact tasks.named('sourcesJar', Jar)
-                artifact tasks.named('publishPluginJavaDocsJar', Jar)
+                try {
+                    artifact tasks.named('kdocsJar', Jar)
+                } catch (UnknownTaskException e) {
+                    artifact tasks.named('publishPluginJavaDocsJar', Jar)
+                }
 
                 pom {
                     name = subproject.name

--- a/cordapp-cpk/build.gradle
+++ b/cordapp-cpk/build.gradle
@@ -106,11 +106,11 @@ processTestResources {
     }
 }
 
-tasks.withType(Jar).matching { it.name == 'publishPluginJavaDocsJar' }
-    .configureEach {
-        def dokka = tasks.named('dokkaHtml')
-        from dokka.flatMap { it.outputDirectory }
-    }
+tasks.register('kdocsJar', Jar) {
+    def dokka = tasks.named('dokkaHtml')
+    from dokka.flatMap { it.outputDirectory }
+    archiveClassifier = 'javadoc'
+}
 
 tasks.withType(Javadoc).configureEach {
     options.showFromPackage()

--- a/jar-filter/build.gradle
+++ b/jar-filter/build.gradle
@@ -73,11 +73,11 @@ dependencies {
     jacocoRuntime "org.jacoco:org.jacoco.agent:${jacoco.toolVersion}:runtime"
 }
 
-tasks.withType(Jar).matching { it.name == 'publishPluginJavaDocsJar' }
-    .configureEach {
-        def dokka = tasks.named('dokkaHtml')
-        from dokka.flatMap { it.outputDirectory }
-    }
+tasks.register('kdocsJar', Jar) {
+    def dokka = tasks.named('dokkaHtml')
+    from dokka.flatMap { it.outputDirectory }
+    archiveClassifier = 'javadoc'
+}
 
 tasks.named('compileTestKotlin') {
     kotlinOptions {


### PR DESCRIPTION
Use Dokka for Kotlin plugins, and Gradle's own `publishPluginJavaDocsJar` docs task otherwise. This prevents us generating duplicate `index.html` files, which will break the build in Gradle 7.x.