### PR TITLE
CORE-3127: Upgrade Bnd 6.0.0 -> 6.1.0.

### DIFF
--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappPlugin.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappPlugin.kt
@@ -268,6 +268,11 @@ class CordappPlugin @Inject constructor(private val layouts: ProjectLayout): Plu
 
                 // Add Bnd instructions to scan for any contracts, flows, schemas etc.
                 bnd(osgi.scanCordaClasses)
+
+                // Accessing the Gradle [Project] during the task execution
+                // phase is incompatible with Gradle's configuration cache.
+                // Prevent this task from accessing the project's properties.
+                properties.convention(emptyMap())
             }
 
             val allCordaProvided = objects.fileCollection()

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ lombok_version=1.18.16
 slf4j_version=1.7.32
 javax_annotations_version=1.3.2
 osgi_version=8.0.0
-bnd_version=6.0.0
+bnd_version=6.1.0
 
 artifactory_version=4.21.0
 gradle_publish_version=0.16.0


### PR DESCRIPTION
Upgrade Bnd 6.0.0 -> 6.1.0.

Also prevent Bnd from accessing the Gradle project's properties when configuring the `jar` task.
