### PR TITLE
CORE-2495: Copy name, scm, licenses and developers to CPK companion POM.

### DIFF
--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/TransitiveRemoteCordappsTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/TransitiveRemoteCordappsTest.kt
@@ -68,6 +68,11 @@ class TransitiveRemoteCordappsTest {
                     "-Pcpk1_type=$cpk1Type",
                     "-Pcpk2_type=$cpk2Type"
                 )
+
+            // Check that we could still read all of Gradle's MavenPom properties.
+            assertThat(publisherProject.output.split(System.lineSeparator()))
+                .noneMatch { it.startsWith("INTERNAL API:") }
+
             testProject = GradleProject(testProjectDir, reporter)
                 .withTestName("transitive-remote-cordapps")
                 .withSubResource("src/main/kotlin/com/example/transitives/ExampleContract.kt")

--- a/cordapp-cpk/src/test/resources/transitive-cordapps/build.gradle
+++ b/cordapp-cpk/src/test/resources/transitive-cordapps/build.gradle
@@ -39,6 +39,32 @@ allprojects {
                     pluginManager.withPlugin('net.corda.plugins.cordapp-cpk') {
                         artifact tasks.named('cpk', Jar)
                     }
+
+                    pom {
+                        name = 'Transitive CorDapps'
+                        url = 'https://com.example.cordapp'
+                        scm {
+                            url = 'https://com.example.cordapp'
+                        }
+                        organization {
+                            name = 'Example-Name'
+                            url = 'https://example.com'
+                        }
+                        licenses {
+                            license {
+                                name = 'Apache-2.0'
+                                url = 'https://www.apache.org/licenses/LICENSE-2.0'
+                                distribution = 'repo'
+                            }
+                        }
+                        developers {
+                            developer {
+                                id = 'Example-Id'
+                                name = 'Example-Name'
+                                email = 'dev@example.com'
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Maven Central requires POMs to contain the following extra fields:
- `name`
- `scm`
- `licenses`
- `developers`

And include `organization` too, for good measure.