### PR TITLE
NOTICK: Switch Jenkins pipeline to using authenticated Gradle wrapper.

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -50,6 +50,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
+                authenticateGradleWrapper()
                 sh './gradlew --no-daemon --info --no-build-cache clean build'
             }
         }


### PR DESCRIPTION
Configure Jenkins pipeline to download Gradle from Artifactory.