### PR TITLE
CORE-2793: Allow cordaProvided dependencies to use constraints.

### DIFF
--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/AttributeFactory.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/AttributeFactory.kt
@@ -26,10 +26,8 @@ import org.gradle.api.model.ObjectFactory
  * variant attribute.
  */
 fun isPlatformModule(dependency: ModuleDependency): Boolean {
-    val attr = dependency.attributes.getAttribute(CATEGORY_ATTRIBUTE) ?: return false
-    return attr.name.let { value ->
-        value == REGULAR_PLATFORM || value == ENFORCED_PLATFORM
-    }
+    val attributeName = (dependency.attributes.getAttribute(CATEGORY_ATTRIBUTE) ?: return false).name
+    return attributeName == REGULAR_PLATFORM || attributeName == ENFORCED_PLATFORM
 }
 
 internal class AttributeFactory(

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithConstraintTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithConstraintTest.kt
@@ -1,0 +1,54 @@
+package net.corda.plugins.cpk
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestReporter
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class CordappWithConstraintTest {
+    companion object {
+        private const val cordappVersion = "1.0.1-SNAPSHOT"
+        private const val library1Version = "1.2.3-SNAPSHOT"
+        private const val library2Version = "1.2.4-SNAPSHOT"
+
+        private lateinit var testProject: GradleProject
+
+        @Suppress("unused")
+        @BeforeAll
+        @JvmStatic
+        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+            testProject = GradleProject(testProjectDir, reporter)
+                .withTestName("cordapp-with-constraint")
+                .withSubResource("src/main/kotlin/com/example/constraint/ConstraintContract.kt")
+                .withSubResource("library1/src/main/java/org/testing/compress/package-info.java")
+                .withSubResource("library1/src/main/java/org/testing/compress/ExampleZip.java")
+                .withSubResource("library1/build.gradle")
+                .withSubResource("library2/src/main/java/org/testing/io/package-info.java")
+                .withSubResource("library2/src/main/java/org/testing/io/ExampleStream.java")
+                .withSubResource("library2/build.gradle")
+                .build(
+                    "-Pcordapp_version=$cordappVersion",
+                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                    "-Pcorda_api_version=$cordaApiVersion",
+                    "-Plibrary1_version=$library1Version",
+                    "-Plibrary2_version=$library2Version",
+                    "-Pcommons_io_version=$commonsIoVersion",
+                    "-Pcommons_codec_version=$commonsCodecVersion",
+                    "-Pcommons_compress_version=$commonsCompressVersion"
+                )
+        }
+    }
+
+    @Test
+    fun testLibrariesWithConstraints() {
+        assertThat(testProject.dependencyConstraints)
+            .noneMatch { it.fileName.startsWith("commons-compress-") }
+            .noneMatch { it.fileName.startsWith("library1-") }
+            .anyMatch { it.fileName == "commons-io-$commonsIoVersion.jar" }
+            .anyMatch { it.fileName == "commons-codec-$commonsCodecVersion.jar" }
+            .anyMatch { it.fileName == "library2-$library2Version.jar" }
+            .hasSizeGreaterThanOrEqualTo(3)
+    }
+}

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/GradleProject.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/GradleProject.kt
@@ -40,8 +40,9 @@ const val cordaReleaseVersion = "4.8"
 const val cordaApiVersion = "5.0.0"
 const val annotationsVersion = "1.0.1"
 const val commonsCollectionsVersion = "3.2.2"
+const val commonsCompressVersion = "1.21"
 const val commonsCodecVersion = "1.15"
-const val commonsIoVersion = "2.8.0"
+const val commonsIoVersion = "2.11.0"
 
 private val GRADLE_7 = GradleVersion.version("7.0")
 

--- a/cordapp-cpk/src/test/resources/cordapp-transitive-deps/cordapp/build.gradle
+++ b/cordapp-cpk/src/test/resources/cordapp-transitive-deps/cordapp/build.gradle
@@ -29,6 +29,10 @@ dependencies {
     cordaEmbedded "commons-io:commons-io:$commons_io_version"
 }
 
-jar {
+tasks.named('jar', Jar) {
     archiveBaseName = 'cordapp'
+    osgi {
+        // Required by commons-io 2.9.0+.
+        suppressImportVersion 'sun.nio.ch'
+    }
 }

--- a/cordapp-cpk/src/test/resources/cordapp-with-constraint/build.gradle
+++ b/cordapp-cpk/src/test/resources/cordapp-with-constraint/build.gradle
@@ -1,0 +1,43 @@
+plugins {
+    id 'net.corda.plugins.cordapp-cpk'
+    id 'org.jetbrains.kotlin.jvm'
+}
+
+apply from: 'repositories.gradle'
+apply from: 'javaTarget.gradle'
+apply from: 'kotlin.gradle'
+
+group = 'com.example'
+version = cordapp_version
+
+cordapp {
+    targetPlatformVersion = platform_version.toInteger()
+
+    contract {
+        name = 'CorDapp With Constraint'
+        versionId = cordapp_contract_version.toInteger()
+        licence = 'Test-Licence'
+        vendor = 'R3'
+    }
+}
+
+configurations {
+    standalone {
+        canBeConsumed = false
+        visible = false
+    }
+}
+
+dependencies {
+    constraints {
+        standalone "commons-codec:commons-codec:$commons_codec_version"
+    }
+
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordaProvided project(':corda-api')
+    cordaProvided project(':library1')
+    implementation project(':library2')
+    implementation files(configurations.standalone)
+
+    standalone "commons-codec:commons-codec"
+}

--- a/cordapp-cpk/src/test/resources/cordapp-with-constraint/library1/build.gradle
+++ b/cordapp-cpk/src/test/resources/cordapp-with-constraint/library1/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'biz.aQute.bnd.builder'
+    id 'java-library'
+}
+
+apply from: '../repositories.gradle'
+apply from: '../javaTarget.gradle'
+
+group = 'org.testing'
+version = library1_version
+
+dependencies {
+    constraints {
+        implementation "org.apache.commons:commons-compress:$commons_compress_version"
+    }
+
+    compileOnly "org.osgi:osgi.annotation:$osgi_version"
+    implementation 'org.apache.commons:commons-compress'
+}

