### PR TITLE
CORE-3384: Remove Lombok from the flask plugin.

### DIFF
--- a/flask/build.gradle
+++ b/flask/build.gradle
@@ -82,9 +82,6 @@ repositories {
 }
 
 dependencies {
-    ['compileOnly', 'annotationProcessor', 'testCompileOnly', 'testAnnotationProcessor'].each { conf ->
-        add(conf, [group: "org.projectlombok", name: "lombok", version: lombok_version])
-    }
     testImplementation project("flask-common")
     testImplementation "org.assertj:assertj-core:$assertj_version"
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version"

--- a/flask/flask-common/build.gradle
+++ b/flask/flask-common/build.gradle
@@ -7,10 +7,6 @@ repositories {
 }
 
 dependencies {
-    ['compileOnly', 'annotationProcessor', 'testCompileOnly', 'testAnnotationProcessor'].each { conf ->
-        add(conf, [group: "org.projectlombok", name: "lombok", version: lombok_version])
-    }
-
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junit_jupiter_version"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_jupiter_version"

--- a/flask/flask-common/src/main/java/net/corda/flask/common/Flask.java
+++ b/flask/flask-common/src/main/java/net/corda/flask/common/Flask.java
@@ -1,13 +1,24 @@
 package net.corda.flask.common;
 
-import lombok.SneakyThrows;
-
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
-import java.util.*;
+import java.security.NoSuchAlgorithmException;
+import java.util.AbstractMap;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
 import java.util.function.Supplier;
 import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
@@ -79,11 +90,10 @@ public class Flask {
         public static final String KILL_TIMEOUT_MILLIS = "net.corda.flask.kill.timeout.millis";
     }
 
-    @SneakyThrows
     public static void computeSizeAndCrc32(
             ZipEntry zipEntry,
             InputStream inputStream,
-            byte[] buffer) {
+            byte[] buffer) throws IOException {
         CRC32 crc32 = new CRC32();
         long sz = 0L;
         while (true) {
@@ -97,9 +107,8 @@ public class Flask {
         zipEntry.setCrc(crc32.getValue());
     }
 
-    @SneakyThrows
     public static void write2Stream(InputStream inputStream, OutputStream os,
-                                    byte[] buffer) {
+                                    byte[] buffer) throws IOException {
         while (true) {
             int read = inputStream.read(buffer);
             if (read < 0) break;
@@ -107,7 +116,7 @@ public class Flask {
         }
     }
 
-    public static void write2Stream(InputStream inputStream, OutputStream os) {
+    public static void write2Stream(InputStream inputStream, OutputStream os) throws IOException {
         write2Stream(inputStream, os, new byte[Constants.BUFFER_SIZE]);
     }
 
@@ -121,15 +130,13 @@ public class Flask {
         }
     }
 
-    @SneakyThrows
-    public static byte[] computeSHA256Digest(Supplier<InputStream> streamSupplier) {
+    public static byte[] computeSHA256Digest(Supplier<InputStream> streamSupplier) throws IOException, NoSuchAlgorithmException {
         byte[] buffer = new byte[Constants.BUFFER_SIZE];
         MessageDigest md = MessageDigest.getInstance("SHA-256");
         return computeDigest(streamSupplier, md, buffer);
     }
 
-    @SneakyThrows
-    public static byte[] computeDigest(Supplier<InputStream> streamSupplier, MessageDigest md, byte[] buffer) {
+    public static byte[] computeDigest(Supplier<InputStream> streamSupplier, MessageDigest md, byte[] buffer) throws IOException {
         try(InputStream stream = new DigestInputStream(streamSupplier.get(), md)) {
             while(stream.read(buffer) >= 0) {}
         }
@@ -146,8 +153,7 @@ public class Flask {
      * @param file the {@link File} to be opened
      * @return an open {@link InputStream} instance reading from the file
      */
-    @SneakyThrows
-    public static InputStream read(File file, boolean buffered) {
+    public static InputStream read(File file, boolean buffered) throws IOException {
         InputStream result = new FileInputStream(file);
         return buffered ? new BufferedInputStream(result) : result;
     }
@@ -158,19 +164,16 @@ public class Flask {
      * @param file the {@link File} to be opened
      * @return an open {@link OutputStream} instance writing to the file
      */
-    @SneakyThrows
-    public static OutputStream write(File file, boolean buffered) {
+    public static OutputStream write(File file, boolean buffered) throws IOException {
         OutputStream result = new FileOutputStream(file);
         return buffered ? new BufferedOutputStream(result) : result;
     }
 
-    @SneakyThrows
-    public static void storeProperties(Properties properties, OutputStream outputStream) {
+    public static void storeProperties(Properties properties, OutputStream outputStream) throws IOException {
         properties.storeToXML(outputStream, null, StandardCharsets.UTF_8.name());
     }
 
-    @SneakyThrows
-    public static void loadProperties(Properties properties, InputStream inputStream) {
+    public static void loadProperties(Properties properties, InputStream inputStream) throws IOException {
         properties.loadFromXML(inputStream);
     }
 }

--- a/flask/flask-common/src/main/java/net/corda/flask/common/LockFile.java
+++ b/flask/flask-common/src/main/java/net/corda/flask/common/LockFile.java
@@ -1,8 +1,5 @@
 package net.corda.flask.common;
 
-import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
@@ -12,7 +9,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.EnumSet;
 
-@RequiredArgsConstructor
 public class LockFile implements Closeable {
 
     private final FileLock lock;
@@ -22,22 +18,23 @@ public class LockFile implements Closeable {
         return FileChannel.open(path, EnumSet.of(StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE));
     }
 
-    @SneakyThrows
-    public static LockFile acquire(Path path, boolean shared) {
+    public static LockFile acquire(Path path, boolean shared) throws IOException {
         FileChannel channel = openFileChannel(path);
         return new LockFile(channel.lock(0L, Long.MAX_VALUE, shared));
     }
 
-    @SneakyThrows
-    public static LockFile tryAcquire(Path path, boolean shared) {
+    public static LockFile tryAcquire(Path path, boolean shared) throws IOException {
         FileChannel channel = openFileChannel(path);
         FileLock lock = channel.tryLock(0L, Long.MAX_VALUE, shared);
         return (lock != null) ? new LockFile(lock) : null;
     }
 
+    private LockFile(FileLock lock) {
+        this.lock = lock;
+    }
+
     @Override
-    @SneakyThrows
-    public void close() {
+    public void close() throws IOException {
         lock.channel().close();
     }
 }

--- a/flask/flask-common/src/main/java/net/corda/flask/common/ThrowingConsumer.java
+++ b/flask/flask-common/src/main/java/net/corda/flask/common/ThrowingConsumer.java
@@ -1,0 +1,19 @@
+package net.corda.flask.common;
+
+import java.util.function.Consumer;
+
+@FunctionalInterface
+public interface ThrowingConsumer<T> extends Consumer<T> {
+    @Override
+    default void accept(T value) {
+        try {
+            acceptThrowing(value);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    void acceptThrowing(T value) throws Exception;
+}

--- a/flask/flask-common/src/main/java/net/corda/flask/common/ThrowingFunction.java
+++ b/flask/flask-common/src/main/java/net/corda/flask/common/ThrowingFunction.java
@@ -1,0 +1,19 @@
+package net.corda.flask.common;
+
+import java.util.function.Function;
+
+@FunctionalInterface
+public interface ThrowingFunction<T, R> extends Function<T, R> {
+    @Override
+    default R apply(T value) {
+        try {
+            return applyThrowing(value);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    R applyThrowing(T value) throws Exception;
+}

--- a/flask/flask-common/src/main/java/net/corda/flask/common/ThrowingSupplier.java
+++ b/flask/flask-common/src/main/java/net/corda/flask/common/ThrowingSupplier.java
@@ -1,0 +1,19 @@
+package net.corda.flask.common;
+
+import java.util.function.Supplier;
+
+@FunctionalInterface
+public interface ThrowingSupplier<T> extends Supplier<T> {
+    @Override
+    default T get() {
+        try {
+            return getThrowing();
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    T getThrowing() throws Exception;
+}

--- a/flask/flask-heartbeat-agent/src/main/java/net/corda/flask/HeartbeatAgent.java
+++ b/flask/flask-heartbeat-agent/src/main/java/net/corda/flask/HeartbeatAgent.java
@@ -7,12 +7,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-public class HeartbeatAgent {
+public final class HeartbeatAgent {
     public static void premain(String agentArgs) {
         Path pidFile = Paths.get(System.getProperty(Flask.JvmProperties.PID_FILE));
         Thread t = new Thread(() -> {
-            LockFile.acquire(pidFile, true);
             try {
+                LockFile.acquire(pidFile, true);
                 Files.delete(pidFile);
             } catch(Exception ex) {
                 //Should deletion fail, we only log the stacktrace because killing the current process, which

--- a/flask/flask-launcher/build.gradle
+++ b/flask/flask-launcher/build.gradle
@@ -19,12 +19,6 @@ configurations {
 }
 
 dependencies {
-    ['', 'test', 'lockFileTest'].each {sourceSetName ->
-        ['compileOnly', 'annotationProcessor'].each { confBaseName ->
-            String configurationName = sourceSetName ? (sourceSetName + confBaseName.capitalize()) : confBaseName
-            add(configurationName, [group: "org.projectlombok", name: "lombok", version: lombok_version])
-        }
-    }
     implementation project(':flask:flask-common')
     implementation "org.slf4j:slf4j-api:$slf4j_version"
     implementation "org.slf4j:slf4j-simple:$slf4j_version"

--- a/flask/flask-launcher/src/lockFileTest/java/net/corda/flask/launcher/LockFileTestMain.java
+++ b/flask/flask-launcher/src/lockFileTest/java/net/corda/flask/launcher/LockFileTestMain.java
@@ -1,7 +1,6 @@
 package net.corda.flask.launcher;
 
-import lombok.SneakyThrows;
-
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -9,12 +8,11 @@ import net.corda.flask.common.LockFile;
 
 public class LockFileTestMain {
 
-    @SneakyThrows
-    public static void main(String[] args) {
-        Path lockfilePath = Paths.get(args[0]);
-        boolean shared = Boolean.parseBoolean(args[1]);
-        boolean keep = Boolean.parseBoolean(args[2]);
-        try (LockFile lockfile = LockFile.acquire(lockfilePath, shared)) {
+    public static void main(String[] args) throws IOException, InterruptedException {
+        final Path lockfilePath = Paths.get(args[0]);
+        final boolean shared = Boolean.parseBoolean(args[1]);
+        final boolean keep = Boolean.parseBoolean(args[2]);
+        try (LockFile ignored = LockFile.acquire(lockfilePath, shared)) {
             while (keep) {
                 Thread.sleep(1000);
             }

--- a/flask/flask-launcher/src/main/java/net/corda/flask/launcher/JavaProcessBuilder.java
+++ b/flask/flask-launcher/src/main/java/net/corda/flask/launcher/JavaProcessBuilder.java
@@ -1,12 +1,9 @@
 package net.corda.flask.launcher;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.SneakyThrows;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Files;
@@ -20,9 +17,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
-@Getter
-@Setter
-public class JavaProcessBuilder {
+public final class JavaProcessBuilder {
 
     private static final Logger log = LoggerFactory.getLogger(JavaProcessBuilder.class);
 
@@ -35,12 +30,22 @@ public class JavaProcessBuilder {
      */
     private static final int COMMAND_LINE_MAX_SIZE = 1024;
 
-    private static final String PATH_SEPARATOR = System.getProperty("path.separator");
-
-    @AllArgsConstructor
     public static class JavaAgent {
-        Path jar;
-        String args;
+        private final Path jar;
+        private final String args;
+
+        public JavaAgent(Path jar, String args) {
+            this.jar = jar;
+            this.args = args;
+        }
+
+        public Path getJar() {
+            return jar;
+        }
+
+        public String getArgs() {
+            return args;
+        }
     }
 
     private String mainClassName;
@@ -58,6 +63,62 @@ public class JavaProcessBuilder {
     private List<String> cliArgs = new ArrayList<>();
 
     private List<JavaAgent> javaAgents = new ArrayList<>();
+
+    public String getMainClassName() {
+        return mainClassName;
+    }
+
+    public void setMainClassName(String newValue) {
+        mainClassName = newValue;
+    }
+
+    public Path getExecutableJar() {
+        return executableJar;
+    }
+
+    public void setExecutableJar(Path newValue) {
+        executableJar = newValue;
+    }
+
+    public List<String> getJvmArgs() {
+        return jvmArgs;
+    }
+
+    public void setJvmArgs(List<String> newValue) {
+        jvmArgs = newValue;
+    }
+
+    public List<String> getClasspath() {
+        return classpath;
+    }
+
+    public void setClasspath(List<String> newValue) {
+        classpath = newValue;
+    }
+
+    public Properties getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Properties newValue) {
+        properties = newValue;
+    }
+
+    public List<String> getCliArgs() {
+        return cliArgs;
+    }
+
+    public void setCliArgs(List<String> newValue) {
+        cliArgs = newValue;
+    }
+
+    public List<JavaAgent> getJavaAgents() {
+        return javaAgents;
+    }
+
+    public void setJavaAgents(List<JavaAgent> newValue) {
+        javaAgents = newValue;
+    }
 
     /**
      * Generate the argument file string according to the grammar specified
@@ -101,15 +162,14 @@ public class JavaProcessBuilder {
         return sb.toString();
     }
 
-    @SneakyThrows
-    public ProcessBuilder build() {
+    public ProcessBuilder build() throws IOException {
         ArrayList<String> cmd = new ArrayList<>();
         Path javaBin = Paths.get(javaHome, "bin", "java");
         cmd.add(javaBin.toString());
         cmd.addAll(jvmArgs);
         if(!classpath.isEmpty()) {
             cmd.add("-cp");
-            cmd.add(String.join(PATH_SEPARATOR, classpath));
+            cmd.add(String.join(File.pathSeparator, classpath));
         }
         for(Map.Entry<Object, Object> entry : properties.entrySet()) {
             cmd.add(String.format("-D%s=%s", entry.getKey(), entry.getValue()));

--- a/flask/flask-launcher/src/test/java/net/corda/flask/launcher/LockFileTest.java
+++ b/flask/flask-launcher/src/test/java/net/corda/flask/launcher/LockFileTest.java
@@ -1,8 +1,6 @@
 package net.corda.flask.launcher;
 
 
-import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -21,25 +19,28 @@ public class LockFileTest {
 
     private final Path executablePath = Paths.get(System.getProperty("lockFileTest.executable.jar"));
 
-    @RequiredArgsConstructor
     private static class LockFileTestMainArgs {
         final Path lockFilePath;
         final boolean shared;
         final boolean keep;
+
+        LockFileTestMainArgs(Path lockFilePath, boolean shared, boolean keep) {
+            this.lockFilePath = lockFilePath;
+            this.shared = shared;
+            this.keep = keep;
+        }
 
         public List<String> getArgs() {
             return Arrays.asList(lockFilePath.toString(), Boolean.toString(shared), Boolean.toString(keep));
         }
     }
 
-    @SneakyThrows
-    private static void kill(Process p) {
+    private static void kill(Process p) throws InterruptedException {
         if (p != null && p.isAlive()) p.destroyForcibly().waitFor();
     }
 
     @Test
-    @SneakyThrows
-    public void testExclusiveLockHeldOnFile() {
+    public void testExclusiveLockHeldOnFile() throws Exception {
         Path lockFilePath = Files.createFile(testDir.resolve("file.lock"));
         // try to acquire an exclusive lock and check that the process returns immediately
         JavaProcessBuilder javaProcessBuilder = new JavaProcessBuilder();

--- a/flask/src/main/java/net/corda/gradle/flask/HeartbeatAgentResource.java
+++ b/flask/src/main/java/net/corda/gradle/flask/HeartbeatAgentResource.java
@@ -1,12 +1,14 @@
 package net.corda.gradle.flask;
 
-import lombok.SneakyThrows;
+import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.resources.ReadableResource;
 import org.gradle.api.resources.ResourceException;
 
 import javax.annotation.Nonnull;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 final class HeartbeatAgentResource implements ReadableResource {
@@ -20,23 +22,32 @@ final class HeartbeatAgentResource implements ReadableResource {
 
     @Override
     @Nonnull
-    @SneakyThrows
     public InputStream read() throws ResourceException {
-        return url.openStream();
+        try {
+            return url.openStream();
+        } catch (IOException e) {
+            throw new ResourceException(e.getMessage(), e);
+        }
     }
 
     @Override
+    @Nonnull
     public String getDisplayName() {
         return getBaseName() + ".jar";
     }
 
     @Override
-    @SneakyThrows
+    @Nonnull
     public URI getURI() {
-        return url.toURI();
+        try {
+            return url.toURI();
+        } catch (URISyntaxException e) {
+            throw new InvalidUserDataException(e.getMessage(), e);
+        }
     }
 
     @Override
+    @Nonnull
     public String getBaseName() {
         return "flask-heartbeat-agent";
     }

--- a/flask/src/main/java/net/corda/gradle/flask/LauncherResource.java
+++ b/flask/src/main/java/net/corda/gradle/flask/LauncherResource.java
@@ -1,12 +1,14 @@
 package net.corda.gradle.flask;
 
-import lombok.SneakyThrows;
+import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.resources.ReadableResource;
 import org.gradle.api.resources.ResourceException;
 
 import javax.annotation.Nonnull;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 final class LauncherResource implements ReadableResource {
@@ -20,23 +22,32 @@ final class LauncherResource implements ReadableResource {
 
     @Override
     @Nonnull
-    @SneakyThrows
     public InputStream read() throws ResourceException {
-        return url.openStream();
+        try {
+            return url.openStream();
+        } catch (IOException e) {
+            throw new ResourceException(e.getMessage(), e);
+        }
     }
 
     @Override
+    @Nonnull
     public String getDisplayName() {
         return getBaseName() + ".tar";
     }
 
     @Override
-    @SneakyThrows
+    @Nonnull
     public URI getURI() {
-        return url.toURI();
+        try {
+            return url.toURI();
+        } catch (URISyntaxException e) {
+            throw new InvalidUserDataException(e.getMessage(), e);
+        }
     }
 
     @Override
+    @Nonnull
     public String getBaseName() {
         return "flask-launcher";
     }

--- a/flask/src/test/groovy/net/corda/gradle/flask/FlaskPluginTest.groovy
+++ b/flask/src/test/groovy/net/corda/gradle/flask/FlaskPluginTest.groovy
@@ -14,7 +14,6 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.security.MessageDigest
-import java.util.concurrent.TimeUnit
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 
@@ -25,8 +24,10 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertNotEquals
 import static org.junit.jupiter.api.Assertions.assertTrue
+import static java.util.concurrent.TimeUnit.MINUTES
 
 @CompileStatic
+@Timeout(value = 3L, unit = MINUTES)
 class FlaskPluginTest {
     private static final int EOF = -1
 
@@ -61,8 +62,7 @@ class FlaskPluginTest {
         }
     }
 
-    @TempDir
-    public Path testGradleHomeDir
+    private final String testGradleHomeDir = System.getProperty("test.gradle.user.home")
 
     @TempDir
     public Path testProjectDir
@@ -86,7 +86,7 @@ class FlaskPluginTest {
         GradleRunner runner = GradleRunner.create()
                 .withDebug(true)
                 .withProjectDir(testProjectDir.toFile())
-                .withArguments(taskName + ["-s", "--info", "-g", testGradleHomeDir.toString()])
+                .withArguments(taskName + ["-s", "--info", "-g", testGradleHomeDir])
                 .withPluginClasspath()
         println(runner.build().getOutput())
     }
@@ -181,7 +181,6 @@ class FlaskPluginTest {
     }
 
     @Test
-    @Timeout(value = 10L, unit = TimeUnit.SECONDS)
     @DisplayName("Check that shutdown hooks are executed on flask jars")
     void shutdownHookTest() {
         invokeGradle("shutdownHookTestJar")

--- a/flask/src/test/resources/testProject/src/flask/java/net/corda/gradle/flask/test/TestLauncher.java
+++ b/flask/src/test/resources/testProject/src/flask/java/net/corda/gradle/flask/test/TestLauncher.java
@@ -21,8 +21,10 @@ public class TestLauncher extends Launcher {
             try (Writer writer = Files.newBufferedWriter(outputfile)) {
                 prop.store(writer, null);
             }
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException(e.getMessage(), e);
         }
     }
 }

--- a/flask/src/test/resources/testProject/src/main/java/net/corda/gradle/flask/test/HangingMain.java
+++ b/flask/src/test/resources/testProject/src/main/java/net/corda/gradle/flask/test/HangingMain.java
@@ -1,6 +1,7 @@
 package net.corda.gradle.flask.test;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.file.Files;
@@ -16,7 +17,7 @@ public class HangingMain {
             try {
                 Files.delete(file);
             } catch (IOException ioe) {
-                throw new RuntimeException(ioe);
+                throw new UncheckedIOException(ioe);
             }
         }));
         Files.createFile(file);

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,6 @@ assertj_version=3.20.2
 junit_jupiter_version=5.8.1
 hamcrest_version=2.2
 asm_version=9.2
-lombok_version=1.18.16
 slf4j_version=1.7.32
 javax_annotations_version=1.3.2
 osgi_version=8.0.0


### PR DESCRIPTION
Remove Lombok from the `flask` plugin project so that there is less to maintain.

There should be no functional change, although we need some new functional interfaces that allow lambdas to throw exceptions.