### PR TITLE
CORE-2578: Exclude JetBrains' annotations jar from CPKs.

### DIFF
--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/DependencyCalculator.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/DependencyCalculator.kt
@@ -28,6 +28,7 @@ open class DependencyCalculator @Inject constructor(objects: ObjectFactory) : De
         private const val CORDA = true
 
         private val HARDCODED_EXCLUDES: Set<Pair<String, String>> = unmodifiableSet(setOf(
+            "org.jetbrains" to "annotations",
             "org.jetbrains.kotlin" to "*",
             "net.corda.kotlin" to "*",
             "org.osgi" to "*",


### PR DESCRIPTION
CPKs do not need to contain `org.jetbrains:annotations`. This is just a transitive dependency of
```groovy
'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
```
that is not required by
```groovy
'org.jetbrains.kotlin:kotlin-osgi-bundle'
```