--- a/cordapp-cpk/src/test/resources/cordapp-with-constraint/library1/src/main/java/org/testing/compress/ExampleZip.java
+++ b/cordapp-cpk/src/test/resources/cordapp-with-constraint/library1/src/main/java/org/testing/compress/ExampleZip.java
@@ -1,0 +1,20 @@
+package org.testing.compress;
+
+import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class ExampleZip implements Closeable {
+    private final ZipArchiveInputStream zip;
+
+    public ExampleZip(InputStream input) {
+        zip = new ZipArchiveInputStream(input);
+    }
+
+    @Override
+    public void close() throws IOException {
+        zip.close();
+    }
+}

--- a/cordapp-cpk/src/test/resources/cordapp-with-constraint/library1/src/main/java/org/testing/compress/package-info.java
+++ b/cordapp-cpk/src/test/resources/cordapp-with-constraint/library1/src/main/java/org/testing/compress/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package org.testing.compress;
+
+import org.osgi.annotation.bundle.Export;

--- a/cordapp-cpk/src/test/resources/cordapp-with-constraint/library2/build.gradle
+++ b/cordapp-cpk/src/test/resources/cordapp-with-constraint/library2/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'biz.aQute.bnd.builder'
+    id 'java-library'
+}
+
+apply from: '../repositories.gradle'
+apply from: '../javaTarget.gradle'
+
+group = 'org.testing'
+version = library2_version
+
+dependencies {
+    constraints {
+        api "commons-io:commons-io:$commons_io_version"
+    }
+
+    compileOnly "org.osgi:osgi.annotation:$osgi_version"
+    api 'commons-io:commons-io'
+}

--- a/cordapp-cpk/src/test/resources/cordapp-with-constraint/library2/src/main/java/org/testing/io/ExampleStream.java
+++ b/cordapp-cpk/src/test/resources/cordapp-with-constraint/library2/src/main/java/org/testing/io/ExampleStream.java
@@ -1,0 +1,10 @@
+package org.testing.io;
+
+import org.apache.commons.io.input.AutoCloseInputStream;
+import java.io.InputStream;
+
+public class ExampleStream extends AutoCloseInputStream {
+    public ExampleStream(InputStream input) {
+        super(input);
+    }
+}

--- a/cordapp-cpk/src/test/resources/cordapp-with-constraint/library2/src/main/java/org/testing/io/package-info.java
+++ b/cordapp-cpk/src/test/resources/cordapp-with-constraint/library2/src/main/java/org/testing/io/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package org.testing.io;
+
+import org.osgi.annotation.bundle.Export;

--- a/cordapp-cpk/src/test/resources/cordapp-with-constraint/settings.gradle
+++ b/cordapp-cpk/src/test/resources/cordapp-with-constraint/settings.gradle
@@ -1,0 +1,12 @@
+pluginManagement {
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version kotlin_version
+        id 'biz.aQute.bnd.builder' version bnd_version
+    }
+}
+
+rootProject.name = 'cordapp-with-constraint'
+include 'library1'
+include 'library2'
+include 'corda-api'
+project(':corda-api').projectDir = file('../resources/test/corda-api')

--- a/cordapp-cpk/src/test/resources/cordapp-with-constraint/src/main/kotlin/com/example/constraint/ConstraintContract.kt
+++ b/cordapp-cpk/src/test/resources/cordapp-with-constraint/src/main/kotlin/com/example/constraint/ConstraintContract.kt
@@ -1,0 +1,15 @@
+@file:Suppress("PackageDirectoryMismatch")
+package com.example.constraint
+
+import net.corda.v5.ledger.contracts.Contract
+import net.corda.v5.ledger.transactions.LedgerTransaction
+import org.apache.commons.codec.Resources
+import org.testing.compress.ExampleZip
+import org.testing.io.ExampleStream
+
+@Suppress("unused")
+class ConstraintContract : Contract {
+    override fun verify(ltx: LedgerTransaction) {
+        ExampleZip(ExampleStream(Resources.getInputStream("testing")))
+    }
+}


### PR DESCRIPTION
Replace `SelfResolvingDependency` with its sub-interface `FileCollectionDependency`, which is what was originally intended anyway. Unfortunately a `ProjectDependency` is also a `SelfResolvingDependency`, but project dependencies are already extracted from the `ResolvedConfiguration`.