### PR TITLE
CORE-3049: Differentiate between remote and project CPK dependencies.

### DIFF
--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappUtils.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappUtils.kt
@@ -84,6 +84,11 @@ const val CORDAPP_WORKFLOW_NAME = "Cordapp-Workflow-Name"
 const val CORDAPP_WORKFLOW_VERSION = "Cordapp-Workflow-Version"
 const val CORDA_CPK_TYPE = "Corda-CPK-Type"
 
+/**
+ * Location of official R3 documentation for building CPKs and CPBs.
+ */
+const val CORDAPP_DOCUMENTATION_URL = "https://docs.corda.net/cordapp-build-systems.html"
+
 @JvmField
 val SEPARATOR: String = System.lineSeparator() + "- "
 

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/VerifyBundle.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/VerifyBundle.kt
@@ -59,7 +59,20 @@ open class VerifyBundle @Inject constructor(objects: ObjectFactory) : DefaultTas
      * someone eagerly configures this [VerifyBundle] by accident.
      */
     internal fun setDependenciesFrom(task: TaskProvider<DependencyCalculator>) {
-        _classpath.setFrom(task.flatMap(DependencyCalculator::externalJars), task.flatMap(DependencyCalculator::libraries))
+        _classpath.setFrom(
+            /**
+             * These jars do not belong to this CPK, but provide
+             * packages that the CPK will need at runtime.
+             */
+            task.flatMap(DependencyCalculator::providedJars),
+            task.flatMap(DependencyCalculator::remoteCordapps),
+            task.flatMap(DependencyCalculator::projectCordapps),
+
+            /**
+             * These jars are the contents of this CPK's lib folder.
+             */
+            task.flatMap(DependencyCalculator::libraries)
+        )
         _classpath.disallowChanges()
         dependsOn(task)
     }

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpb/CpbTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpb/CpbTest.kt
@@ -80,7 +80,7 @@ class CpbTest {
         } ?: fail("Corda platform CorDapp CPK not found")
 
         val expectedCpks = allCpks.filter { it != cordaPlatformCordappCpk }
