### PR TITLE
CORE-2591: CPK 'migration' package should be private by default.

### DIFF
--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/OsgiExtension.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/OsgiExtension.kt
@@ -280,7 +280,10 @@ open class OsgiExtension(objects: ObjectFactory, useImportPolicy: Provider<Boole
                 val packageRange = getPackageRange(elements)
                 if (!packageRange.isEmpty()) {
                     val packageName = elements.slice(packageRange)
-                    if (packageName[0] != "META-INF" && packageName[0] != "OSGI-INF" && packageName.isJavaIdentifiers) {
+                    if (packageName[0] != "META-INF"
+                        && packageName[0] != "OSGI-INF"
+                        && packageName[0] != "migration"
+                        && packageName.isJavaIdentifiers) {
                         _autoExportPackages.add(packageName.joinToString("."))
                     }
                 }

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/Assertions.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/Assertions.kt
@@ -14,6 +14,11 @@ class AssertHeaders(private val parameters: Parameters) {
         return this
     }
 
+    fun containsExactly(vararg elements: String): AssertHeaders {
+        assertThat(actualElements).containsExactly(*elements)
+        return this
+    }
+
     fun containsPackageWithAttributes(packageName: String, vararg attributes: String): AssertHeaders {
         assertThat(parameters.keys).contains(packageName)
         val packageAttributes = parameters[packageName].map(Any::toString)

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithSchemaTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithSchemaTest.kt
@@ -1,0 +1,55 @@
+package net.corda.plugins.cpk
+
+import aQute.bnd.osgi.Constants.PRIVATE_PACKAGE
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestReporter
+import org.junit.jupiter.api.io.TempDir
+import org.osgi.framework.Constants.EXPORT_PACKAGE
+import java.nio.file.Path
+
+class CordappWithSchemaTest {
+    companion object {
+        private const val cordappVersion = "1.0.1-SNAPSHOT"
+        private const val slf4jVersion = "2.0.0-alpha1"
+
+        private lateinit var testProject: GradleProject
+
+        @Suppress("unused")
+        @BeforeAll
+        @JvmStatic
+        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+            testProject = GradleProject(testProjectDir, reporter)
+                .withTestName("cordapp-with-schema")
+                .withSubResource("src/main/kotlin/com/example/schema/SchemaContract.kt")
+                .withSubResource("src/main/resources/migration/sample.changelog-master.xml")
+                .withSubResource("src/main/resources/migration/sample-migration-v1.0.xml")
+                .build(
+                    "-Pcordapp_version=$cordappVersion",
+                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                    "-Pcorda_api_version=$cordaApiVersion",
+                    "-Pslf4j_version=$slf4jVersion"
+                )
+        }
+    }
+
+    @Test
+    fun schemaMigrationTest() {
+        val artifacts = testProject.artifacts
+        assertThat(artifacts).hasSize(2)
+
+        val cordapp = artifacts.single { it.toString().endsWith(".jar") }
+        assertThat(cordapp).isRegularFile()
+
+        val jarManifest = cordapp.manifest
+        println(jarManifest.mainAttributes.entries)
+
+        with(jarManifest.mainAttributes) {
+            assertThatHeader(getValue(PRIVATE_PACKAGE))
+                .containsPackageWithAttributes("migration")
+            assertThatHeader(getValue(EXPORT_PACKAGE))
+                .doesNotContainPackage("migration")
+        }
+    }
+}

--- a/cordapp-cpk/src/test/resources/cordapp-with-schema/build.gradle
+++ b/cordapp-cpk/src/test/resources/cordapp-with-schema/build.gradle
@@ -1,0 +1,33 @@
+plugins {
+    id 'net.corda.plugins.cordapp-cpk'
+    id 'org.jetbrains.kotlin.jvm'
+}
+
+apply from: 'repositories.gradle'
+apply from: 'javaTarget.gradle'
+apply from: 'kotlin.gradle'
+
+group = 'com.example'
+version = cordapp_version
+
+cordapp {
+    targetPlatformVersion = platform_version.toInteger()
+    minimumPlatformVersion = platform_version.toInteger()
+
+    contract {
+        name = 'CorDapp With Schema'
+        versionId = cordapp_contract_version.toInteger()
+        licence = 'Test-Licence'
+        vendor = 'R3'
+    }
+}
+
+dependencies {
+    cordaProvided project(':corda-api')
+    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    implementation "org.slf4j:slf4j-api:$slf4j_version"
+}
+
+tasks.named('jar', Jar) {
+    archiveBaseName = 'cordapp-with-schema'
+}

--- a/cordapp-cpk/src/test/resources/cordapp-with-schema/settings.gradle
+++ b/cordapp-cpk/src/test/resources/cordapp-with-schema/settings.gradle
@@ -1,0 +1,16 @@
+// Common settings for all Gradle test projects.
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+    }
+
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version kotlin_version
+        id 'biz.aQute.bnd.builder' version bnd_version
+    }
+}
+
+rootProject.name = 'cordapp-with-schema'
+
+include 'corda-api'
+project(':corda-api').projectDir = file('../resources/test/corda-api')

--- a/cordapp-cpk/src/test/resources/cordapp-with-schema/src/main/kotlin/com/example/schema/SchemaContract.kt
+++ b/cordapp-cpk/src/test/resources/cordapp-with-schema/src/main/kotlin/com/example/schema/SchemaContract.kt
@@ -1,0 +1,31 @@
+@file:Suppress("PackageDirectoryMismatch")
+package com.example.schema
+
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Table
+import net.corda.v5.persistence.MappedSchema
+import net.corda.v5.ledger.contracts.Contract
+import net.corda.v5.ledger.transactions.LedgerTransaction
+
+class SampleContract : Contract {
+    override fun verify(tx: LedgerTransaction) {
+    }
+}
+
+data class Sample(val names: Set<String>)
+
+object SampleBase
+
+object SampleSchema : MappedSchema(
+    schemaFamily = SampleBase::class.java,
+    version = 1,
+    mappedTypes = listOf(PersistentSampleState::class.java)
+) {
+    @Entity
+    @Table(name = "sample_states")
+    class PersistentSampleState(
+        @Column(name = "name")
+        var name: String
+    )
+}

--- a/cordapp-cpk/src/test/resources/cordapp-with-schema/src/main/resources/migration/sample-migration-v1.0.xml
+++ b/cordapp-cpk/src/test/resources/cordapp-with-schema/src/main/resources/migration/sample-migration-v1.0.xml
@@ -1,0 +1,16 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="https://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="https://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <changeSet author="R3.Corda" id="sample-migration-v1.0">
+        <createTable tableName="sample_states">
+            <column name="output_index" type="INT" />
+            <column name="transaction_id" type="VARCHAR(80)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/cordapp-cpk/src/test/resources/cordapp-with-schema/src/main/resources/migration/sample.changelog-master.xml
+++ b/cordapp-cpk/src/test/resources/cordapp-with-schema/src/main/resources/migration/sample.changelog-master.xml
@@ -1,0 +1,6 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="https://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="https://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <include file="migration/sample-migration-v1.0.xml"/>
+</databaseChangeLog>


### PR DESCRIPTION
We expect Liquibase migration scripts to be added to a CPK "main" jar's `migration` package. However, we also cannot allow two CPKs to export the same package into the OSGi framework. Together, these two constraints _require_ that `migration.*` is always `Private-Package`, regardless of the `jar` task's
```gradle
osgi {
    autoExport = true
}
```
setting.