### PR TITLE
CORE-3809: Fix cordapp-cpb plugin only to resolve cpbPackaging configuration after entire configuration phase.

### DIFF
--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappPlugin.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappPlugin.kt
@@ -356,8 +356,11 @@ class CordappPlugin @Inject constructor(private val layouts: ProjectLayout): Plu
                 }
             }
         }
-        project.artifacts.add(ARCHIVES_CONFIGURATION, cpkTask)
-        project.artifacts.add(CORDA_CPK_CONFIGURATION_NAME, cpkTask)
+
+        with(project.artifacts) {
+            add(ARCHIVES_CONFIGURATION, cpkTask)
+            add(CORDA_CPK_CONFIGURATION_NAME, cpkTask)
+        }
     }
 
     private fun configureCordappAttributes(symbolicName: String, attributes: Attributes) {


### PR DESCRIPTION
Resolve the `cpbPackaging` configuration via a `projectsEvaluated` handler instead of the project's own `afterEvaluate` handler. We _must not_ resolve this configuration until every other project in the build has also had a chance to apply the `cordapp-cpk` plugin.

This is a subtle fix to an incomplete workaround to a Gradle bug.