-            .associateByTo(TreeMap(), { it.fileName.toString() }, {Files.newInputStream(it).use(::sha256)})
+            .associateByTo(TreeMap(), { it.fileName.toString() }, { Files.newInputStream(it).use(::sha256) })
 
         val assembledCpbFiles = testProject.artifacts.filter {
             it.fileName.toString().endsWith(".cpb")

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappApiLibraryTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappApiLibraryTest.kt
@@ -55,7 +55,7 @@ class CordappApiLibraryTest {
             .hasSizeGreaterThanOrEqualTo(1)
         assertThat(testProject.cpkDependencies)
             .anyMatch { it.name == "com.example.cordapp" && it.version == toOSGi(CONTRACT_CORDAPP_VERSION) }
-            .allMatch { it.signers.allSHA256 }
+            .allMatch { it.signers.isSameAsMe }
             .hasSize(1)
 
         val artifacts = testProject.artifacts

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappJarForCPKDependenciesTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappJarForCPKDependenciesTest.kt
@@ -49,7 +49,7 @@ class CordappJarForCPKDependenciesTest {
             .doesNotExist()
         assertThat(testProject.cpkDependencies)
             .anyMatch { it.name == "com.example.cordapp" && it.version == toOSGi(cordappVersion) }
-            .allMatch { it.signers.allSHA256 }
+            .allMatch { it.signers.isSameAsMe }
             .hasSize(1)
     }
 }

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappPrivateDependencyTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappPrivateDependencyTest.kt
@@ -40,7 +40,7 @@ class CordappPrivateDependencyTest {
             .isEmpty()
         assertThat(testProject.cpkDependencies)
             .anyMatch { it.name == "com.example.cordapp" && it.version == toOSGi(cordappVersion) }
-            .allMatch { it.signers.allSHA256 }
+            .allMatch { it.signers.isSameAsMe }
             .hasSize(1)
 
         val artifacts = testProject.artifacts

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappTransitiveDependencyTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappTransitiveDependencyTest.kt
@@ -43,7 +43,7 @@ class CordappTransitiveDependencyTest {
             .hasSize(1)
         assertThat(testProject.cpkDependencies)
             .anyMatch { it.name == "com.example.cordapp" && it.version == toOSGi(cordappVersion) }
-            .allMatch { it.signers.allSHA256 }
+            .allMatch { it.signers.isSameAsMe }
             .hasSize(1)
 
         val artifacts = testProject.artifacts

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/GradleProject.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/GradleProject.kt
@@ -7,6 +7,7 @@ import aQute.bnd.version.VersionRange
 import net.corda.plugins.cpk.xml.CPKDependency
 import net.corda.plugins.cpk.xml.DependencyConstraint
 import net.corda.plugins.cpk.xml.HashValue
+import net.corda.plugins.cpk.xml.SameAsMe
 import net.corda.plugins.cpk.xml.loadCPKDependencies
 import net.corda.plugins.cpk.xml.loadDependencyConstraints
 import org.assertj.core.api.Assertions.assertThat
@@ -71,7 +72,8 @@ fun createDocumentBuilderFactory() = XMLFactory.createDocumentBuilderFactory()
 
 val Path.manifest: Manifest get() = toFile().manifest
 
-val List<HashValue>.allSHA256: Boolean get() = isNotEmpty() && all(HashValue::isSHA256)
+val List<Any>.allSHA256: Boolean get() = isNotEmpty() && all { it is HashValue && it.isSHA256 }
+val List<Any>.isSameAsMe: Boolean get() = (size == 1) && all { it is SameAsMe }
 
 private const val HASH_ALGORITHM = "SHA-256"
 

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/HashSelectionTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/HashSelectionTest.kt
@@ -12,6 +12,7 @@ import net.corda.plugins.cpk.xml.HashValue
 class HashSelectionTest {
     companion object {
         const val cordappVersion = "1.2.5-SNAPSHOT"
+        const val hostVersion = "1.0-SNAPSHOT"
         const val SHA3_256 = "SHA3-256"
 
         private lateinit var cordappProject: GradleProject
@@ -41,10 +42,9 @@ class HashSelectionTest {
                 .withTestName("hash-selection")
                 .build(
                     "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcorda_release_version=$cordaReleaseVersion",
                     "-Pcommons_codec_version=$commonsCodecVersion",
-                    "-Pcorda_api_version=$cordaApiVersion",
                     "-Pcordapp_version=$cordappVersion",
+                    "-Phost_version=$hostVersion",
                     "-Prepository_dir=$repositoryDir"
                 )
         }

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/HashSelectionTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/HashSelectionTest.kt
@@ -1,33 +1,51 @@
 package net.corda.plugins.cpk
 
+import java.nio.file.Files
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
+import net.corda.plugins.cpk.xml.HashValue
 
 class HashSelectionTest {
     companion object {
         const val cordappVersion = "1.2.5-SNAPSHOT"
         const val SHA3_256 = "SHA3-256"
 
+        private lateinit var cordappProject: GradleProject
         private lateinit var testProject: GradleProject
 
         @Suppress("unused")
         @BeforeAll
         @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        fun setup(
+            @TempDir testProjectDir: Path,
+            @TempDir cordappDir: Path,
+            reporter: TestReporter
+        ) {
+            val repositoryDir = Files.createDirectory(testProjectDir.resolve("maven"))
+            cordappProject = GradleProject(cordappDir, reporter)
+                .withTestName("hash-selection/cordapp")
+                .withTaskName("publishAllPublicationsToTestRepository")
+                .build(
+                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                    "-Pcorda_release_version=$cordaReleaseVersion",
+                    "-Pcommons_io_version=$commonsIoVersion",
+                    "-Pcorda_api_version=$cordaApiVersion",
+                    "-Pcordapp_version=$cordappVersion",
+                    "-Prepository_dir=$repositoryDir"
+                )
             testProject = GradleProject(testProjectDir, reporter)
                 .withTestName("hash-selection")
-                .withSubResource("cordapp/build.gradle")
                 .build(
                     "-Pcordapp_contract_version=$expectedCordappContractVersion",
                     "-Pcorda_release_version=$cordaReleaseVersion",
                     "-Pcommons_codec_version=$commonsCodecVersion",
-                    "-Pcommons_io_version=$commonsIoVersion",
                     "-Pcorda_api_version=$cordaApiVersion",
-                    "-Pcordapp_version=$cordappVersion"
+                    "-Pcordapp_version=$cordappVersion",
+                    "-Prepository_dir=$repositoryDir"
                 )
         }
     }
@@ -39,7 +57,8 @@ class HashSelectionTest {
             .allMatch { it.hash.algorithm == SHA3_256 }
             .hasSize(1)
         assertThat(testProject.cpkDependencies)
-            .allMatch { dep -> dep.signers.isNotEmpty() && dep.signers.all { it.algorithm == SHA3_256 } }
-            .hasSize(1)
+            .allMatch { dep ->
+                dep.signers.isNotEmpty() && dep.signers.all { it is HashValue && it.algorithm == SHA3_256 }
+            }.hasSize(1)
     }
 }

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/TransitiveCordappsTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/TransitiveCordappsTest.kt
@@ -83,7 +83,7 @@ class TransitiveCordappsTest {
             .anyMatch { it.name == "com.example.cpk-one" && it.version == toOSGi(cpk1Version) && it.type == cpk1Type }
             .anyMatch { it.name == "com.example.cpk-two" && it.version == toOSGi(cpk2Version) && it.type == cpk2Type }
             .anyMatch { it.name == "com.example.cpk-three" && it.version == toOSGi(cpk3Version) && it.type == null }
-            .allMatch { it.signers.allSHA256 }
+            .allMatch { it.signers.isSameAsMe }
             .hasSize(3)
 
         val artifacts = testProject.artifacts

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/VerifyCordappDependencyTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/VerifyCordappDependencyTest.kt
@@ -59,7 +59,7 @@ class VerifyCordappDependencyTest {
             .hasSize(1)
         assertThat(testProject.cpkDependencies)
             .anyMatch { it.name == "com.example.cordapp" && it.version == toOSGi(cordappVersion) }
-            .allMatch { it.signers.allSHA256 }
+            .allMatch { it.signers.isSameAsMe }
             .hasSize(1)
         assertThat(testProject.outcomeOf("verifyBundle")).isEqualTo(SUCCESS)
 

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithDependentCordappTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithDependentCordappTest.kt
@@ -94,7 +94,7 @@ class WithDependentCordappTest {
             .hasSizeGreaterThanOrEqualTo(1)
         assertThat(testProject.cpkDependencies)
             .anyMatch { it.name == "com.example.cordapp" && it.version == toOSGi("0") }
-            .allMatch { it.signers.allSHA256 }
+            .allMatch { it.signers.isSameAsMe }
             .hasSize(1)
 
         if (libraryGuavaVersion != guavaVersion) {

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithoutTransitiveCordappsTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithoutTransitiveCordappsTest.kt
@@ -57,7 +57,7 @@ class WithoutTransitiveCordappsTest {
         assertThat(testProject.cpkDependencies)
             .anyMatch { it.name == "com.example.cpk-two" && it.version == toOSGi(cpk2Version) }
             .noneMatch { it.name == "com.example.cpk-one" }
-            .allMatch { it.signers.allSHA256 }
+            .allMatch { it.signers.isSameAsMe }
             .hasSize(1)
 
         val artifacts = testProject.artifacts

--- a/cordapp-cpk/src/test/resources/hash-selection/build.gradle
+++ b/cordapp-cpk/src/test/resources/hash-selection/build.gradle
@@ -12,7 +12,7 @@ apply from: 'repositories.gradle'
 apply from: 'javaTarget.gradle'
 
 group = 'com.example'
-version = cordapp_version
+version = host_version
 
 cordapp {
     targetPlatformVersion = platform_version.toInteger()

--- a/cordapp-cpk/src/test/resources/hash-selection/build.gradle
+++ b/cordapp-cpk/src/test/resources/hash-selection/build.gradle
@@ -2,6 +2,12 @@ plugins {
     id 'net.corda.plugins.cordapp-cpk'
 }
 
+repositories {
+    maven {
+        name = 'Test'
+        url = repository_dir
+    }
+}
 apply from: 'repositories.gradle'
 apply from: 'javaTarget.gradle'
 
@@ -24,7 +30,7 @@ cordapp {
 
 dependencies {
     implementation "commons-codec:commons-codec:$commons_codec_version"
-    cordapp project(':cordapp')
+    cordapp "com.example:hash-selection-cordapp:$cordapp_version"
 }
 
 tasks.named('jar', Jar) {

--- a/cordapp-cpk/src/test/resources/hash-selection/cordapp/build.gradle
+++ b/cordapp-cpk/src/test/resources/hash-selection/cordapp/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'net.corda.plugins.cordapp-cpk'
     id 'org.jetbrains.kotlin.jvm'
-    id 'maven-publish'
 }
 
 apply from: 'repositories.gradle'
@@ -16,7 +15,7 @@ cordapp {
     minimumPlatformVersion = platform_version.toInteger()
 
     contract {
-        name = 'CorDapp'
+        name = 'Hash Selection CorDapp'
         versionId = cordapp_contract_version.toInteger()
         licence = 'Test-Licence'
         vendor = 'R3'
@@ -33,54 +32,58 @@ tasks.named('jar', Jar) {
     archiveBaseName = 'cordapp'
 }
 
-tasks.withType(GenerateModuleMetadata).configureEach {
-    // Ensure our Maven Repository is "bare bones",
-    // i.e. has no sneaky extra Gradle metadata.
-    enabled = false
-}
+allprojects {
+    apply plugin: 'maven-publish'
 
-publishing {
+    tasks.withType(GenerateModuleMetadata).configureEach {
+        // Ensure our Maven Repository is "bare bones",
+        // i.e. has no sneaky extra Gradle metadata.
+        enabled = false
+    }
+
     publishing {
-        repositories {
-            maven {
-                name = 'Test'
-                url = repository_dir
+        publishing {
+            repositories {
+                maven {
+                    name = 'Test'
+                    url = repository_dir
+                }
             }
-        }
 
-        publications {
-            maven(MavenPublication) {
-                pluginManager.withPlugin('java') {
-                    from components.java
-                }
+            publications {
+                maven(MavenPublication) {
+                    pluginManager.withPlugin('java') {
+                        from components.java
+                    }
 
-                // Publish any CPK that this project may have.
-                pluginManager.withPlugin('net.corda.plugins.cordapp-cpk') {
-                    artifact tasks.named('cpk', Jar)
-                }
+                    // Publish any CPK that this project may have.
+                    pluginManager.withPlugin('net.corda.plugins.cordapp-cpk') {
+                        artifact tasks.named('cpk', Jar)
+                    }
 
-                pom {
-                    name = 'Hash Selection CorDapp'
-                    url = 'https://com.example.cordapp'
-                    scm {
+                    pom {
+                        name = 'Hash Selection CorDapp'
                         url = 'https://com.example.cordapp'
-                    }
-                    organization {
-                        name = 'Example-Name'
-                        url = 'https://example.com'
-                    }
-                    licenses {
-                        license {
-                            name = 'Apache-2.0'
-                            url = 'https://www.apache.org/licenses/LICENSE-2.0'
-                            distribution = 'repo'
+                        scm {
+                            url = 'https://com.example.cordapp'
                         }
-                    }
-                    developers {
-                        developer {
-                            id = 'Example-Id'
+                        organization {
                             name = 'Example-Name'
-                            email = 'dev@example.com'
+                            url = 'https://example.com'
+                        }
+                        licenses {
+                            license {
+                                name = 'Apache-2.0'
+                                url = 'https://www.apache.org/licenses/LICENSE-2.0'
+                                distribution = 'repo'
+                            }
+                        }
+                        developers {
+                            developer {
+                                id = 'Example-Id'
+                                name = 'Example-Name'
+                                email = 'dev@example.com'
+                            }
                         }
                     }
                 }

--- a/cordapp-cpk/src/test/resources/hash-selection/cordapp/build.gradle
+++ b/cordapp-cpk/src/test/resources/hash-selection/cordapp/build.gradle
@@ -1,12 +1,14 @@
 plugins {
     id 'net.corda.plugins.cordapp-cpk'
     id 'org.jetbrains.kotlin.jvm'
+    id 'maven-publish'
 }
 
-apply from: '../repositories.gradle'
-apply from: '../javaTarget.gradle'
-apply from: '../kotlin.gradle'
+apply from: 'repositories.gradle'
+apply from: 'javaTarget.gradle'
+apply from: 'kotlin.gradle'
 
+group = 'com.example'
 version = cordapp_version
 
 cordapp {
@@ -29,4 +31,60 @@ dependencies {
 
 tasks.named('jar', Jar) {
     archiveBaseName = 'cordapp'
+}
+
+tasks.withType(GenerateModuleMetadata).configureEach {
+    // Ensure our Maven Repository is "bare bones",
+    // i.e. has no sneaky extra Gradle metadata.
+    enabled = false
+}
+
+publishing {
+    publishing {
+        repositories {
+            maven {
+                name = 'Test'
+                url = repository_dir
+            }
+        }
+
+        publications {
+            maven(MavenPublication) {
+                pluginManager.withPlugin('java') {
+                    from components.java
+                }
+
+                // Publish any CPK that this project may have.
+                pluginManager.withPlugin('net.corda.plugins.cordapp-cpk') {
+                    artifact tasks.named('cpk', Jar)
+                }
+
+                pom {
+                    name = 'Hash Selection CorDapp'
+                    url = 'https://com.example.cordapp'
+                    scm {
+                        url = 'https://com.example.cordapp'
+                    }
+                    organization {
+                        name = 'Example-Name'
+                        url = 'https://example.com'
+                    }
+                    licenses {
+                        license {
+                            name = 'Apache-2.0'
+                            url = 'https://www.apache.org/licenses/LICENSE-2.0'
+                            distribution = 'repo'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = 'Example-Id'
+                            name = 'Example-Name'
+                            email = 'dev@example.com'
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/cordapp-cpk/src/test/resources/hash-selection/cordapp/settings.gradle
+++ b/cordapp-cpk/src/test/resources/hash-selection/cordapp/settings.gradle
@@ -8,7 +8,7 @@ pluginManagement {
     }
 }
 
-rootProject.name = 'hash-selection'
+rootProject.name = 'hash-selection-cordapp'
 
 include 'corda-api'
 project(':corda-api').projectDir = file('../resources/test/corda-api')

--- a/cordapp-cpk/src/test/resources/hash-selection/settings.gradle
+++ b/cordapp-cpk/src/test/resources/hash-selection/settings.gradle
@@ -9,6 +9,3 @@ pluginManagement {
 }
 
 rootProject.name = 'hash-selection'
-
-include 'corda-api'
-project(':corda-api').projectDir = file('../resources/test/corda-api')

--- a/cordapp-cpk/src/test/resources/xml/corda-cpk-1.0.xsd
+++ b/cordapp-cpk/src/test/resources/xml/corda-cpk-1.0.xsd
@@ -14,8 +14,8 @@
     </xs:complexType>
 
     <xs:complexType name="cpkDependenciesType">
-        <xs:sequence>
-            <xs:element maxOccurs="unbounded" minOccurs="0" name="cpkDependency" type="cpk:cpkDependencyType"/>
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="cpkDependency" type="cpk:cpkDependencyType"/>
         </xs:sequence>
     </xs:complexType>
 
@@ -29,14 +29,19 @@
     </xs:complexType>
 
     <xs:complexType name="signersType">
-        <xs:sequence>
-            <xs:element maxOccurs="unbounded" minOccurs="0" name="signer" type="cpk:hashType"/>
-        </xs:sequence>
+        <xs:choice minOccurs="0">
+            <xs:sequence maxOccurs="unbounded">
+                <xs:element name="signer" type="cpk:hashType"/>
+            </xs:sequence>
+            <xs:element name="sameAsMe" type="cpk:sameAsMeType"/>
+        </xs:choice>
     </xs:complexType>
 
+    <xs:complexType name="sameAsMeType"/>
+
     <xs:complexType name="dependencyConstraintsType">
-        <xs:sequence>
-            <xs:element maxOccurs="unbounded" minOccurs="0" name="dependencyConstraint" type="cpk:dependencyConstraintType"/>
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="dependencyConstraint" type="cpk:dependencyConstraintType"/>
         </xs:sequence>
     </xs:complexType>
 


### PR DESCRIPTION
Denote dependent CPKs which belong to the same Gradle build as the CPK that the `cordapp-cpk` plugin is building as all being signed with the same key. This allows us to avoid writing the SHA-256 of the "development" key into the CPK's `META-INF/CPKDependencies` file, and hence to sign all of these CPKs later with the actual "release" key.

CPKs which are downloaded from a Maven repository are assumed to have been signed with their correct "release" key.