### PR TITLE
CORE-2739: Upgrade to Bnd 6.0.0.

### DIFF
--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/OsgiExtension.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/OsgiExtension.kt
@@ -34,7 +34,7 @@ fun TaskInputs.nested(nestName: String, osgi: OsgiExtension) {
 }
 
 @Suppress("UnstableApiUsage", "MemberVisibilityCanBePrivate", "unused")
-open class OsgiExtension(objects: ObjectFactory, useImportPolicy: Provider<Boolean>, jar: Jar) {
+open class OsgiExtension(objects: ObjectFactory, jar: Jar) {
     private companion object {
         private const val CORDAPP_CONFIG_PLUGIN_ID = "net.corda.cordapp.cordapp-configuration"
         private const val CORDAPP_CONFIG_FILENAME = "cordapp-configuration.properties"
@@ -92,7 +92,7 @@ open class OsgiExtension(objects: ObjectFactory, useImportPolicy: Provider<Boole
             return value.split(",").mapTo(LinkedHashSet(), String::trim)
         }
 
-        fun consumerPolicy(value: String): String = "$value;version='\${range;[=,+);\${@}}'"
+        fun consumerPolicy(value: String): String = "$value:o;version='\${range;[=,+);\${@}}'"
         fun dynamic(value: String): String = "$value;resolution:=dynamic;version=!"
         fun optional(value: String): String = "$value;resolution:=optional"
         fun emptyVersion(value: String): String = "$value;version='[0,0)'"
@@ -214,7 +214,7 @@ open class OsgiExtension(objects: ObjectFactory, useImportPolicy: Provider<Boole
         }
     }
 
-    val applyImportPolicy: Property<Boolean> = objects.property(Boolean::class.java).convention(useImportPolicy)
+    val applyImportPolicy: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
 
     private val activePolicy: Provider<out Set<String>>
         get() = applyImportPolicy.flatMap { isActive ->

--- a/cordapp-cpk/src/test/resources/corda-api/build.gradle
+++ b/cordapp-cpk/src/test/resources/corda-api/build.gradle
@@ -29,8 +29,10 @@ tasks.named('jar', Jar) {
         attributes('Corda-Platform-Version': 1000)
     }
 
-    bnd """\
+    bundle {
+        bnd '''\
 Bundle-SymbolicName: net.corda.api
 Bundle-Name: Fake Corda APIs
-"""
+'''
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ lombok_version=1.18.16
 slf4j_version=1.7.32
 javax_annotations_version=1.3.2
 osgi_version=8.0.0
-bnd_version=5.3.0
+bnd_version=6.0.0
 
 artifactory_version=4.21.0
 gradle_publish_version=0.15.0


### PR DESCRIPTION
Bnd 6.0.0 has been released with [these changes](https://github.com/bndtools/bnd/wiki/Changes-in-6.0.0).

We can now make our import policy instruction "optional", so that it won't generate warnings if no packages need to apply it.

Bnd 6.0.0 also replaces deprecated Gradle `Convention` objects with `Extension` objects, so the `cordapp-cpk` plugin has been updated accordingly.