### PR TITLE
ENT-6378 Include `corda-shell` in `cordformation` task

### DIFF
--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -423,6 +423,7 @@ open class Node @Inject constructor(private val project: Project) {
             installWebserverJar()
         }
         installAgentJar()
+        installShell()
         installDrivers()
         installCordapps()
         installCordappConfigs()
@@ -589,6 +590,17 @@ open class Node @Inject constructor(private val project: Project) {
         }.firstOrNull()
         agentJar?.let {
             project.logger.info("Jolokia agent jar: $it")
+            copyToDriversDir(it)
+        }
+    }
+
+    private fun installShell() {
+        val agentJar = project.configurations
+            .getByName(RUNTIME_CLASSPATH_CONFIGURATION_NAME)
+            .files { "corda-shell" in it.name }
+            .firstOrNull()
+        agentJar?.let {
+            project.logger.info("Corda shell: $it")
             copyToDriversDir(it)
         }
     }


### PR DESCRIPTION
Due to moving the `corda-shell` out of the main Corda codebase, it is no longer run by default and instead relies on the `corda-shell` jar existing in a node's `drivers` directory to execute.

The `cordformation` task has been modified to include the `corda-shell` jar as long as the project calling `cordformation` contains a runtime dependency (e.g. `runtimeOnly`) on the `corda-shell` artifact.

For example:

OS:

```
runtimeOnly "net.corda:corda-shell:4.8-SNAPSHOT"
```

ENT:

```
runtimeOnly "com.r3.corda:corda-shell:4.8-SNAPSHOT"
```