### PR TITLE
NOTICK: Use JUnit's PER_CLASS TestInstance lifecycle.

### DIFF
--- a/api-scanner/src/test/java/net/corda/plugins/apiscanner/ExtendedClassTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/apiscanner/ExtendedClassTest.java
@@ -2,18 +2,21 @@ package net.corda.plugins.apiscanner;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Path;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
+@TestInstance(PER_CLASS)
 class ExtendedClassTest {
-    private static GradleProject testProject;
+    private GradleProject testProject;
 
     @BeforeAll
-    static void setup(@TempDir Path testProjectDir) throws IOException {
+    void setup(@TempDir Path testProjectDir) throws IOException {
         testProject = new GradleProject(testProjectDir, "extended-class").build();
     }
 

--- a/api-scanner/src/test/java/net/corda/plugins/apiscanner/KotlinAnnotationsTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/apiscanner/KotlinAnnotationsTest.java
@@ -2,18 +2,21 @@ package net.corda.plugins.apiscanner;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Path;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
+@TestInstance(PER_CLASS)
 class KotlinAnnotationsTest {
-    private static GradleProject testProject;
+    private GradleProject testProject;
 
     @BeforeAll
-    static void setup(@TempDir Path testProjectDir) throws IOException {
+    void setup(@TempDir Path testProjectDir) throws IOException {
         testProject = new GradleProject(testProjectDir, "kotlin-annotations")
             .withResource("kotlin.gradle")
             .build();

--- a/api-scanner/src/test/java/net/corda/plugins/apiscanner/KotlinConstantTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/apiscanner/KotlinConstantTest.java
@@ -2,18 +2,21 @@ package net.corda.plugins.apiscanner;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
+@TestInstance(PER_CLASS)
 class KotlinConstantTest {
-    private static GradleProject testProject;
+    private GradleProject testProject;
 
     @BeforeAll
-    static void setup(@TempDir Path testProjectDir) throws IOException {
+    void setup(@TempDir Path testProjectDir) throws IOException {
         testProject = new GradleProject(testProjectDir, "kotlin-constant")
             .withResource("kotlin.gradle")
             .build();

--- a/api-scanner/src/test/java/net/corda/plugins/apiscanner/KotlinEnumTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/apiscanner/KotlinEnumTest.java
@@ -2,18 +2,21 @@ package net.corda.plugins.apiscanner;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
+@TestInstance(PER_CLASS)
 class KotlinEnumTest {
-    private static GradleProject testProject;
+    private GradleProject testProject;
 
     @BeforeAll
-    static void setup(@TempDir Path testProjectDir) throws IOException {
+    void setup(@TempDir Path testProjectDir) throws IOException {
         testProject = new GradleProject(testProjectDir, "kotlin-enum")
             .withResource("kotlin.gradle")
             .build();

--- a/api-scanner/src/test/java/net/corda/plugins/apiscanner/KotlinExcludeMethodTest.java
+++ b/api-scanner/src/test/java/net/corda/plugins/apiscanner/KotlinExcludeMethodTest.java
@@ -2,18 +2,21 @@ package net.corda.plugins.apiscanner;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Path;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
+@TestInstance(PER_CLASS)
 class KotlinExcludeMethodTest {
-    private static GradleProject testProject;
+    private GradleProject testProject;
 
     @BeforeAll
-    static void setup(@TempDir Path testProjectDir) throws IOException {
+    void setup(@TempDir Path testProjectDir) throws IOException {
         testProject = new GradleProject(testProjectDir, "kotlin-exclude-method")
             .withResource("kotlin.gradle")
             .build();

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpb/CpbPlatformTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpb/CpbPlatformTest.kt
@@ -8,46 +8,48 @@ import net.corda.plugins.cpk.toOSGi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.stream.Collectors.toList
 
+@TestInstance(PER_CLASS)
 class CpbPlatformTest {
-    companion object {
+    private companion object {
         private const val platformCordappVersion = "3.4.2"
         private const val cordappVersion = "1.2.3"
+    }
 
-        private lateinit var externalProject: GradleProject
-        private lateinit var testProject: GradleProject
+    private lateinit var externalProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(
-            @TempDir externalCordappProjectDir: Path,
-            @TempDir testProjectDir: Path,
-            reporter: TestReporter
-        ) {
-            val mavenRepoDir = Files.createDirectory(testProjectDir.resolve("maven"))
-            externalProject = GradleProject(externalCordappProjectDir, reporter)
-                .withTestName("external-cordapp")
-                .withSubResource("corda-platform-cordapp/build.gradle")
-                .withSubResource("external-cordapp-transitive-dependency/build.gradle")
-                .withTaskName("publishAllPublicationsToTestRepository")
-                .build("-Pmaven_repository_dir=$mavenRepoDir",
-                       "-Pcorda_api_version=$cordaApiVersion",
-                       "-Pplatform_cordapp_version=$platformCordappVersion",
-                       "-Pcordapp_version=$cordappVersion",
-                       "-Pcordapp_contract_version=$expectedCordappContractVersion")
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("cpb-with-platform")
-                .withSubResource("src/main/kotlin/com/example/cpb/platform/ExampleContract.kt")
-                .build("-Pmaven_repository_dir=$mavenRepoDir",
-                       "-Pcorda_api_version=$cordaApiVersion",
-                       "-Pcordapp_version=$cordappVersion",
-                       "-Pcordapp_contract_version=$expectedCordappContractVersion")
-        }
+    @BeforeAll
+    fun setup(
+        @TempDir externalCordappProjectDir: Path,
+        @TempDir testProjectDir: Path,
+        reporter: TestReporter
+    ) {
+        val mavenRepoDir = Files.createDirectory(testProjectDir.resolve("maven"))
+        externalProject = GradleProject(externalCordappProjectDir, reporter)
+            .withTestName("external-cordapp")
+            .withSubResource("corda-platform-cordapp/build.gradle")
+            .withSubResource("external-cordapp-transitive-dependency/build.gradle")
+            .withTaskName("publishAllPublicationsToTestRepository")
+            .build("-Pmaven_repository_dir=$mavenRepoDir",
+                   "-Pcorda_api_version=$cordaApiVersion",
+                   "-Pplatform_cordapp_version=$platformCordappVersion",
+                   "-Pcordapp_version=$cordappVersion",
+                   "-Pcordapp_contract_version=$expectedCordappContractVersion")
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("cpb-with-platform")
+            .withSubResource("src/main/kotlin/com/example/cpb/platform/ExampleContract.kt")
+            .build("-Pmaven_repository_dir=$mavenRepoDir",
+                   "-Pcorda_api_version=$cordaApiVersion",
+                   "-Pcordapp_version=$cordappVersion",
+                   "-Pcordapp_contract_version=$expectedCordappContractVersion")
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpb/DeepTransitiveCordappsTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpb/DeepTransitiveCordappsTest.kt
@@ -7,41 +7,42 @@ import net.corda.plugins.cpk.expectedCordappContractVersion
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import java.util.jar.JarEntry
 import java.util.jar.JarFile
 
+@TestInstance(PER_CLASS)
 class DeepTransitiveCordappsTest {
-    companion object {
+    private companion object {
         private const val cpk1Version = "1.0-SNAPSHOT"
         private const val cpk2Version = "2.0-SNAPSHOT"
         private const val cpkFinalVersion = "3.0-SNAPSHOT"
+    }
 
-        private lateinit var testProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("deep-transitive-cordapps")
-                .withSubResource("cpk-one/build.gradle")
-                .withSubResource("cpk-one/src/main/kotlin/com/example/one/ContractOne.kt")
-                .withSubResource("cpk-two/build.gradle")
-                .withSubResource("cpk-two/src/main/kotlin/com/example/one/ContractTwo.kt")
-                .withSubResource("cpk-final/build.gradle")
-                .withSubResource("cpk-final/src/main/kotlin/com/example/final/ContractFinal.kt")
-                .build(
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pannotations_version=$annotationsVersion",
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Pcpk1_version=$cpk1Version",
-                    "-Pcpk2_version=$cpk2Version",
-                    "-PcpkFinal_version=$cpkFinalVersion"
-                )
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("deep-transitive-cordapps")
+            .withSubResource("cpk-one/build.gradle")
+            .withSubResource("cpk-one/src/main/kotlin/com/example/one/ContractOne.kt")
+            .withSubResource("cpk-two/build.gradle")
+            .withSubResource("cpk-two/src/main/kotlin/com/example/one/ContractTwo.kt")
+            .withSubResource("cpk-final/build.gradle")
+            .withSubResource("cpk-final/src/main/kotlin/com/example/final/ContractFinal.kt")
+            .build(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pannotations_version=$annotationsVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pcpk1_version=$cpk1Version",
+                "-Pcpk2_version=$cpk2Version",
+                "-PcpkFinal_version=$cpkFinalVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/ComplexPackagesTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/ComplexPackagesTest.kt
@@ -4,6 +4,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.Constants.BUNDLE_LICENSE
@@ -16,21 +18,18 @@ import org.osgi.framework.Constants.IMPORT_PACKAGE
 import org.osgi.framework.Constants.REQUIRE_CAPABILITY
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class ComplexPackagesTest {
-    companion object {
-        private lateinit var testProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("complex-packages")
-                .withSubResource("src/main/java/com/example/cordapp/package-info.java")
-                .withSubResource("src/main/java/com/example/cordapp/sub1/Secret.java")
-                .withSubResource("src/main/java/com/example/cordapp/sub2/package-info.java")
-                .build("-Pcordapp_contract_version=$expectedCordappContractVersion")
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("complex-packages")
+            .withSubResource("src/main/java/com/example/cordapp/package-info.java")
+            .withSubResource("src/main/java/com/example/cordapp/sub1/Secret.java")
+            .withSubResource("src/main/java/com/example/cordapp/sub2/package-info.java")
+            .build("-Pcordapp_contract_version=$expectedCordappContractVersion")
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/ConfigureCordaMetadataTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/ConfigureCordaMetadataTest.kt
@@ -3,36 +3,37 @@ package net.corda.plugins.cpk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.Constants.DYNAMICIMPORT_PACKAGE
 import org.osgi.framework.Constants.IMPORT_PACKAGE
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class ConfigureCordaMetadataTest {
-    companion object {
+    private companion object {
         private const val CORDAPP_VERSION = "1.1.1-SNAPSHOT"
         private const val HIBERNATE_ANNOTATIONS_PACKAGE = "org.hibernate.annotations"
         private const val HIBERNATE_PROXY_PACKAGE = "org.hibernate.proxy"
         private const val CORDA_OSGI_VERSION = "version=[5,6)"
+    }
 
-        private lateinit var testProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("configure-corda-metadata")
-                .withSubResource("cordapp/src/main/kotlin/com/example/metadata/custom/ExampleContract.kt")
-                .withSubResource("cordapp/build.gradle")
-                .build(
-                    "-Pcontract_name=Configure Contract Metadata",
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Pcordapp_version=$CORDAPP_VERSION"
-                )
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("configure-corda-metadata")
+            .withSubResource("cordapp/src/main/kotlin/com/example/metadata/custom/ExampleContract.kt")
+            .withSubResource("cordapp/build.gradle")
+            .build(
+                "-Pcontract_name=Configure Contract Metadata",
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pcordapp_version=$CORDAPP_VERSION"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappApiLibraryTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappApiLibraryTest.kt
@@ -4,6 +4,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.Constants.BUNDLE_LICENSE
@@ -14,37 +16,37 @@ import org.osgi.framework.Constants.BUNDLE_VERSION
 import org.osgi.framework.Constants.IMPORT_PACKAGE
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class CordappApiLibraryTest {
-    companion object {
+    private companion object {
         private const val CONTRACT_CORDAPP_VERSION = "1.1.5-SNAPSHOT"
         private const val WORKFLOW_CORDAPP_VERSION = "2.6.3-SNAPSHOT"
         private const val expectedContractGuavaVersion = "29.0-jre"
         private const val expectedWorkflowGuavaVersion = "19.0"
-        private lateinit var testProject: GradleProject
+    }
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            // Check that the Workflow CorDapp is using a lower version
-            // of Guava than the Contract CorDapp.
-            assertThat(osgiVersion(expectedWorkflowGuavaVersion))
-                .isLessThan(osgiVersion(expectedContractGuavaVersion))
+    private lateinit var testProject: GradleProject
 
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("cordapp-api-library")
-                .withSubResource("src/main/kotlin/com/example/workflow/ExampleWorkflow.kt")
-                .withSubResource("cordapp/build.gradle")
-                .build(
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcordapp_workflow_version=$expectedCordappWorkflowVersion",
-                    "-Pcontract_cordapp_version=$CONTRACT_CORDAPP_VERSION",
-                    "-Pcontract_guava_version=$expectedContractGuavaVersion",
-                    "-Pworkflow_cordapp_version=$WORKFLOW_CORDAPP_VERSION",
-                    "-Pworkflow_guava_version=$expectedWorkflowGuavaVersion"
-                )
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        // Check that the Workflow CorDapp is using a lower version
+        // of Guava than the Contract CorDapp.
+        assertThat(osgiVersion(expectedWorkflowGuavaVersion))
+            .isLessThan(osgiVersion(expectedContractGuavaVersion))
+
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("cordapp-api-library")
+            .withSubResource("src/main/kotlin/com/example/workflow/ExampleWorkflow.kt")
+            .withSubResource("cordapp/build.gradle")
+            .build(
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcordapp_workflow_version=$expectedCordappWorkflowVersion",
+                "-Pcontract_cordapp_version=$CONTRACT_CORDAPP_VERSION",
+                "-Pcontract_guava_version=$expectedContractGuavaVersion",
+                "-Pworkflow_cordapp_version=$WORKFLOW_CORDAPP_VERSION",
+                "-Pworkflow_guava_version=$expectedWorkflowGuavaVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappClassesDependencyTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappClassesDependencyTest.kt
@@ -5,6 +5,8 @@ import java.nio.file.Path
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.Constants.IMPORT_PACKAGE
@@ -14,31 +16,31 @@ import org.osgi.framework.Constants.IMPORT_PACKAGE
  * our CorDapp against library.jar. It MUST NOT use library's
  * unpackaged classes, which have no OSGi metadata.
  */
+@TestInstance(PER_CLASS)
 class CordappClassesDependencyTest {
-    companion object {
+    private companion object {
         private const val CORDAPP_VERSION = "1.1.1-SNAPSHOT"
         private const val LIBRARY_VERSION = "2.2.2-SNAPSHOT"
         private const val compilePrefix = "COMPILE "
-        private lateinit var testProject: GradleProject
+    }
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("cordapp-classes-dep")
-                .withSubResource("src/main/kotlin/com/example/host/CordappHostContract.kt")
-                .withSubResource("library/src/main/java/com/example/library/package-info.java")
-                .withSubResource("library/src/main/java/com/example/library/ExternalLibrary.java")
-                .withSubResource("library/src/main/java/com/example/library/impl/ExternalLibraryImpl.java")
-                .withSubResource("library/build.gradle")
-                .build(
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Pcordapp_version=$CORDAPP_VERSION",
-                    "-Plibrary_version=$LIBRARY_VERSION"
-                )
-        }
+    private lateinit var testProject: GradleProject
+
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("cordapp-classes-dep")
+            .withSubResource("src/main/kotlin/com/example/host/CordappHostContract.kt")
+            .withSubResource("library/src/main/java/com/example/library/package-info.java")
+            .withSubResource("library/src/main/java/com/example/library/ExternalLibrary.java")
+            .withSubResource("library/src/main/java/com/example/library/impl/ExternalLibraryImpl.java")
+            .withSubResource("library/build.gradle")
+            .build(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pcordapp_version=$CORDAPP_VERSION",
+                "-Plibrary_version=$LIBRARY_VERSION"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappGradleConfigurationsTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappGradleConfigurationsTest.kt
@@ -4,6 +4,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.gradle.util.GradleVersion
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
@@ -11,59 +13,59 @@ import java.util.stream.Collectors.toList
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 
+@TestInstance(PER_CLASS)
 class CordappGradleConfigurationsTest {
-    companion object {
+    private companion object {
         private val GRADLE_6_9 = GradleVersion.version("6.9")
-        private lateinit var testProject: GradleProject
-        private lateinit var dependencies: List<ZipEntry>
+    }
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withGradleVersion(GRADLE_6_9)
-                .withBuildScript("""\
-                    |plugins {
-                    |    id 'net.corda.plugins.cordapp-cpk'
-                    |}
-                    |
-                    |apply from: 'repositories.gradle'
-                    |
-                    |version = '1.0-SNAPSHOT'
-                    |group = 'com.example'
-                    |
-                    |dependencies {
-                    |    compile "javax.activation:javax.activation-api:1.2.0"
-                    |    runtime "commons-io:commons-io:2.7"
-                    |    cordaProvided "com.google.guava:guava:20.0"
-                    |    cordaRuntimeOnly "javax.servlet:javax.servlet-api:3.1.0"
-                    |    api "javax.annotation:javax.annotation-api:1.3.2"
-                    |    implementation "javax.persistence:javax.persistence-api:2.2"
-                    |    runtimeOnly "javax.validation:validation-api:1.1.0.Final"
-                    |}
-                    |
-                    |jar {
-                    |    archiveBaseName = 'configurations'
-                    |}
-                    |
-                    |cordapp {
-                    |    contract {
-                    |        name = 'Testing'
-                    |        versionId = 1
-                    |        targetPlatformVersion = 999
-                    |    }
-                    |}
-                """.trimMargin())
-                .build()
+    private lateinit var testProject: GradleProject
+    private lateinit var dependencies: List<ZipEntry>
 
-            val cordapp = testProject.artifacts.single { it.toString().endsWith(".cpk") }
-            assertThat(cordapp).isRegularFile()
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withGradleVersion(GRADLE_6_9)
+            .withBuildScript("""\
+                |plugins {
+                |    id 'net.corda.plugins.cordapp-cpk'
+                |}
+                |
+                |apply from: 'repositories.gradle'
+                |
+                |version = '1.0-SNAPSHOT'
+                |group = 'com.example'
+                |
+                |dependencies {
+                |    compile "javax.activation:javax.activation-api:1.2.0"
+                |    runtime "commons-io:commons-io:2.7"
+                |    cordaProvided "com.google.guava:guava:20.0"
+                |    cordaRuntimeOnly "javax.servlet:javax.servlet-api:3.1.0"
+                |    api "javax.annotation:javax.annotation-api:1.3.2"
+                |    implementation "javax.persistence:javax.persistence-api:2.2"
+                |    runtimeOnly "javax.validation:validation-api:1.1.0.Final"
+                |}
+                |
+                |jar {
+                |    archiveBaseName = 'configurations'
+                |}
+                |
+                |cordapp {
+                |    contract {
+                |        name = 'Testing'
+                |        versionId = 1
+                |        targetPlatformVersion = 999
+                |    }
+                |}
+            """.trimMargin())
+            .build()
 
-            dependencies = ZipFile(cordapp.toFile()).use { zip ->
-                zip.stream().filter { entry -> entry.name.startsWith("lib/") && !entry.isDirectory }
-                   .collect(toList())
-            }
+        val cordapp = testProject.artifacts.single { it.toString().endsWith(".cpk") }
+        assertThat(cordapp).isRegularFile()
+
+        dependencies = ZipFile(cordapp.toFile()).use { zip ->
+            zip.stream().filter { entry -> entry.name.startsWith("lib/") && !entry.isDirectory }
+               .collect(toList())
         }
     }
 

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappJarForCPKDependenciesTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappJarForCPKDependenciesTest.kt
@@ -2,6 +2,8 @@ package net.corda.plugins.cpk
 
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
@@ -12,33 +14,32 @@ import org.junit.jupiter.api.Test
  * Generating the CPKDependencies file requires that Gradle
  * also build the "main" jar file for any dependent CPKs.
  */
+@TestInstance(PER_CLASS)
 class CordappJarForCPKDependenciesTest {
-    companion object {
+    private companion object {
         private const val CPK_DEPENDENCIES_TASK_NAME = "cordappCPKDependencies"
         private const val cordappVersion = "1.2.1-SNAPSHOT"
         private const val hostVersion = "2.0.1-SNAPSHOT"
+    }
 
-        private lateinit var testProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("cordapp-transitive-deps")
-                .withSubResource("cordapp/build.gradle")
-                .withTaskName(CPK_DEPENDENCIES_TASK_NAME)
-                .build(
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcommons_collections_version=$commonsCollectionsVersion",
-                    "-Pcommons_codec_version=$commonsCodecVersion",
-                    "-Pannotations_version=$annotationsVersion",
-                    "-Pcommons_io_version=$commonsIoVersion",
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Pcordapp_version=$cordappVersion",
-                    "-Phost_version=$hostVersion"
-                )
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("cordapp-transitive-deps")
+            .withSubResource("cordapp/build.gradle")
+            .withTaskName(CPK_DEPENDENCIES_TASK_NAME)
+            .build(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcommons_collections_version=$commonsCollectionsVersion",
+                "-Pcommons_codec_version=$commonsCodecVersion",
+                "-Pannotations_version=$annotationsVersion",
+                "-Pcommons_io_version=$commonsIoVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pcordapp_version=$cordappVersion",
+                "-Phost_version=$hostVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappPrivateDependencyTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappPrivateDependencyTest.kt
@@ -3,35 +3,36 @@ package net.corda.plugins.cpk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import java.io.StringReader
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class CordappPrivateDependencyTest {
-    companion object {
+    private companion object {
         private const val cordappVersion = "1.2.1-SNAPSHOT"
         private const val hostVersion = "2.0.1-SNAPSHOT"
         private const val dependencyPrefix = "DEPENDENCY "
+    }
 
-        private lateinit var testProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("cordapp-private-deps")
-                .withSubResource("cordapp/build.gradle")
-                .build(
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcommons_collections_version=$commonsCollectionsVersion",
-                    "-Pcommons_codec_version=$commonsCodecVersion",
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Pcordapp_version=$cordappVersion",
-                    "-Phost_version=$hostVersion"
-                )
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("cordapp-private-deps")
+            .withSubResource("cordapp/build.gradle")
+            .build(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcommons_collections_version=$commonsCollectionsVersion",
+                "-Pcommons_codec_version=$commonsCodecVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pcordapp_version=$cordappVersion",
+                "-Phost_version=$hostVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappTransitiveDependencyTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappTransitiveDependencyTest.kt
@@ -3,35 +3,36 @@ package net.corda.plugins.cpk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class CordappTransitiveDependencyTest {
-    companion object {
+    private companion object {
         private const val cordappVersion = "1.2.1-SNAPSHOT"
         private const val hostVersion = "2.0.1-SNAPSHOT"
+    }
 
-        private lateinit var testProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("cordapp-transitive-deps")
-                .withSubResource("cordapp/build.gradle")
-                .build(
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcommons_collections_version=$commonsCollectionsVersion",
-                    "-Pcommons_codec_version=$commonsCodecVersion",
-                    "-Pannotations_version=$annotationsVersion",
-                    "-Pcommons_io_version=$commonsIoVersion",
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Pcordapp_version=$cordappVersion",
-                    "-Phost_version=$hostVersion"
-                )
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("cordapp-transitive-deps")
+            .withSubResource("cordapp/build.gradle")
+            .build(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcommons_collections_version=$commonsCollectionsVersion",
+                "-Pcommons_codec_version=$commonsCodecVersion",
+                "-Pannotations_version=$annotationsVersion",
+                "-Pcommons_io_version=$commonsIoVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pcordapp_version=$cordappVersion",
+                "-Phost_version=$hostVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithConstraintTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithConstraintTest.kt
@@ -3,42 +3,43 @@ package net.corda.plugins.cpk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class CordappWithConstraintTest {
-    companion object {
+    private companion object {
         private const val cordappVersion = "1.0.1-SNAPSHOT"
         private const val library1Version = "1.2.3-SNAPSHOT"
         private const val library2Version = "1.2.4-SNAPSHOT"
+    }
 
-        private lateinit var testProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("cordapp-with-constraint")
-                .withSubResource("src/main/kotlin/com/example/constraint/ConstraintContract.kt")
-                .withSubResource("library1/src/main/java/org/testing/compress/package-info.java")
-                .withSubResource("library1/src/main/java/org/testing/compress/ExampleZip.java")
-                .withSubResource("library1/build.gradle")
-                .withSubResource("library2/src/main/java/org/testing/io/package-info.java")
-                .withSubResource("library2/src/main/java/org/testing/io/ExampleStream.java")
-                .withSubResource("library2/build.gradle")
-                .build(
-                    "-Pcordapp_version=$cordappVersion",
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Plibrary1_version=$library1Version",
-                    "-Plibrary2_version=$library2Version",
-                    "-Pcommons_io_version=$commonsIoVersion",
-                    "-Pcommons_codec_version=$commonsCodecVersion",
-                    "-Pcommons_compress_version=$commonsCompressVersion"
-                )
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("cordapp-with-constraint")
+            .withSubResource("src/main/kotlin/com/example/constraint/ConstraintContract.kt")
+            .withSubResource("library1/src/main/java/org/testing/compress/package-info.java")
+            .withSubResource("library1/src/main/java/org/testing/compress/ExampleZip.java")
+            .withSubResource("library1/build.gradle")
+            .withSubResource("library2/src/main/java/org/testing/io/package-info.java")
+            .withSubResource("library2/src/main/java/org/testing/io/ExampleStream.java")
+            .withSubResource("library2/build.gradle")
+            .build(
+                "-Pcordapp_version=$cordappVersion",
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Plibrary1_version=$library1Version",
+                "-Plibrary2_version=$library2Version",
+                "-Pcommons_io_version=$commonsIoVersion",
+                "-Pcommons_codec_version=$commonsCodecVersion",
+                "-Pcommons_compress_version=$commonsCompressVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithEmbeddedTransitivesTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithEmbeddedTransitivesTest.kt
@@ -5,6 +5,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.Constants.BUNDLE_CLASSPATH
@@ -18,8 +20,9 @@ import java.nio.file.Path
 import java.util.jar.JarEntry
 import java.util.jar.JarFile
 
+@TestInstance(PER_CLASS)
 class CordappWithEmbeddedTransitivesTest {
-    companion object {
+    private companion object {
         private const val cordappVersion = "2.3.4-SNAPSHOT"
         private const val hostVersion = "1.2.3-SNAPSHOT"
         private const val slf4jVersion = "2.0.0-alpha1"
@@ -30,28 +33,26 @@ class CordappWithEmbeddedTransitivesTest {
         private const val cordaOsgiVersion = "version=\"[5.0,6)\""
         private const val cordappOsgiVersion = "version=\"[2.3,3)\""
         private const val hostOsgiVersion = "version=\"1.2.3\""
+    }
 
-        private lateinit var testProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("cordapp-embedded-transitives")
-                .withSubResource("src/main/kotlin/com/example/host/HostContract.kt")
-                .withSubResource("cordapp/build.gradle")
-                .withSubResource("cordapp/src/main/kotlin/com/example/cordapp/CordappContract.kt")
-                .build(
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcommons_collections_version=$commonsCollectionsVersion",
-                    "-Pcommons_io_version=$commonsIoVersion",
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Pslf4j_version=$slf4jVersion",
-                    "-Pcordapp_version=$cordappVersion",
-                    "-Phost_version=$hostVersion"
-                )
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("cordapp-embedded-transitives")
+            .withSubResource("src/main/kotlin/com/example/host/HostContract.kt")
+            .withSubResource("cordapp/build.gradle")
+            .withSubResource("cordapp/src/main/kotlin/com/example/cordapp/CordappContract.kt")
+            .build(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcommons_collections_version=$commonsCollectionsVersion",
+                "-Pcommons_io_version=$commonsIoVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pslf4j_version=$slf4jVersion",
+                "-Pcordapp_version=$cordappVersion",
+                "-Phost_version=$hostVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithLoggingTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithLoggingTest.kt
@@ -4,31 +4,32 @@ import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome.FAILED
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class CordappWithLoggingTest {
-    companion object {
+    private companion object {
         private const val cordappVersion = "1.0.1-SNAPSHOT"
         private const val slf4jVersion = "2.0.0-alpha1"
+    }
 
-        private lateinit var testProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("cordapp-with-logging")
-                .withSubResource("src/main/java/com/example/contract/LoggingContract.java")
-                .buildAndFail(
-                    "-Pcordapp_version=$cordappVersion",
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Pslf4j_version=$slf4jVersion"
-                )
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("cordapp-with-logging")
+            .withSubResource("src/main/java/com/example/contract/LoggingContract.java")
+            .buildAndFail(
+                "-Pcordapp_version=$cordappVersion",
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pslf4j_version=$slf4jVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithOwnGuavaVersionTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithOwnGuavaVersionTest.kt
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.Constants.BUNDLE_LICENSE
@@ -17,8 +19,9 @@ import org.osgi.framework.Constants.IMPORT_PACKAGE
 import org.osgi.framework.Constants.REQUIRE_CAPABILITY
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class CordappWithOwnGuavaVersionTest {
-    companion object {
+    private companion object {
         private const val cordappVersion = "1.0.1-SNAPSHOT"
         private const val cordaGuavaVersion = "20.0"
         private const val guavaVersion = "29.0-jre"
@@ -26,24 +29,22 @@ class CordappWithOwnGuavaVersionTest {
         private const val guavaOsgiVersion = "version=\"[29.0,30)\""
         private const val cordaOsgiVersion = "version=\"[5.0,6)\""
         private const val cordappOsgiVersion = "version=\"1.0.1\""
+    }
 
-        private lateinit var testProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("cordapp-with-guava")
-                .withSubResource("src/main/java/com/example/contract/GuavaContract.java")
-                .build(
-                    "-Pcordapp_version=$cordappVersion",
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Pcorda_guava_version=$cordaGuavaVersion",
-                    "-Pguava_version=$guavaVersion"
-                )
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("cordapp-with-guava")
+            .withSubResource("src/main/java/com/example/contract/GuavaContract.java")
+            .build(
+                "-Pcordapp_version=$cordappVersion",
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pcorda_guava_version=$cordaGuavaVersion",
+                "-Pguava_version=$guavaVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithPlatformTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithPlatformTest.kt
@@ -4,6 +4,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.Constants.BUNDLE_NAME
@@ -15,41 +17,41 @@ import org.osgi.framework.Constants.REQUIRE_CAPABILITY
 import java.nio.file.Files
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class CordappWithPlatformTest {
-    companion object {
+    private companion object {
         private const val kotlinOsgiVersion = "version=\"[1.4,2)\""
         private const val cordaOsgiVersion = "version=\"[5.0,6)\""
 
         private const val cordappVersion = "3.2.1-SNAPSHOT"
+    }
 
-        private lateinit var publisherProject: GradleProject
-        private lateinit var testProject: GradleProject
+    private lateinit var publisherProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(
-            @TempDir publisherProjectDir: Path,
-            @TempDir testProjectDir: Path,
-            reporter: TestReporter
-        ) {
-            val repositoryDir = Files.createDirectory(testProjectDir.resolve("maven"))
-            publisherProject = GradleProject(publisherProjectDir, reporter)
-                .withTestName("publish-platform")
-                .withTaskName("publishAllPublicationsToTestRepository")
-                .build(
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Prepository_dir=$repositoryDir"
-                )
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("cordapp-with-platform")
-                .withSubResource("src/main/kotlin/com/example/cpk/platform/ExampleContract.kt")
-                .build(
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Pcordapp_version=$cordappVersion",
-                    "-Prepository_dir=$repositoryDir"
-                )
-        }
+    @BeforeAll
+    fun setup(
+        @TempDir publisherProjectDir: Path,
+        @TempDir testProjectDir: Path,
+        reporter: TestReporter
+    ) {
+        val repositoryDir = Files.createDirectory(testProjectDir.resolve("maven"))
+        publisherProject = GradleProject(publisherProjectDir, reporter)
+            .withTestName("publish-platform")
+            .withTaskName("publishAllPublicationsToTestRepository")
+            .build(
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Prepository_dir=$repositoryDir"
+            )
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("cordapp-with-platform")
+            .withSubResource("src/main/kotlin/com/example/cpk/platform/ExampleContract.kt")
+            .build(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pcordapp_version=$cordappVersion",
+                "-Prepository_dir=$repositoryDir"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithSameGuavaVersionAsCordaTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithSameGuavaVersionAsCordaTest.kt
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.Constants.BUNDLE_LICENSE
@@ -17,32 +19,31 @@ import org.osgi.framework.Constants.IMPORT_PACKAGE
 import org.osgi.framework.Constants.REQUIRE_CAPABILITY
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class CordappWithSameGuavaVersionAsCordaTest {
-    companion object {
+    private companion object {
         private const val cordappVersion = "1.0.1-SNAPSHOT"
         private const val cordaGuavaVersion = "20.0"
 
         private const val guavaOsgiVersion = "version=\"[20.0,21)\""
         private const val cordaOsgiVersion = "version=\"[5.0,6)\""
         private const val cordappOsgiVersion = "version=\"1.0.1\""
+    }
 
-        private lateinit var testProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("cordapp-with-guava")
-                .withSubResource("src/main/java/com/example/contract/GuavaContract.java")
-                .build(
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcorda_guava_version=$cordaGuavaVersion",
-                    "-Pguava_version=$cordaGuavaVersion",
-                    "-Pcordapp_version=$cordappVersion"
-                )
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("cordapp-with-guava")
+            .withSubResource("src/main/java/com/example/contract/GuavaContract.java")
+            .build(
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcorda_guava_version=$cordaGuavaVersion",
+                "-Pguava_version=$cordaGuavaVersion",
+                "-Pcordapp_version=$cordappVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithSchemaTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithSchemaTest.kt
@@ -4,34 +4,35 @@ import aQute.bnd.osgi.Constants.PRIVATE_PACKAGE
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.Constants.EXPORT_PACKAGE
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class CordappWithSchemaTest {
-    companion object {
+    private companion object {
         private const val cordappVersion = "1.0.1-SNAPSHOT"
         private const val slf4jVersion = "2.0.0-alpha1"
+    }
 
-        private lateinit var testProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("cordapp-with-schema")
-                .withSubResource("src/main/kotlin/com/example/schema/SchemaContract.kt")
-                .withSubResource("src/main/resources/migration/sample.changelog-master.xml")
-                .withSubResource("src/main/resources/migration/sample-migration-v1.0.xml")
-                .build(
-                    "-Pcordapp_version=$cordappVersion",
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Pslf4j_version=$slf4jVersion"
-                )
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("cordapp-with-schema")
+            .withSubResource("src/main/kotlin/com/example/schema/SchemaContract.kt")
+            .withSubResource("src/main/resources/migration/sample.changelog-master.xml")
+            .withSubResource("src/main/resources/migration/sample-migration-v1.0.xml")
+            .build(
+                "-Pcordapp_version=$cordappVersion",
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pslf4j_version=$slf4jVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/EagerDependenciesTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/EagerDependenciesTest.kt
@@ -5,27 +5,29 @@ import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class EagerDependenciesTest {
-    companion object {
+    private companion object {
         private const val taskName = "cordappDependencyConstraints"
-        private lateinit var testProject: GradleProject
+    }
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("eager-dependencies")
-                .build(
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcommons_io_version=$commonsIoVersion",
-                    "-Pcorda_api_version=$cordaApiVersion"
-                )
-        }
+    private lateinit var testProject: GradleProject
+
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("eager-dependencies")
+            .build(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcommons_io_version=$commonsIoVersion",
+                "-Pcorda_api_version=$cordaApiVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/EagerJarsTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/EagerJarsTest.kt
@@ -3,26 +3,25 @@ package net.corda.plugins.cpk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class EagerJarsTest {
-    companion object {
-        private lateinit var testProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("eager-jars")
-                .build(
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcommons_io_version=$commonsIoVersion",
-                    "-Pcorda_api_version=$cordaApiVersion"
-                )
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("eager-jars")
+            .build(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcommons_io_version=$commonsIoVersion",
+                "-Pcorda_api_version=$cordaApiVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/EmbedTransitiveDependenciesTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/EmbedTransitiveDependenciesTest.kt
@@ -5,6 +5,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.Constants.BUNDLE_CLASSPATH
@@ -17,27 +19,26 @@ import java.nio.file.Path
 import java.util.jar.JarEntry
 import java.util.jar.JarFile
 
+@TestInstance(PER_CLASS)
 class EmbedTransitiveDependenciesTest {
-    companion object {
+    private companion object {
         private const val cordappVersion = "2.3.4-SNAPSHOT"
         private const val annotationsOsgiVersion = "version=\"$annotationsVersion\""
+    }
 
-        private lateinit var testProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("embed-transitive-deps")
-                .withSubResource("library/build.gradle")
-                .build(
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pannotations_version=$annotationsVersion",
-                    "-Pcommons_io_version=$commonsIoVersion",
-                    "-Pcordapp_version=$cordappVersion"
-                )
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("embed-transitive-deps")
+            .withSubResource("library/build.gradle")
+            .build(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pannotations_version=$annotationsVersion",
+                "-Pcommons_io_version=$commonsIoVersion",
+                "-Pcordapp_version=$cordappVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/HashSelectionTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/HashSelectionTest.kt
@@ -4,50 +4,51 @@ import java.nio.file.Files
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import net.corda.plugins.cpk.xml.HashValue
 
+@TestInstance(PER_CLASS)
 class HashSelectionTest {
-    companion object {
+    private companion object {
         const val cordappVersion = "1.2.5-SNAPSHOT"
         const val hostVersion = "1.0-SNAPSHOT"
         const val SHA3_256 = "SHA3-256"
+    }
 
-        private lateinit var cordappProject: GradleProject
-        private lateinit var testProject: GradleProject
+    private lateinit var cordappProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(
-            @TempDir testProjectDir: Path,
-            @TempDir cordappDir: Path,
-            reporter: TestReporter
-        ) {
-            val repositoryDir = Files.createDirectory(testProjectDir.resolve("maven"))
-            cordappProject = GradleProject(cordappDir, reporter)
-                .withTestName("hash-selection/cordapp")
-                .withTaskName("publishAllPublicationsToTestRepository")
-                .build(
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcorda_release_version=$cordaReleaseVersion",
-                    "-Pcommons_io_version=$commonsIoVersion",
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Pcordapp_version=$cordappVersion",
-                    "-Prepository_dir=$repositoryDir"
-                )
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("hash-selection")
-                .build(
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcommons_codec_version=$commonsCodecVersion",
-                    "-Pcordapp_version=$cordappVersion",
-                    "-Phost_version=$hostVersion",
-                    "-Prepository_dir=$repositoryDir"
-                )
-        }
+    @BeforeAll
+    fun setup(
+        @TempDir testProjectDir: Path,
+        @TempDir cordappDir: Path,
+        reporter: TestReporter
+    ) {
+        val repositoryDir = Files.createDirectory(testProjectDir.resolve("maven"))
+        cordappProject = GradleProject(cordappDir, reporter)
+            .withTestName("hash-selection/cordapp")
+            .withTaskName("publishAllPublicationsToTestRepository")
+            .build(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcorda_release_version=$cordaReleaseVersion",
+                "-Pcommons_io_version=$commonsIoVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pcordapp_version=$cordappVersion",
+                "-Prepository_dir=$repositoryDir"
+            )
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("hash-selection")
+            .build(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcommons_codec_version=$commonsCodecVersion",
+                "-Pcordapp_version=$cordappVersion",
+                "-Phost_version=$hostVersion",
+                "-Prepository_dir=$repositoryDir"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/SimpleCordappTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/SimpleCordappTest.kt
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.Constants.BUNDLE_LICENSE
@@ -17,30 +19,29 @@ import org.osgi.framework.Constants.IMPORT_PACKAGE
 import org.osgi.framework.Constants.REQUIRE_CAPABILITY
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class SimpleCordappTest {
-    companion object {
-        private lateinit var testProject: GradleProject
-
+    private companion object {
         private const val SIGNING_TAG = "Jar signing with following options:"
         private const val cordappVersion = "1.0.1-SNAPSHOT"
         private const val ioOsgiVersion = "version=\"[1.4,2)\""
         private const val cordaOsgiVersion = "version=\"[5.0,6)\""
         private const val cordappOsgiVersion = "version=\"1.0.1\""
+    }
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("simple-cordapp")
-                .withSubResource("src/main/java/com/example/contract/ExampleContract.java")
-                .build(
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcommons_io_version=$commonsIoVersion",
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Pcordapp_version=$cordappVersion"
-                )
-        }
+    private lateinit var testProject: GradleProject
+
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("simple-cordapp")
+            .withSubResource("src/main/java/com/example/contract/ExampleContract.java")
+            .build(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcommons_io_version=$commonsIoVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pcordapp_version=$cordappVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/SimpleKotlinCordappTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/SimpleKotlinCordappTest.kt
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.Constants.BUNDLE_LICENSE
@@ -17,8 +19,9 @@ import org.osgi.framework.Constants.IMPORT_PACKAGE
 import org.osgi.framework.Constants.REQUIRE_CAPABILITY
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class SimpleKotlinCordappTest {
-    companion object {
+    private companion object {
         private const val cordappVersion = "1.0.1-SNAPSHOT"
         private const val guavaVersion = "29.0-jre"
 
@@ -27,25 +30,23 @@ class SimpleKotlinCordappTest {
         private const val kotlinOsgiVersion = "version=\"[1.4,2)\""
         private const val cordaOsgiVersion = "version=\"[5.0,6)\""
         private const val cordappOsgiVersion = "version=\"1.0.1\""
+    }
 
-        private lateinit var testProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("simple-kotlin-cordapp")
-                .withSubResource("src/main/kotlin/com/example/contract/ExampleContract.kt")
-                .withSubResource("src/main/kotlin/com/example/contract/states/ExampleState.kt")
-                .build(
-                    "-Pcordapp_version=$cordappVersion",
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcommons_io_version=$commonsIoVersion",
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Pguava_version=$guavaVersion"
-                )
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("simple-kotlin-cordapp")
+            .withSubResource("src/main/kotlin/com/example/contract/ExampleContract.kt")
+            .withSubResource("src/main/kotlin/com/example/contract/states/ExampleState.kt")
+            .build(
+                "-Pcordapp_version=$cordappVersion",
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcommons_io_version=$commonsIoVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pguava_version=$guavaVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/TransitiveCordappsTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/TransitiveCordappsTest.kt
@@ -3,6 +3,8 @@ package net.corda.plugins.cpk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
@@ -21,8 +23,9 @@ import java.nio.file.Path
  * Verify that transitive cordapp and cordaProvided dependencies
  * are inherited by downstream CPK projects.
  */
+@TestInstance(PER_CLASS)
 class TransitiveCordappsTest {
-    companion object {
+    private companion object {
         private const val cordappVersion = "1.0.1-SNAPSHOT"
         private const val cpk1Version = "1.0-SNAPSHOT"
         private const val cpk2Version = "2.0-SNAPSHOT"
@@ -34,33 +37,33 @@ class TransitiveCordappsTest {
         private const val kotlinOsgiVersion = "version=\"[1.4,2)\""
         private const val cordaOsgiVersion = "version=\"[5.0,6)\""
         private const val cordappOsgiVersion = "version=\"1.0.1\""
+    }
 
-        private fun buildProject(
-            taskName: String,
-            testProjectDir: Path,
-            reporter: TestReporter
-        ): GradleProject {
-            val repositoryDir = testProjectDir.resolve("maven")
-            return GradleProject(testProjectDir, reporter)
-                .withTestName("transitive-cordapps")
-                .withSubResource("src/main/kotlin/com/example/transitives/ExampleContract.kt")
-                .withSubResource("cpk-one/build.gradle")
-                .withSubResource("cpk-two/build.gradle")
-                .withSubResource("cpk-three/build.gradle")
-                .withTaskName(taskName)
-                .build(
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcommons_io_version=$commonsIoVersion",
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Pcordapp_version=$cordappVersion",
-                    "-Pcpk1_version=$cpk1Version",
-                    "-Pcpk2_version=$cpk2Version",
-                    "-Pcpk3_version=$cpk3Version",
-                    "-Prepository_dir=$repositoryDir",
-                    "-Pcpk1_type=$cpk1Type",
-                    "-Pcpk2_type=$cpk2Type"
-                )
-        }
+    private fun buildProject(
+        taskName: String,
+        testProjectDir: Path,
+        reporter: TestReporter
+    ): GradleProject {
+        val repositoryDir = testProjectDir.resolve("maven")
+        return GradleProject(testProjectDir, reporter)
+            .withTestName("transitive-cordapps")
+            .withSubResource("src/main/kotlin/com/example/transitives/ExampleContract.kt")
+            .withSubResource("cpk-one/build.gradle")
+            .withSubResource("cpk-two/build.gradle")
+            .withSubResource("cpk-three/build.gradle")
+            .withTaskName(taskName)
+            .build(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcommons_io_version=$commonsIoVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pcordapp_version=$cordappVersion",
+                "-Pcpk1_version=$cpk1Version",
+                "-Pcpk2_version=$cpk2Version",
+                "-Pcpk3_version=$cpk3Version",
+                "-Prepository_dir=$repositoryDir",
+                "-Pcpk1_type=$cpk1Type",
+                "-Pcpk2_type=$cpk2Type"
+            )
     }
 
     @ParameterizedTest

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/VerifyCompileOnlyDependencyTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/VerifyCompileOnlyDependencyTest.kt
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.Constants.BUNDLE_LICENSE
@@ -18,27 +20,26 @@ import org.osgi.framework.Constants.IMPORT_PACKAGE
 import org.osgi.framework.Constants.REQUIRE_CAPABILITY
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class VerifyCompileOnlyDependencyTest {
-    companion object {
+    private companion object {
         private const val cordappVersion = "1.0.5.SNAPSHOT"
         private const val cordappOsgiVersion = "version=\"1.0.5\""
+    }
 
-        private lateinit var testProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("verify-compile-only")
-                .withSubResource("src/main/java/com/example/sample/Host.java")
-                .build(
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pannotations_version=$annotationsVersion",
-                    "-Pcommons_io_version=$commonsIoVersion",
-                    "-Pcordapp_version=$cordappVersion"
-                )
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("verify-compile-only")
+            .withSubResource("src/main/java/com/example/sample/Host.java")
+            .build(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pannotations_version=$annotationsVersion",
+                "-Pcommons_io_version=$commonsIoVersion",
+                "-Pcordapp_version=$cordappVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/VerifyCordaProvidedDependencyTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/VerifyCordaProvidedDependencyTest.kt
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.Constants.BUNDLE_LICENSE
@@ -18,28 +20,27 @@ import org.osgi.framework.Constants.IMPORT_PACKAGE
 import org.osgi.framework.Constants.REQUIRE_CAPABILITY
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class VerifyCordaProvidedDependencyTest {
-    companion object {
+    private companion object {
         private const val cordappVersion = "1.0.9.SNAPSHOT"
         private const val cordappOsgiVersion = "version=\"1.0.9\""
         private const val annotationsOsgiVersion = "version=\"[1.0,2)\""
+    }
 
-        private lateinit var testProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("verify-corda-provided")
-                .withSubResource("src/main/java/com/example/provided/Host.java")
-                .build(
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pannotations_version=$annotationsVersion",
-                    "-Pcommons_io_version=$commonsIoVersion",
-                    "-Pcordapp_version=$cordappVersion"
-                )
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("verify-corda-provided")
+            .withSubResource("src/main/java/com/example/provided/Host.java")
+            .build(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pannotations_version=$annotationsVersion",
+                "-Pcommons_io_version=$commonsIoVersion",
+                "-Pcordapp_version=$cordappVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/VerifyCordappDependencyTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/VerifyCordappDependencyTest.kt
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.Constants.BUNDLE_LICENSE
@@ -18,8 +20,9 @@ import org.osgi.framework.Constants.IMPORT_PACKAGE
 import org.osgi.framework.Constants.REQUIRE_CAPABILITY
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class VerifyCordappDependencyTest {
-    companion object {
+    private companion object {
         private const val cordappVersion = "1.1.1-SNAPSHOT"
         private const val hostVersion = "2.0.0-SNAPSHOT"
 
@@ -27,27 +30,25 @@ class VerifyCordappDependencyTest {
         private const val cordaOsgiVersion = "version=\"[5.0,6)\""
         private const val cordappOsgiVersion = "version=\"[1.1,2)\""
         private const val hostOsgiVersion = "version=\"2.0.0\""
+    }
 
-        private lateinit var testProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("verify-cordapp-dependency")
-                .withSubResource("src/main/kotlin/com/example/host/HostCordapp.kt")
-                .withSubResource("cordapp/build.gradle")
-                .withSubResource("cordapp/src/main/kotlin/com/example/cordapp/ExampleCordapp.kt")
-                .build(
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcommons_collections_version=$commonsCollectionsVersion",
-                    "-Pcommons_io_version=$commonsIoVersion",
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Pcordapp_version=$cordappVersion",
-                    "-Phost_version=$hostVersion"
-                )
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("verify-cordapp-dependency")
+            .withSubResource("src/main/kotlin/com/example/host/HostCordapp.kt")
+            .withSubResource("cordapp/build.gradle")
+            .withSubResource("cordapp/src/main/kotlin/com/example/cordapp/ExampleCordapp.kt")
+            .build(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcommons_collections_version=$commonsCollectionsVersion",
+                "-Pcommons_io_version=$commonsIoVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pcordapp_version=$cordappVersion",
+                "-Phost_version=$hostVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/VerifyNotProvidedDependencyTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/VerifyNotProvidedDependencyTest.kt
@@ -4,30 +4,31 @@ import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome.FAILED
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class VerifyNotProvidedDependencyTest {
-    companion object {
+    private companion object {
         private const val cordappVersion = "1.0.9.SNAPSHOT"
+    }
 
-        private lateinit var testProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("verify-not-provided")
-                .withSubResource("src/main/java/com/example/unprovided/Host.java")
-                .buildAndFail(
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pannotations_version=$annotationsVersion",
-                    "-Pcommons_io_version=$commonsIoVersion",
-                    "-Pcordapp_version=$cordappVersion"
-                )
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("verify-not-provided")
+            .withSubResource("src/main/java/com/example/unprovided/Host.java")
+            .buildAndFail(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pannotations_version=$annotationsVersion",
+                "-Pcommons_io_version=$commonsIoVersion",
+                "-Pcordapp_version=$cordappVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithCordaDependencyTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithCordaDependencyTest.kt
@@ -3,26 +3,25 @@ package net.corda.plugins.cpk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class WithCordaDependencyTest {
-    companion object {
-        private lateinit var testProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("with-corda-dependency")
-                .withSubResource("library/build.gradle")
-                .buildAndFail(
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcorda_release_version=$cordaReleaseVersion"
-                )
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("with-corda-dependency")
+            .withSubResource("library/build.gradle")
+            .buildAndFail(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcorda_release_version=$cordaReleaseVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithCordaMetadataTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithCordaMetadataTest.kt
@@ -3,6 +3,8 @@ package net.corda.plugins.cpk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.Constants.BUNDLE_LICENSE
@@ -13,8 +15,9 @@ import org.osgi.framework.Constants.DYNAMICIMPORT_PACKAGE
 import org.osgi.framework.Constants.IMPORT_PACKAGE
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class WithCordaMetadataTest {
-    companion object {
+    private companion object {
         private const val CONTRACT_CORDAPP_NAME = "com.example.contracts"
         private const val CONTRACT_CORDAPP_VERSION = "1.1.1-SNAPSHOT"
         private const val WORKFLOW_CORDAPP_NAME = "com.example.workflows"
@@ -26,35 +29,33 @@ class WithCordaMetadataTest {
         private const val JAVAX_PERSISTENCE_PACKAGE = "javax.persistence"
         private const val TEST_LICENCE = "Test-Licence"
         private const val TEST_VENDOR = "R3"
+    }
 
-        private lateinit var testProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("with-corda-metadata")
-                .withSubResource("contracts/build.gradle")
-                .withSubResource("contracts/src/main/kotlin/com/example/metadata/contracts/ExampleContract.kt")
-                .withSubResource("contracts/src/main/kotlin/com/example/metadata/schemas/ExampleSchema.kt")
-                .withSubResource("workflows/build.gradle")
-                .withSubResource("workflows/src/main/kotlin/com/example/metadata/workflows/ExampleFlow.kt")
-                .withSubResource("services/build.gradle")
-                .withSubResource("services/src/main/kotlin/com/example/metadata/services/ExampleService.kt")
-                .build(
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Pcontract_name=With Contract Metadata",
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcontract_cordapp_version=$CONTRACT_CORDAPP_VERSION",
-                    "-Pworkflow_name=With Workflow Metadata",
-                    "-Pcordapp_workflow_version=$expectedCordappWorkflowVersion",
-                    "-Pworkflow_cordapp_version=$WORKFLOW_CORDAPP_VERSION",
-                    "-Pservice_name=With Service Metadata",
-                    "-Pcordapp_service_version=$expectedCordappServiceVersion",
-                    "-Pservice_cordapp_version=$SERVICE_CORDAPP_VERSION"
-                )
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("with-corda-metadata")
+            .withSubResource("contracts/build.gradle")
+            .withSubResource("contracts/src/main/kotlin/com/example/metadata/contracts/ExampleContract.kt")
+            .withSubResource("contracts/src/main/kotlin/com/example/metadata/schemas/ExampleSchema.kt")
+            .withSubResource("workflows/build.gradle")
+            .withSubResource("workflows/src/main/kotlin/com/example/metadata/workflows/ExampleFlow.kt")
+            .withSubResource("services/build.gradle")
+            .withSubResource("services/src/main/kotlin/com/example/metadata/services/ExampleService.kt")
+            .build(
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pcontract_name=With Contract Metadata",
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcontract_cordapp_version=$CONTRACT_CORDAPP_VERSION",
+                "-Pworkflow_name=With Workflow Metadata",
+                "-Pcordapp_workflow_version=$expectedCordappWorkflowVersion",
+                "-Pworkflow_cordapp_version=$WORKFLOW_CORDAPP_VERSION",
+                "-Pservice_name=With Service Metadata",
+                "-Pcordapp_service_version=$expectedCordappServiceVersion",
+                "-Pservice_cordapp_version=$SERVICE_CORDAPP_VERSION"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithDeepEmbeddedCordaTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithDeepEmbeddedCordaTest.kt
@@ -3,26 +3,25 @@ package net.corda.plugins.cpk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class WithDeepEmbeddedCordaTest {
-    companion object {
-        private lateinit var testProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("with-deep-embedded-corda")
-                .withSubResource("library/build.gradle")
-                .buildAndFail(
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcorda_release_version=$cordaReleaseVersion"
-                )
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("with-deep-embedded-corda")
+            .withSubResource("library/build.gradle")
+            .buildAndFail(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcorda_release_version=$cordaReleaseVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithDependentCordappTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithDependentCordappTest.kt
@@ -4,37 +4,40 @@ import net.corda.plugins.cpk.xml.loadDependencyConstraints
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class WithDependentCordappTest {
-    companion object {
+    private companion object {
         private const val CORDA_GUAVA_VERSION = "20.0"
         private const val librarySlf4jVersion = "1.7.21"
+    }
 
-        private fun buildProject(
-            guavaVersion: String,
-            libraryGuavaVersion: String,
-            testProjectDir: Path,
-            reporter: TestReporter
-        ): GradleProject {
-            return GradleProject(testProjectDir, reporter)
-                .withTestName("with-dependent-cordapp")
-                .withSubResource("library/build.gradle")
-                .withSubResource("cordapp/build.gradle")
-                .build(
-                    "-Pcordapp_workflow_version=$expectedCordappWorkflowVersion",
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcommons_io_version=$commonsIoVersion",
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Plibrary_guava_version=$libraryGuavaVersion",
-                    "-Pguava_version=$guavaVersion",
-                    "-Pslf4j_version=$librarySlf4jVersion"
-                )
-        }
+    private fun buildProject(
+        guavaVersion: String,
+        libraryGuavaVersion: String,
+        testProjectDir: Path,
+        reporter: TestReporter
+    ): GradleProject {
+        return GradleProject(testProjectDir, reporter)
+            .withTestName("with-dependent-cordapp")
+            .withSubResource("library/build.gradle")
+            .withSubResource("cordapp/build.gradle")
+            .build(
+                "-Pcordapp_workflow_version=$expectedCordappWorkflowVersion",
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcommons_io_version=$commonsIoVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Plibrary_guava_version=$libraryGuavaVersion",
+                "-Pguava_version=$guavaVersion",
+                "-Pslf4j_version=$librarySlf4jVersion"
+            )
     }
 
     @ParameterizedTest

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithEmbeddedCordaTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithEmbeddedCordaTest.kt
@@ -3,25 +3,24 @@ package net.corda.plugins.cpk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class WithEmbeddedCordaTest {
-    companion object {
-        private lateinit var testProject: GradleProject
+    private lateinit var testProject: GradleProject
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("with-embedded-corda")
-                .buildAndFail(
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcorda_release_version=$cordaReleaseVersion"
-                )
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("with-embedded-corda")
+            .buildAndFail(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcorda_release_version=$cordaReleaseVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithEmbeddedJarTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithEmbeddedJarTest.kt
@@ -5,6 +5,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.Constants.BUNDLE_CLASSPATH
@@ -20,29 +22,29 @@ import java.nio.file.Path
 import java.util.jar.JarEntry
 import java.util.jar.JarFile
 
+@TestInstance(PER_CLASS)
 class WithEmbeddedJarTest {
-    companion object {
+    private companion object {
         private const val RESOLUTION_OPTIONAL = "resolution:=optional"
         private const val SUPPRESS_VERSION = "version=[0,0)"
         private const val cordappVersion = "1.0.2-SNAPSHOT"
         private const val guavaVersion = "29.0-jre"
-        private lateinit var testProject: GradleProject
+    }
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("with-embedded-jar")
-                .withSubResource("library/build.gradle")
-                .withSubResource("library/src/main/java/com/example/library/ExampleApi.java")
-                .build(
-                    "-Pcordapp_version=$cordappVersion",
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pguava_version=$guavaVersion"
-                )
-        }
+    private lateinit var testProject: GradleProject
+
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("with-embedded-jar")
+            .withSubResource("library/build.gradle")
+            .withSubResource("library/src/main/java/com/example/library/ExampleApi.java")
+            .build(
+                "-Pcordapp_version=$cordappVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pguava_version=$guavaVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithProvidedLibraryTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithProvidedLibraryTest.kt
@@ -3,6 +3,8 @@ package net.corda.plugins.cpk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -13,24 +15,24 @@ import org.osgi.framework.Constants.BUNDLE_VENDOR
 import org.osgi.framework.Constants.BUNDLE_VERSION
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class WithProvidedLibraryTest {
-    companion object {
+    private companion object {
         private const val cordappVersion = "1.0.2-SNAPSHOT"
-        private lateinit var testProject: GradleProject
+    }
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withTestName("with-provided-library")
-                .withSubResource("library/build.gradle")
-                .build(
-                    "-Pcordapp_version=$cordappVersion",
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion"
-                )
-        }
+    private lateinit var testProject: GradleProject
+
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("with-provided-library")
+            .withSubResource("library/build.gradle")
+            .build(
+                "-Pcordapp_version=$cordappVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pcordapp_contract_version=$expectedCordappContractVersion"
+            )
     }
 
     @Test

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithoutTransitiveCordappsTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithoutTransitiveCordappsTest.kt
@@ -2,6 +2,8 @@ package net.corda.plugins.cpk
 
 import java.io.StringReader
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
@@ -12,35 +14,36 @@ import java.nio.file.Path
  * Verify that non-transitive cordapp and cordaProvided
  * dependencies are NOT inherited by downstream CPK projects.
  */
+@TestInstance(PER_CLASS)
 class WithoutTransitiveCordappsTest {
-    companion object {
+    private companion object {
         private const val cordappVersion = "1.0.1-SNAPSHOT"
         private const val cpk1Version = "1.0-SNAPSHOT"
         private const val cpk2Version = "2.0-SNAPSHOT"
         private const val providedPrefix = "ALL-PROVIDED: "
+    }
 
-        private fun buildProject(
-            taskName: String,
-            testProjectDir: Path,
-            reporter: TestReporter
-        ): GradleProject {
-            val repositoryDir = testProjectDir.resolve("maven")
-            return GradleProject(testProjectDir, reporter)
-                .withTestName("without-transitive-cordapps")
-                .withSubResource("cpk-one/build.gradle")
-                .withSubResource("cpk-two/build.gradle")
-                .withTaskName(taskName)
-                .build(
-                    "-Pcordapp_contract_version=$expectedCordappContractVersion",
-                    "-Pcommons_codec_version=$commonsCodecVersion",
-                    "-Pcommons_io_version=$commonsIoVersion",
-                    "-Pcorda_api_version=$cordaApiVersion",
-                    "-Pcordapp_version=$cordappVersion",
-                    "-Pcpk1_version=$cpk1Version",
-                    "-Pcpk2_version=$cpk2Version",
-                    "-Prepository_dir=$repositoryDir"
-                )
-        }
+    private fun buildProject(
+        taskName: String,
+        testProjectDir: Path,
+        reporter: TestReporter
+    ): GradleProject {
+        val repositoryDir = testProjectDir.resolve("maven")
+        return GradleProject(testProjectDir, reporter)
+            .withTestName("without-transitive-cordapps")
+            .withSubResource("cpk-one/build.gradle")
+            .withSubResource("cpk-two/build.gradle")
+            .withTaskName(taskName)
+            .build(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcommons_codec_version=$commonsCodecVersion",
+                "-Pcommons_io_version=$commonsIoVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pcordapp_version=$cordappVersion",
+                "-Pcpk1_version=$cpk1Version",
+                "-Pcpk2_version=$cpk2Version",
+                "-Prepository_dir=$repositoryDir"
+            )
     }
 
     @ParameterizedTest

--- a/cordapp/src/test/kotlin/net/corda/plugins/CordappGradleConfigurationsTest.kt
+++ b/cordapp/src/test/kotlin/net/corda/plugins/CordappGradleConfigurationsTest.kt
@@ -4,6 +4,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
@@ -11,55 +13,52 @@ import java.util.stream.Collectors.toList
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 
+@TestInstance(PER_CLASS)
 class CordappGradleConfigurationsTest {
-    companion object {
-        private lateinit var testProject: GradleProject
-        private lateinit var poms: List<ZipEntry>
+    private lateinit var testProject: GradleProject
+    private lateinit var poms: List<ZipEntry>
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withBuildScript("""
-                    |plugins {
-                    |    id 'net.corda.plugins.cordapp'
-                    |}
-                    |
-                    |apply from: 'repositories.gradle'
-                    |
-                    |version = '1.0-SNAPSHOT'
-                    |group = 'com.example'
-                    |
-                    |dependencies {
-                    |    compile "org.slf4j:slf4j-api:1.7.26"
-                    |    runtime "commons-io:commons-io:2.6"
-                    |    cordaCompile "com.google.guava:guava:20.0"
-                    |    cordaRuntime "javax.servlet:javax.servlet-api:3.1.0"
-                    |    implementation "javax.persistence:javax.persistence-api:2.2"
-                    |    runtimeOnly "javax.validation:validation-api:1.1.0.Final"
-                    |}
-                    |
-                    |jar {
-                    |    archiveName = 'configurations.jar'
-                    |}
-                    |
-                    |cordapp {
-                    |    info {
-                    |        name = 'Testing'
-                    |        targetPlatformVersion = 5
-                    |    }
-                    |}
-                """.trimMargin())
-                .build()
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withBuildScript("""
+                |plugins {
+                |    id 'net.corda.plugins.cordapp'
+                |}
+                |
+                |apply from: 'repositories.gradle'
+                |
+                |version = '1.0-SNAPSHOT'
+                |group = 'com.example'
+                |
+                |dependencies {
+                |    compile "org.slf4j:slf4j-api:1.7.26"
+                |    runtime "commons-io:commons-io:2.6"
+                |    cordaCompile "com.google.guava:guava:20.0"
+                |    cordaRuntime "javax.servlet:javax.servlet-api:3.1.0"
+                |    implementation "javax.persistence:javax.persistence-api:2.2"
+                |    runtimeOnly "javax.validation:validation-api:1.1.0.Final"
+                |}
+                |
+                |jar {
+                |    archiveName = 'configurations.jar'
+                |}
+                |
+                |cordapp {
+                |    info {
+                |        name = 'Testing'
+                |        targetPlatformVersion = 5
+                |    }
+                |}
+            """.trimMargin())
+            .build()
 
-            val cordapp = testProject.pathOf("build", "libs", "configurations.jar")
-            assertThat(cordapp).isRegularFile()
+        val cordapp = testProject.pathOf("build", "libs", "configurations.jar")
+        assertThat(cordapp).isRegularFile()
 
-            poms = ZipFile(cordapp.toFile()).use { zip ->
-                zip.stream().filter { entry -> entry.name.endsWith("/pom.xml") }
-                   .collect(toList())
-            }
+        poms = ZipFile(cordapp.toFile()).use { zip ->
+            zip.stream().filter { entry -> entry.name.endsWith("/pom.xml") }
+               .collect(toList())
         }
     }
 

--- a/cordapp/src/test/kotlin/net/corda/plugins/CordappLibraryGradleConfigurationsTest.kt
+++ b/cordapp/src/test/kotlin/net/corda/plugins/CordappLibraryGradleConfigurationsTest.kt
@@ -4,6 +4,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
@@ -11,57 +13,56 @@ import java.util.stream.Collectors.toList
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 
+@TestInstance(PER_CLASS)
 class CordappLibraryGradleConfigurationsTest {
-    companion object {
+    private companion object {
         private lateinit var testProject: GradleProject
         private lateinit var poms: List<ZipEntry>
+    }
 
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
-            testProject = GradleProject(testProjectDir, reporter)
-                .withBuildScript("""
-                    |plugins {
-                    |    id 'java-library'
-                    |    id 'net.corda.plugins.cordapp'
-                    |}
-                    |
-                    |apply from: 'repositories.gradle'
-                    |
-                    |version = '1.0-SNAPSHOT'
-                    |group = 'com.example'
-                    |
-                    |dependencies {
-                    |    compile "org.slf4j:slf4j-api:1.7.26"
-                    |    runtime "commons-io:commons-io:2.6"
-                    |    cordaCompile "com.google.guava:guava:20.0"
-                    |    cordaRuntime "javax.servlet:javax.servlet-api:3.1.0"
-                    |    api "javax.annotation:javax.annotation-api:1.3.2"
-                    |    implementation "javax.persistence:javax.persistence-api:2.2"
-                    |    runtimeOnly "javax.validation:validation-api:1.1.0.Final"
-                    |}
-                    |
-                    |jar {
-                    |    archiveName = 'configurations.jar'
-                    |}
-                    |
-                    |cordapp {
-                    |    info {
-                    |        name = 'Testing'
-                    |        targetPlatformVersion = 5
-                    |    }
-                    |}
-                """.trimMargin())
-                .build()
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withBuildScript("""
+                |plugins {
+                |    id 'java-library'
+                |    id 'net.corda.plugins.cordapp'
+                |}
+                |
+                |apply from: 'repositories.gradle'
+                |
+                |version = '1.0-SNAPSHOT'
+                |group = 'com.example'
+                |
+                |dependencies {
+                |    compile "org.slf4j:slf4j-api:1.7.26"
+                |    runtime "commons-io:commons-io:2.6"
+                |    cordaCompile "com.google.guava:guava:20.0"
+                |    cordaRuntime "javax.servlet:javax.servlet-api:3.1.0"
+                |    api "javax.annotation:javax.annotation-api:1.3.2"
+                |    implementation "javax.persistence:javax.persistence-api:2.2"
+                |    runtimeOnly "javax.validation:validation-api:1.1.0.Final"
+                |}
+                |
+                |jar {
+                |    archiveName = 'configurations.jar'
+                |}
+                |
+                |cordapp {
+                |    info {
+                |        name = 'Testing'
+                |        targetPlatformVersion = 5
+                |    }
+                |}
+            """.trimMargin())
+            .build()
 
-            val cordapp = testProject.pathOf("build", "libs", "configurations.jar")
-            assertThat(cordapp).isRegularFile()
+        val cordapp = testProject.pathOf("build", "libs", "configurations.jar")
+        assertThat(cordapp).isRegularFile()
 
-            poms = ZipFile(cordapp.toFile()).use { zip ->
-                zip.stream().filter { entry -> entry.name.endsWith("/pom.xml") }
-                   .collect(toList())
-            }
+        poms = ZipFile(cordapp.toFile()).use { zip ->
+            zip.stream().filter { entry -> entry.name.endsWith("/pom.xml") }
+               .collect(toList())
         }
     }
 

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/AbstractFunctionTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/AbstractFunctionTest.kt
@@ -7,23 +7,25 @@ import org.hamcrest.core.IsNot.not
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.lang.reflect.Modifier.ABSTRACT
 import java.nio.file.Path
 import kotlin.reflect.full.declaredFunctions
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class AbstractFunctionTest {
-    companion object {
+    private companion object {
         private const val FUNCTION_CLASS = "net.corda.gradle.AbstractFunctions"
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "abstract-function").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "abstract-function").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteAmbiguousPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteAmbiguousPropertyTest.kt
@@ -11,13 +11,16 @@ import org.hamcrest.core.IsNot.not
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.reflect.full.declaredMemberExtensionProperties
 
 @RequiresKotlin14
+@TestInstance(PER_CLASS)
 class DeleteAmbiguousPropertyTest {
-    companion object {
+    private companion object {
         private const val PROPERTY_CLASS = "net.corda.gradle.DeleteAmbiguousValProperty"
 
         private val nameIntToInt = isMethod("nameIntToInt", String::class.java, Map::class.java)
@@ -29,14 +32,13 @@ class DeleteAmbiguousPropertyTest {
         private val mapIntToByteName = isExtensionProperty("name", String::class, typeOfMap(Int::class, Byte::class))
         private val collectionStringName = isExtensionProperty("name", String::class, typeOfCollection(String::class))
         private val collectionLongName = isExtensionProperty("name", String::class, typeOfCollection(Long::class))
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-ambiguous-property").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-ambiguous-property").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteAndStubTests.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteAndStubTests.kt
@@ -18,14 +18,17 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.reflect.full.declaredMemberFunctions
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class DeleteAndStubTests {
-    companion object {
+    private companion object {
         private const val VAR_PROPERTY_CLASS = "net.corda.gradle.HasVarPropertyForDeleteAndStub"
         private const val VAL_PROPERTY_CLASS = "net.corda.gradle.HasValPropertyForDeleteAndStub"
         private const val DELETED_FUN_CLASS = "net.corda.gradle.DeletedFunctionInsideStubbed"
@@ -46,13 +49,13 @@ class DeleteAndStubTests {
         private val getUnwantedVal = isMethod("getUnwantedVal", String::class.java)
         private val getUnwantedVar = isMethod("getUnwantedVar", String::class.java)
         private val setUnwantedVar = isMethod("setUnwantedVar", Void.TYPE, String::class.java)
-        private lateinit var testProject: JarFilterProject
+    }
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-and-stub").build()
-        }
+    private lateinit var testProject: JarFilterProject
+
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-and-stub").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteClassReferencesTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteClassReferencesTest.kt
@@ -8,14 +8,17 @@ import org.hamcrest.core.IsIterableContaining.hasItem
 import org.hamcrest.core.IsNot.not
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.reflect.full.declaredFunctions
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class DeleteClassReferencesTest {
-    companion object {
+    private companion object {
         private const val USES_UNWANTED_CLASS = "net.corda.gradle.UsesUnwantedData"
         private const val UNWANTED_CLASS = "net.corda.gradle.UnwantedData"
 
@@ -29,14 +32,13 @@ class DeleteClassReferencesTest {
         private val jvmUnwantedVal = isProperty(equalTo("jvmUnwantedVal"), equalTo(UNWANTED_CLASS))
         private val jvmCompanionVar = isField(equalTo("jvmCompanionVar"), equalTo(UNWANTED_CLASS))
         private val jvmCompanionVal = isField(equalTo("jvmCompanionVal"), equalTo(UNWANTED_CLASS))
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-class-references").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-class-references").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteConstructorTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteConstructorTest.kt
@@ -16,28 +16,30 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.jvm.kotlin
 import kotlin.reflect.full.primaryConstructor
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class DeleteConstructorTest {
-    companion object {
+    private companion object {
         private const val STRING_PRIMARY_CONSTRUCTOR_CLASS = "net.corda.gradle.PrimaryStringConstructorToDelete"
         private const val LONG_PRIMARY_CONSTRUCTOR_CLASS = "net.corda.gradle.PrimaryLongConstructorToDelete"
         private const val INT_PRIMARY_CONSTRUCTOR_CLASS = "net.corda.gradle.PrimaryIntConstructorToDelete"
         private const val SECONDARY_CONSTRUCTOR_CLASS = "net.corda.gradle.HasConstructorToDelete"
         private const val DEFAULT_VALUE_PRIMARY_CLASS = "net.corda.gradle.PrimaryConstructorWithDefaultToDelete"
         private const val DEFAULT_VALUE_SECONDARY_CLASS = "net.corda.gradle.SecondaryConstructorWithDefaultToDelete"
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-constructor").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-constructor").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteExtensionValPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteExtensionValPropertyTest.kt
@@ -11,25 +11,28 @@ import org.hamcrest.core.IsIterableContaining.hasItem
 import org.hamcrest.core.IsNot.not
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.reflect.full.declaredMemberExtensionProperties
 import kotlin.reflect.full.declaredMemberProperties
 
+@TestInstance(PER_CLASS)
 class DeleteExtensionValPropertyTest {
-    companion object {
+    private companion object {
         private const val PROPERTY_CLASS = "net.corda.gradle.HasValExtension"
 
         private val unwantedVal = isProperty("unwantedVal", String::class)
         private val listUnwantedVal = isExtensionProperty("unwantedVal", String::class, typeOfList(String::class))
         private val getUnwantedVal = isMethod("getUnwantedVal", String::class.java, List::class.java)
-        private lateinit var testProject: JarFilterProject
+    }
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-extension-val").build()
-        }
+    private lateinit var testProject: JarFilterProject
+
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-extension-val").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteFieldTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteFieldTest.kt
@@ -8,24 +8,26 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class DeleteFieldTest {
-    companion object {
+    private companion object {
         private const val STRING_FIELD_CLASS = "net.corda.gradle.HasStringFieldToDelete"
         private const val INTEGER_FIELD_CLASS = "net.corda.gradle.HasIntFieldToDelete"
         private const val LONG_FIELD_CLASS = "net.corda.gradle.HasLongFieldToDelete"
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-field").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-field").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteFunctionTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteFunctionTest.kt
@@ -11,27 +11,30 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.jvm.kotlin
 import kotlin.reflect.full.declaredFunctions
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class DeleteFunctionTest {
-    companion object {
+    private companion object {
         private const val FUNCTION_CLASS = "net.corda.gradle.HasFunctionToDelete"
         private const val INDIRECT_CLASS = "net.corda.gradle.HasIndirectFunctionToDelete"
         private const val DEFAULT_VALUE_CLASS = "net.corda.gradle.HasFunctionWithDefaultParameter"
 
         private val unwantedFun = isFunction("unwantedFun", String::class, String::class)
         private val javaUnwantedFun = isMethod("unwantedFun", String::class.java, String::class.java)
-        private lateinit var testProject: JarFilterProject
+    }
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-function").build()
-        }
+    private lateinit var testProject: JarFilterProject
+
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-function").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteInnerLambdaTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteInnerLambdaTest.kt
@@ -9,29 +9,31 @@ import org.hamcrest.core.IsNot.not
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class DeleteInnerLambdaTest {
-    companion object {
+    private companion object {
         private const val LAMBDA_CLASS = "net.corda.gradle.HasInnerLambda"
         private const val SIZE = 64
 
         private val constructInt = isKonstructor(LAMBDA_CLASS, Int::class)
         private val constructBytes = isKonstructor(LAMBDA_CLASS, ByteArray::class)
+    }
 
-        private lateinit var testProject: JarFilterProject
-        private lateinit var sourceClasses: List<String>
-        private lateinit var filteredClasses: List<String>
+    private lateinit var testProject: JarFilterProject
+    private lateinit var sourceClasses: List<String>
+    private lateinit var filteredClasses: List<String>
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-inner-lambda").build()
-            sourceClasses = testProject.sourceJar.getClassNames(LAMBDA_CLASS)
-            filteredClasses = testProject.filteredJar.getClassNames(LAMBDA_CLASS)
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-inner-lambda").build()
+        sourceClasses = testProject.sourceJar.getClassNames(LAMBDA_CLASS)
+        filteredClasses = testProject.filteredJar.getClassNames(LAMBDA_CLASS)
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteJavaPermittedSubclassTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteJavaPermittedSubclassTest.kt
@@ -2,6 +2,8 @@ package net.corda.gradle.jarfilter
 
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE.JAVA_17
 import org.junit.jupiter.api.io.TempDir
@@ -9,19 +11,19 @@ import java.nio.file.Path
 import kotlin.test.assertFailsWith
 
 @EnabledForJreRange(min = JAVA_17)
+@TestInstance(PER_CLASS)
 class DeleteJavaPermittedSubclassTest {
-    companion object {
+    private companion object {
         private const val SEALED_CLASS = "net.corda.gradle.WantedSealedClass"
         private const val WANTED_SUBCLASS = "net.corda.gradle.WantedSubclass"
         private const val UNWANTED_SUBCLASS = "net.corda.gradle.UnwantedSubclass"
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-java-permitted-subclass").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-java-permitted-subclass").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteJavaRecordComponentFieldTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteJavaRecordComponentFieldTest.kt
@@ -3,6 +3,8 @@ package net.corda.gradle.jarfilter
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE.JAVA_17
 import org.junit.jupiter.api.io.TempDir
@@ -10,17 +12,17 @@ import java.nio.file.Path
 import kotlin.test.assertFailsWith
 
 @EnabledForJreRange(min = JAVA_17)
+@TestInstance(PER_CLASS)
 class DeleteJavaRecordComponentFieldTest {
-    companion object {
+    private companion object {
         private const val RECORD_CLASS = "net.corda.gradle.RecordWithUnwantedComponentField"
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-java-record-component-field").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-java-record-component-field").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteJavaRecordComponentMethodTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteJavaRecordComponentMethodTest.kt
@@ -7,6 +7,8 @@ import org.hamcrest.core.IsNot.not
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE.JAVA_17
 import org.junit.jupiter.api.io.TempDir
@@ -14,19 +16,19 @@ import java.nio.file.Path
 import kotlin.test.assertFailsWith
 
 @EnabledForJreRange(min = JAVA_17)
+@TestInstance(PER_CLASS)
 class DeleteJavaRecordComponentMethodTest {
-    companion object {
+    private companion object {
         private const val RECORD_CLASS = "net.corda.gradle.RecordWithUnwantedComponentMethod"
 
         private val number = isMethod("number", Int::class.javaPrimitiveType!!)
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-java-record-component-method").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-java-record-component-method").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteJavaRecordComponentTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteJavaRecordComponentTest.kt
@@ -3,6 +3,8 @@ package net.corda.gradle.jarfilter
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE.JAVA_17
 import org.junit.jupiter.api.io.TempDir
@@ -10,17 +12,17 @@ import java.nio.file.Path
 import kotlin.test.assertFailsWith
 
 @EnabledForJreRange(min = JAVA_17)
+@TestInstance(PER_CLASS)
 class DeleteJavaRecordComponentTest {
-    companion object {
+    private companion object {
         private const val RECORD_CLASS = "net.corda.gradle.RecordWithUnwantedComponent"
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-java-record-component").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-java-record-component").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteJavaRecordConstructorTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteJavaRecordConstructorTest.kt
@@ -7,6 +7,8 @@ import org.hamcrest.core.IsNot.not
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE.JAVA_17
 import org.junit.jupiter.api.io.TempDir
@@ -14,19 +16,19 @@ import java.nio.file.Path
 import kotlin.test.assertFailsWith
 
 @EnabledForJreRange(min = JAVA_17)
+@TestInstance(PER_CLASS)
 class DeleteJavaRecordConstructorTest {
-    companion object {
+    private companion object {
         private const val RECORD_CLASS = "net.corda.gradle.RecordWithConstructor"
 
         private val noArgs = isConstructor(RECORD_CLASS)
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-java-record-constructor").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-java-record-constructor").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteJavaRecordFunctionTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteJavaRecordFunctionTest.kt
@@ -7,25 +7,27 @@ import org.hamcrest.core.IsIterableContaining.hasItem
 import org.hamcrest.core.IsNot.not
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE.JAVA_17
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
 @EnabledForJreRange(min = JAVA_17)
+@TestInstance(PER_CLASS)
 class DeleteJavaRecordFunctionTest {
-    companion object {
+    private companion object {
         private const val RECORD_CLASS = "net.corda.gradle.RecordWithFunction"
 
         private val getMessage = isMethod("getMessage", String::class.java)
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-java-record-function").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-java-record-function").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteJavaRecordTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteJavaRecordTest.kt
@@ -2,6 +2,8 @@ package net.corda.gradle.jarfilter
 
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE.JAVA_17
 import org.junit.jupiter.api.io.TempDir
@@ -9,17 +11,17 @@ import java.nio.file.Path
 import kotlin.test.assertFailsWith
 
 @EnabledForJreRange(min = JAVA_17)
+@TestInstance(PER_CLASS)
 class DeleteJavaRecordTest {
-    companion object {
+    private companion object {
         private const val UNWANTED_CLASS = "net.corda.gradle.UnwantedRecord"
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-java-record").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-java-record").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteJavaSealedClassTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteJavaSealedClassTest.kt
@@ -2,6 +2,8 @@ package net.corda.gradle.jarfilter
 
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE.JAVA_17
 import org.junit.jupiter.api.io.TempDir
@@ -9,18 +11,18 @@ import java.nio.file.Path
 import kotlin.test.assertFailsWith
 
 @EnabledForJreRange(min = JAVA_17)
+@TestInstance(PER_CLASS)
 class DeleteJavaSealedClassTest {
-    companion object {
+    private companion object {
         private const val SEALED_CLASS = "net.corda.gradle.DeletableSealedClass"
         private const val SUBCLASS = "net.corda.gradle.SealedSubclass"
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-java-sealed-class").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-java-sealed-class").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteLazyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteLazyTest.kt
@@ -11,28 +11,31 @@ import org.hamcrest.core.IsNot.not
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class DeleteLazyTest {
-    companion object {
+    private companion object {
         private const val LAZY_VAL_CLASS = "net.corda.gradle.HasLazyVal"
 
         private val unwantedVal = isProperty("unwantedVal", String::class)
         private val getUnwantedVal = isMethod("getUnwantedVal", String::class.java)
-        private lateinit var testProject: JarFilterProject
-        private lateinit var sourceClasses: List<String>
-        private lateinit var filteredClasses: List<String>
+    }
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-lazy").build()
-            sourceClasses = testProject.sourceJar.getClassNames(LAZY_VAL_CLASS)
-            filteredClasses = testProject.filteredJar.getClassNames(LAZY_VAL_CLASS)
-        }
+    private lateinit var testProject: JarFilterProject
+    private lateinit var sourceClasses: List<String>
+    private lateinit var filteredClasses: List<String>
+
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-lazy").build()
+        sourceClasses = testProject.sourceJar.getClassNames(LAZY_VAL_CLASS)
+        filteredClasses = testProject.filteredJar.getClassNames(LAZY_VAL_CLASS)
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteMultiFileTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteMultiFileTest.kt
@@ -3,24 +3,26 @@ package net.corda.gradle.jarfilter
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class DeleteMultiFileTest {
-    companion object {
+    private companion object {
         private const val MULTIFILE_CLASS = "net.corda.gradle.HasMultiData"
         private const val STRING_METHOD = "stringToDelete"
         private const val LONG_METHOD = "longToDelete"
         private const val INT_METHOD = "intToDelete"
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-multifile").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-multifile").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteNestedClassTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteNestedClassTest.kt
@@ -9,12 +9,15 @@ import org.hamcrest.core.IsNot.not
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class DeleteNestedClassTest {
-    companion object {
+    private companion object {
         private const val HOST_CLASS = "net.corda.gradle.HasNestedClasses"
         private const val KEPT_CLASS = "$HOST_CLASS\$OneToKeep"
         private const val DELETED_CLASS = "$HOST_CLASS\$OneToThrowAway"
@@ -34,14 +37,13 @@ class DeleteNestedClassTest {
         private val deletedClass = isKClass(DELETED_CLASS)
         private val wantedSubclass = isKClass(WANTED_SUBCLASS)
         private val unwantedSubclass = isKClass(UNWANTED_SUBCLASS)
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-nested-class").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-nested-class").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteObjectTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteObjectTest.kt
@@ -6,32 +6,34 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import org.objectweb.asm.Opcodes.ACC_PRIVATE
 import org.objectweb.asm.Opcodes.ACC_PUBLIC
 import java.nio.file.Path
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class DeleteObjectTest {
-    companion object {
+    private companion object {
         private const val OBJECT_CLASS = "net.corda.gradle.HasObjects"
         private const val UNWANTED_FIELD_OBJ_FIELD = "unwantedFieldObj"
         private const val UNWANTED_GET_OBJ_METHOD = "getUnwantedGetObj"
         private const val UNWANTED_OBJ_METHOD = "getUnwantedObj"
         private const val UNWANTED_OBJ_FIELD = "unwantedObj"
         private const val UNWANTED_FUN_METHOD = "unwantedFun"
+    }
 
-        private lateinit var testProject: JarFilterProject
-        private lateinit var sourceClasses: List<String>
-        private lateinit var filteredClasses: List<String>
+    private lateinit var testProject: JarFilterProject
+    private lateinit var sourceClasses: List<String>
+    private lateinit var filteredClasses: List<String>
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-object").build()
-            sourceClasses = testProject.sourceJar.getClassNames(OBJECT_CLASS)
-            filteredClasses = testProject.filteredJar.getClassNames(OBJECT_CLASS)
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-object").build()
+        sourceClasses = testProject.sourceJar.getClassNames(OBJECT_CLASS)
+        filteredClasses = testProject.filteredJar.getClassNames(OBJECT_CLASS)
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteOverloadedFunctionTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteOverloadedFunctionTest.kt
@@ -8,25 +8,28 @@ import org.hamcrest.core.IsNot.not
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.reflect.full.declaredFunctions
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class DeleteOverloadedFunctionTest {
-    companion object {
+    private companion object {
         private const val FUNCTION_CLASS = "net.corda.gradle.HasOverloadedFunction"
         private const val LAMBDA_CLASS = "net.corda.gradle.HasOverloadWithLambda"
 
         private val stringData1 = isFunction("stringData", String::class, String::class)
         private val stringData2 = isFunction("stringData", String::class, Int::class, String::class)
-        private lateinit var testProject: JarFilterProject
+    }
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-overloaded-function").build()
-        }
+    private lateinit var testProject: JarFilterProject
+
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-overloaded-function").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteSealedSubclassTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteSealedSubclassTest.kt
@@ -5,6 +5,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.test.assertFailsWith
@@ -14,19 +16,19 @@ import kotlin.test.assertFailsWith
  * are declared in the same file as the sealed class. Check that the metadata
  * is still updated correctly in this case.
  */
+@TestInstance(PER_CLASS)
 class DeleteSealedSubclassTest {
-    companion object {
+    private companion object {
         private const val SEALED_CLASS = "net.corda.gradle.SealedBaseClass"
         private const val WANTED_SUBCLASS = "net.corda.gradle.WantedSubclass"
         private const val UNWANTED_SUBCLASS = "net.corda.gradle.UnwantedSubclass"
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-sealed-subclass").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-sealed-subclass").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteStaticFieldTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteStaticFieldTest.kt
@@ -2,24 +2,26 @@ package net.corda.gradle.jarfilter
 
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class DeleteStaticFieldTest {
-    companion object {
+    private companion object {
         private const val PROPERTY_CLASS = "net.corda.gradle.StaticFieldsToDelete"
         private const val DEFAULT_BIG_NUMBER: Long = 123456789L
         private const val DEFAULT_NUMBER: Int = 123456
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-static-field").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-static-field").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteStaticFunctionTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteStaticFunctionTest.kt
@@ -7,23 +7,26 @@ import org.hamcrest.core.IsIterableContaining.hasItem
 import org.hamcrest.core.IsNot.not
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class DeleteStaticFunctionTest {
-    companion object {
+    private companion object {
         private const val FUNCTION_CLASS = "net.corda.gradle.StaticFunctionsToDelete"
 
         private val unwantedInline = isMethod("unwantedInlineToDelete", Any::class.java, String::class.java, Class::class.java)
         private val defaultUnwantedInline = isMethod("unwantedInlineToDelete\$default", Any::class.java, String::class.java, Class::class.java, Integer.TYPE, Any::class.java)
-        private lateinit var testProject: JarFilterProject
+    }
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-static-function").build()
-        }
+    private lateinit var testProject: JarFilterProject
+
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-static-function").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteStaticValPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteStaticValPropertyTest.kt
@@ -2,25 +2,28 @@ package net.corda.gradle.jarfilter
 
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class DeleteStaticValPropertyTest {
-    companion object {
+    private companion object {
         private const val PROPERTY_CLASS = "net.corda.gradle.StaticValToDelete"
         private const val DEFAULT_BIG_NUMBER: Long = 123456789L
         private const val DEFAULT_NUMBER: Int = 123456
+
         private object LocalBlob
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-static-val").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-static-val").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteStaticVarPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteStaticVarPropertyTest.kt
@@ -3,24 +3,27 @@ package net.corda.gradle.jarfilter
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class DeleteStaticVarPropertyTest {
-    companion object {
+    private companion object {
         private const val PROPERTY_CLASS = "net.corda.gradle.StaticVarToDelete"
         private const val DEFAULT_BIG_NUMBER: Long = 123456789L
         private const val DEFAULT_NUMBER: Int = 123456
+
         private object LocalBlob
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-static-var").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-static-var").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteTypeAliasFromFileTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteTypeAliasFromFileTest.kt
@@ -4,24 +4,26 @@ import net.corda.gradle.jarfilter.asm.fileMetadata
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class DeleteTypeAliasFromFileTest {
-    companion object {
+    private companion object {
         private const val TYPEALIAS_CLASS = "net.corda.gradle.FileWithTypeAlias"
+    }
 
-        private lateinit var testProject: JarFilterProject
-        private lateinit var sourceClasses: List<String>
-        private lateinit var filteredClasses: List<String>
+    private lateinit var testProject: JarFilterProject
+    private lateinit var sourceClasses: List<String>
+    private lateinit var filteredClasses: List<String>
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-file-typealias").build()
-            sourceClasses = testProject.sourceJar.getClassNames(TYPEALIAS_CLASS)
-            filteredClasses = testProject.filteredJar.getClassNames(TYPEALIAS_CLASS)
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-file-typealias").build()
+        sourceClasses = testProject.sourceJar.getClassNames(TYPEALIAS_CLASS)
+        filteredClasses = testProject.filteredJar.getClassNames(TYPEALIAS_CLASS)
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteValPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteValPropertyTest.kt
@@ -12,27 +12,30 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import org.objectweb.asm.Opcodes.ACC_PRIVATE
 import java.nio.file.Path
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class DeleteValPropertyTest {
-    companion object {
+    private companion object {
         private const val PROPERTY_CLASS = "net.corda.gradle.HasValPropertyForDelete"
         private const val GETTER_CLASS = "net.corda.gradle.HasValGetterForDelete"
         private const val JVM_FIELD_CLASS = "net.corda.gradle.HasValJvmFieldForDelete"
 
         private val unwantedVal = isProperty("unwantedVal", String::class)
         private val getUnwantedVal = isMethod("getUnwantedVal", String::class.java)
-        private lateinit var testProject: JarFilterProject
+    }
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-val-property").build()
-        }
+    private lateinit var testProject: JarFilterProject
+
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-val-property").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteVarPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/DeleteVarPropertyTest.kt
@@ -12,14 +12,17 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import org.objectweb.asm.Opcodes.ACC_PRIVATE
 import java.nio.file.Path
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class DeleteVarPropertyTest {
-    companion object {
+    private companion object {
         private const val PROPERTY_CLASS = "net.corda.gradle.HasUnwantedVarPropertyForDelete"
         private const val GETTER_CLASS = "net.corda.gradle.HasUnwantedGetForDelete"
         private const val SETTER_CLASS = "net.corda.gradle.HasUnwantedSetForDelete"
@@ -28,13 +31,13 @@ class DeleteVarPropertyTest {
         private val unwantedVar = isProperty("unwantedVar", String::class)
         private val getUnwantedVar = isMethod("getUnwantedVar", String::class.java)
         private val setUnwantedVar = isMethod("setUnwantedVar", Void.TYPE, String::class.java)
-        private lateinit var testProject: JarFilterProject
+    }
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "delete-var-property").build()
-        }
+    private lateinit var testProject: JarFilterProject
+
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "delete-var-property").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/FieldRemovalTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/FieldRemovalTest.kt
@@ -23,7 +23,7 @@ import kotlin.test.assertFailsWith
  * one of their properties. (Check we haven't blown the constructor away!)
  */
 class FieldRemovalTest {
-    companion object {
+    private companion object {
         private val logger: Logger = StdOutLogging(FieldRemovalTest::class)
         private const val SHORT_NUMBER = 999.toShort()
         private const val BYTE_NUMBER = 99.toByte()

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/InterfaceFunctionTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/InterfaceFunctionTest.kt
@@ -3,22 +3,24 @@ package net.corda.gradle.jarfilter
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.lang.reflect.Modifier.ABSTRACT
 import java.nio.file.Path
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class InterfaceFunctionTest {
-    companion object {
+    private companion object {
         private const val FUNCTION_CLASS = "net.corda.gradle.InterfaceFunctions"
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "interface-function").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "interface-function").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterExecuteTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/JarFilterExecuteTest.kt
@@ -10,13 +10,16 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsIterableContaining.hasItem
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.reflect.full.declaredFunctions
 import kotlin.reflect.full.declaredMemberProperties
 
+@TestInstance(PER_CLASS)
 class JarFilterExecuteTest {
-    companion object {
+    private companion object {
         private const val EXAMPLE_CLASS = "net.corda.gradle.ExampleKotlin"
         private const val NESTED_CLASS = "net.corda.gradle.ExampleKotlin\$Nested"
         private const val INNER_CLASS = "net.corda.gradle.ExampleKotlin\$Inner"
@@ -30,14 +33,13 @@ class JarFilterExecuteTest {
         private val stringVar = isProperty("stringVar", String::class)
         private val longVar = isProperty("longVar", Long::class)
         private val intVar = isProperty("intVar", Int::class)
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "basic-execute").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "basic-execute").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixAnnotationTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixAnnotationTest.kt
@@ -9,7 +9,7 @@ import org.hamcrest.core.IsIterableContaining.hasItem
 import org.junit.jupiter.api.Test
 
 class MetaFixAnnotationTest {
-    companion object {
+    private companion object {
         private val logger: Logger = StdOutLogging(MetaFixAnnotationTest::class)
         private val defaultCon = isKonstructor(
             returnType = SimpleAnnotation::class

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConstructorDefaultParameterTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConstructorDefaultParameterTest.kt
@@ -12,27 +12,27 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import kotlin.reflect.full.primaryConstructor
 
+@TestInstance(PER_CLASS)
 class MetaFixConstructorDefaultParameterTest {
-    companion object {
+    private companion object {
         private val logger: Logger = StdOutLogging(MetaFixConstructorDefaultParameterTest::class)
-        private val primaryCon
-                = isKonstructor(WithConstructorParameters::class, Long::class, Int::class, String::class)
-        private val secondaryCon
-                = isKonstructor(WithConstructorParameters::class, Char::class, String::class)
+        private val primaryCon = isKonstructor(WithConstructorParameters::class, Long::class, Int::class, String::class)
+        private val secondaryCon = isKonstructor(WithConstructorParameters::class, Char::class, String::class)
+    }
 
-        lateinit var sourceClass: Class<out HasAll>
-        lateinit var fixedClass: Class<out HasAll>
+    lateinit var sourceClass: Class<out HasAll>
+    lateinit var fixedClass: Class<out HasAll>
 
-        @BeforeAll
-        @JvmStatic
-        fun setup() {
-            val bytecode = recodeMetadataFor<WithConstructorParameters, MetadataTemplate>()
-            sourceClass = bytecode.toClass<WithConstructorParameters, HasAll>()
-            fixedClass = bytecode.fixMetadata(logger, pathsOf(WithConstructorParameters::class))
-                .toClass<WithConstructorParameters, HasAll>()
-        }
+    @BeforeAll
+    fun setup() {
+        val bytecode = recodeMetadataFor<WithConstructorParameters, MetadataTemplate>()
+        sourceClass = bytecode.toClass<WithConstructorParameters, HasAll>()
+        fixedClass = bytecode.fixMetadata(logger, pathsOf(WithConstructorParameters::class))
+            .toClass<WithConstructorParameters, HasAll>()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConstructorTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixConstructorTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test
 import kotlin.jvm.kotlin
 
 class MetaFixConstructorTest {
-    companion object {
+    private companion object {
         private val logger: Logger = StdOutLogging(MetaFixConstructorTest::class)
         private val unwantedCon = isKonstructor(WithConstructor::class, Int::class, Long::class)
         private val wantedCon = isKonstructor(WithConstructor::class, Long::class)

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixExecuteTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixExecuteTest.kt
@@ -10,13 +10,16 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsIterableContaining.hasItem
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.reflect.full.declaredFunctions
 import kotlin.reflect.full.declaredMemberProperties
 
+@TestInstance(PER_CLASS)
 class MetaFixExecuteTest {
-    companion object {
+    private companion object {
         private const val EXAMPLE_CLASS = "net.corda.gradle.ExampleKotlin"
         private const val NESTED_CLASS = "net.corda.gradle.ExampleKotlin\$Nested"
         private const val INNER_CLASS = "net.corda.gradle.ExampleKotlin\$Inner"
@@ -30,14 +33,13 @@ class MetaFixExecuteTest {
         private val stringVar = isProperty("stringVar", String::class)
         private val longVar = isProperty("longVar", Long::class)
         private val intVar = isProperty("intVar", Int::class)
+    }
 
-        private lateinit var testProject: MetaFixProject
+    private lateinit var testProject: MetaFixProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = MetaFixProject(testProjectDir, "basic-execute").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = MetaFixProject(testProjectDir, "basic-execute").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFieldValPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFieldValPropertyTest.kt
@@ -9,10 +9,12 @@ import org.hamcrest.core.IsIterableContaining.hasItem
 import org.hamcrest.core.IsNot.not
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import kotlin.reflect.full.declaredMemberProperties
 
 class MetaFixFieldValPropertyTest {
-    companion object {
+    private companion object {
         private val logger: Logger = StdOutLogging(MetaFixFieldValPropertyTest::class)
         private val unwantedVal = isProperty("unwantedVal", String::class)
         private val wantedVal = isProperty("wantedVal", Int::class)

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFieldVarPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFieldVarPropertyTest.kt
@@ -9,10 +9,12 @@ import org.hamcrest.core.IsIterableContaining.hasItem
 import org.hamcrest.core.IsNot.not
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import kotlin.reflect.full.declaredMemberProperties
 
 class MetaFixFieldVarPropertyTest {
-    companion object {
+    private companion object {
         private val logger: Logger = StdOutLogging(MetaFixVarPropertyTest::class)
         private val unwantedVar = isProperty("unwantedVar", String::class)
         private val wantedVar = isProperty("wantedVar", Int::class)

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFunctionDefaultParameterTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFunctionDefaultParameterTest.kt
@@ -11,28 +11,29 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import kotlin.reflect.KFunction
 import kotlin.reflect.full.declaredFunctions
 
+@TestInstance(PER_CLASS)
 class MetaFixFunctionDefaultParameterTest {
-    companion object {
+    private companion object {
         private val logger: Logger = StdOutLogging(MetaFixFunctionDefaultParameterTest::class)
-        private val hasMandatoryParams
-                = isFunction("hasMandatoryParams", String::class, Long::class, Int::class, String::class)
-        private val hasOptionalParams
-                = isFunction("hasOptionalParams", String::class, String::class)
+        private val hasMandatoryParams =
+            isFunction("hasMandatoryParams", String::class, Long::class, Int::class, String::class)
+        private val hasOptionalParams = isFunction("hasOptionalParams", String::class, String::class)
+    }
 
-        lateinit var sourceClass: Class<out Any>
-        lateinit var fixedClass: Class<out Any>
+    lateinit var sourceClass: Class<out Any>
+    lateinit var fixedClass: Class<out Any>
 
-        @BeforeAll
-        @JvmStatic
-        fun setup() {
-            val bytecode = recodeMetadataFor<WithFunctionParameters, MetadataTemplate>()
-            sourceClass = bytecode.toClass<WithFunctionParameters, Any>()
-            fixedClass = bytecode.fixMetadata(logger, pathsOf(WithFunctionParameters::class))
-                    .toClass<WithFunctionParameters, Any>()
-        }
+    @BeforeAll
+    fun setup() {
+        val bytecode = recodeMetadataFor<WithFunctionParameters, MetadataTemplate>()
+        sourceClass = bytecode.toClass<WithFunctionParameters, Any>()
+        fixedClass = bytecode.fixMetadata(logger, pathsOf(WithFunctionParameters::class))
+                .toClass<WithFunctionParameters, Any>()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFunctionTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixFunctionTest.kt
@@ -14,7 +14,7 @@ import kotlin.jvm.kotlin
 import kotlin.reflect.full.declaredFunctions
 
 class MetaFixFunctionTest {
-    companion object {
+    private companion object {
         private val logger: Logger = StdOutLogging(MetaFixFunctionTest::class)
         private val longData = isFunction("longData", Long::class)
         private val unwantedFun = isFunction("unwantedFun", String::class, String::class)

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixNestedClassTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixNestedClassTest.kt
@@ -14,7 +14,7 @@ import kotlin.reflect.jvm.jvmName
  * about what the MetaFixer task has done.
  */
 class MetaFixNestedClassTest {
-    companion object {
+    private companion object {
         private val logger: Logger = StdOutLogging(MetaFixNestedClassTest::class)
         private val WANTED_CLASS: String = WithNestedClass.Wanted::class.jvmName
         private val UNWANTED_CLASS: String = "${WithNestedClass::class.jvmName}\$Unwanted"

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixPackageDefaultParameterTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixPackageDefaultParameterTest.kt
@@ -5,6 +5,8 @@ import net.corda.gradle.jarfilter.asm.toClass
 import org.gradle.api.logging.Logger
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import kotlin.reflect.full.declaredFunctions
 import kotlin.test.assertFailsWith
 
@@ -13,23 +15,23 @@ import kotlin.test.assertFailsWith
  * supports package metadata. Until then, we can only execute the code
  * paths to ensure they don't throw any exceptions.
  */
+@TestInstance(PER_CLASS)
 class MetaFixPackageDefaultParameterTest {
-    companion object {
+    private companion object {
         private const val TEMPLATE_CLASS = "net.corda.gradle.jarfilter.template.PackageWithDefaultParameters"
         private const val DEFAULT_PARAMETERS_CLASS = "net.corda.gradle.jarfilter.PackageWithDefaultParameters"
         private val logger: Logger = StdOutLogging(MetaFixPackageDefaultParameterTest::class)
+    }
 
-        lateinit var sourceClass: Class<out Any>
-        lateinit var fixedClass: Class<out Any>
+    lateinit var sourceClass: Class<out Any>
+    lateinit var fixedClass: Class<out Any>
 
-        @BeforeAll
-        @JvmStatic
-        fun setup() {
-            val defaultParametersClass = Class.forName(DEFAULT_PARAMETERS_CLASS)
-            val bytecode = defaultParametersClass.metadataAs(Class.forName(TEMPLATE_CLASS))
-            sourceClass = bytecode.toClass(defaultParametersClass, Any::class.java)
-            fixedClass = bytecode.fixMetadata(logger, setOf(DEFAULT_PARAMETERS_CLASS)).toClass(sourceClass, Any::class.java)
-        }
+    @BeforeAll
+    fun setup() {
+        val defaultParametersClass = Class.forName(DEFAULT_PARAMETERS_CLASS)
+        val bytecode = defaultParametersClass.metadataAs(Class.forName(TEMPLATE_CLASS))
+        sourceClass = bytecode.toClass(defaultParametersClass, Any::class.java)
+        fixedClass = bytecode.fixMetadata(logger, setOf(DEFAULT_PARAMETERS_CLASS)).toClass(sourceClass, Any::class.java)
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixPackageTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixPackageTest.kt
@@ -9,6 +9,8 @@ import net.corda.gradle.jarfilter.matcher.isProperty
 import org.gradle.api.logging.Logger
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import kotlin.jvm.kotlin
 import kotlin.reflect.full.declaredFunctions
 import kotlin.reflect.full.declaredMembers
@@ -19,26 +21,26 @@ import kotlin.test.assertFailsWith
  * supports package metadata. Until then, we can only execute the code
  * paths to ensure they don't throw any exceptions.
  */
+@TestInstance(PER_CLASS)
 class MetaFixPackageTest {
-    companion object {
+    private companion object {
         private const val TEMPLATE_CLASS = "net.corda.gradle.jarfilter.PackageTemplate"
         private const val EMPTY_CLASS = "net.corda.gradle.jarfilter.EmptyPackage"
         private val logger: Logger = StdOutLogging(MetaFixPackageTest::class)
         private val staticVal = isProperty("templateVal", Long::class)
         private val staticVar = isProperty("templateVar", Int::class)
         private val staticFun = isFunction("templateFun", String::class)
+    }
 
-        private lateinit var sourceClass: Class<out Any>
-        private lateinit var fixedClass: Class<out Any>
+    private lateinit var sourceClass: Class<out Any>
+    private lateinit var fixedClass: Class<out Any>
 
-        @BeforeAll
-        @JvmStatic
-        fun setup() {
-            val emptyClass = Class.forName(EMPTY_CLASS)
-            val bytecode = emptyClass.metadataAs(Class.forName(TEMPLATE_CLASS))
-            sourceClass = bytecode.toClass(emptyClass, Any::class.java)
-            fixedClass = bytecode.fixMetadata(logger, setOf(EMPTY_CLASS)).toClass(sourceClass, Any::class.java)
-        }
+    @BeforeAll
+    fun setup() {
+        val emptyClass = Class.forName(EMPTY_CLASS)
+        val bytecode = emptyClass.metadataAs(Class.forName(TEMPLATE_CLASS))
+        sourceClass = bytecode.toClass(emptyClass, Any::class.java)
+        fixedClass = bytecode.fixMetadata(logger, setOf(EMPTY_CLASS)).toClass(sourceClass, Any::class.java)
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixSealedClassTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixSealedClassTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 import kotlin.reflect.jvm.jvmName
 
 class MetaFixSealedClassTest {
-    companion object {
+    private companion object {
         private val logger: Logger = StdOutLogging(MetaFixSealedClassTest::class)
         private val UNWANTED_CLASS: String = "${MetaSealedClass::class.jvmName}\$Unwanted"
         private val WANTED_CLASS: String = MetaSealedClass.Wanted::class.jvmName

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixValPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixValPropertyTest.kt
@@ -14,7 +14,7 @@ import kotlin.jvm.kotlin
 import kotlin.reflect.full.declaredMemberProperties
 
 class MetaFixValPropertyTest {
-    companion object {
+    private companion object {
         private val logger: Logger = StdOutLogging(MetaFixValPropertyTest::class)
         private val unwantedVal = isProperty("unwantedVal", String::class)
         private val intVal = isProperty("intVal", Int::class)

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixVarPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/MetaFixVarPropertyTest.kt
@@ -14,7 +14,7 @@ import kotlin.jvm.kotlin
 import kotlin.reflect.full.declaredMemberProperties
 
 class MetaFixVarPropertyTest {
-    companion object {
+    private companion object {
         private val logger: Logger = StdOutLogging(MetaFixVarPropertyTest::class)
         private val unwantedVar = isProperty("unwantedVar", String::class)
         private val intVar = isProperty("intVar", Int::class)

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/RemoveAnnotationFromJavaRecordTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/RemoveAnnotationFromJavaRecordTest.kt
@@ -4,29 +4,31 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE.JAVA_17
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
 @EnabledForJreRange(min = JAVA_17)
+@TestInstance(PER_CLASS)
 class RemoveAnnotationFromJavaRecordTest {
-    companion object {
+    private companion object {
         private const val ANNOTATION_CLASS = "net.corda.gradle.RemoveFromRecord"
         private const val RECORD_CLASS = "net.corda.gradle.RecordWithUnwantedAnnotation"
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "remove-java-record-annotation").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "remove-java-record-annotation").build()
+    }
 
-        fun ClassLoader.loadAnnotation(className: String): Class<out Annotation> {
-            return load<Annotation>(className).apply {
-                assertTrue(isAnnotation)
-            }
+    fun ClassLoader.loadAnnotation(className: String): Class<out Annotation> {
+        return load<Annotation>(className).apply {
+            assertTrue(isAnnotation)
         }
     }
 

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/RemoveAnnotationsTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/RemoveAnnotationsTest.kt
@@ -8,26 +8,28 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
+@TestInstance(PER_CLASS)
 class RemoveAnnotationsTest {
-    companion object {
+    private companion object {
         private const val ANNOTATED_CLASS = "net.corda.gradle.HasUnwantedAnnotations"
         private const val REMOVE_ME_CLASS = "net.corda.gradle.jarfilter.RemoveMe"
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "remove-annotations").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "remove-annotations").build()
+    }
 
-        fun ClassLoader.loadAnnotation(className: String): Class<out Annotation> {
-            return load<Annotation>(className).apply {
-                assertTrue(isAnnotation)
-            }
+    fun ClassLoader.loadAnnotation(className: String): Class<out Annotation> {
+        return load<Annotation>(className).apply {
+            assertTrue(isAnnotation)
         }
     }
 

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/SanitiseDeleteConstructorTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/SanitiseDeleteConstructorTest.kt
@@ -18,24 +18,27 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.jvm.kotlin
 import kotlin.reflect.full.primaryConstructor
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class SanitiseDeleteConstructorTest {
-    companion object {
+    private companion object {
         private const val COMPLEX_CONSTRUCTOR_CLASS = "net.corda.gradle.HasOverloadedComplexConstructorToDelete"
 
         private val isDefaultConstructorMarker = equalTo("kotlin.jvm.internal.DefaultConstructorMarker")
-        private lateinit var testProject: JarFilterProject
+    }
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "sanitise-delete-constructor").build()
-        }
+    private lateinit var testProject: JarFilterProject
+
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "sanitise-delete-constructor").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/SanitiseStubConstructorTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/SanitiseStubConstructorTest.kt
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.lang.reflect.InvocationTargetException
 import java.nio.file.Path
@@ -18,25 +20,26 @@ import kotlin.jvm.kotlin
 import kotlin.reflect.full.primaryConstructor
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class SanitiseStubConstructorTest {
-    companion object {
+    private companion object {
         private const val COMPLEX_CONSTRUCTOR_CLASS = "net.corda.gradle.HasOverloadedComplexConstructorToStub"
         private const val COUNT_OVERLOADED = 1
         private const val COUNT_MULTIPLE = 2
-        private lateinit var testProject: JarFilterProject
+    }
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "sanitise-stub-constructor").build()
-        }
+    private lateinit var testProject: JarFilterProject
 
-        fun <T> newInstance(clazz: Class<T>): T {
-            return try {
-                clazz.getDeclaredConstructor().newInstance()
-            } catch (e: InvocationTargetException) {
-                throw e.targetException
-            }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "sanitise-stub-constructor").build()
+    }
+
+    fun <T> newInstance(clazz: Class<T>): T {
+        return try {
+            clazz.getDeclaredConstructor().newInstance()
+        } catch (e: InvocationTargetException) {
+            throw e.targetException
         }
     }
 

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/StubConstructorTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/StubConstructorTest.kt
@@ -11,28 +11,30 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.lang.reflect.InvocationTargetException
 import java.nio.file.Path
 import kotlin.reflect.full.primaryConstructor
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class StubConstructorTest {
-    companion object {
+    private companion object {
         private const val STRING_PRIMARY_CONSTRUCTOR_CLASS = "net.corda.gradle.PrimaryStringConstructorToStub"
         private const val LONG_PRIMARY_CONSTRUCTOR_CLASS = "net.corda.gradle.PrimaryLongConstructorToStub"
         private const val INT_PRIMARY_CONSTRUCTOR_CLASS = "net.corda.gradle.PrimaryIntConstructorToStub"
         private const val SECONDARY_CONSTRUCTOR_CLASS = "net.corda.gradle.HasConstructorToStub"
         private const val DEFAULT_VALUE_PRIMARY_CLASS = "net.corda.gradle.PrimaryConstructorWithDefaultToStub"
         private const val DEFAULT_VALUE_SECONDARY_CLASS = "net.corda.gradle.SecondaryConstructorWithDefaultToStub"
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "stub-constructor").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "stub-constructor").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/StubFunctionOutTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/StubFunctionOutTest.kt
@@ -7,24 +7,26 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import javax.annotation.Resource
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class StubFunctionOutTest {
-    companion object {
+    private companion object {
         private const val FUNCTION_CLASS = "net.corda.gradle.HasFunctionToStub"
         private const val STUB_ME_OUT_ANNOTATION = "net.corda.gradle.jarfilter.StubMeOut"
         private const val PARAMETER_ANNOTATION = "net.corda.gradle.Parameter"
+    }
 
-        private lateinit var testProject: JarFilterProject
+    private lateinit var testProject: JarFilterProject
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "stub-function").build()
-        }
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "stub-function").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/StubStaticFunctionTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/StubStaticFunctionTest.kt
@@ -4,6 +4,8 @@ import net.corda.gradle.jarfilter.matcher.isMethod
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsIterableContaining.hasItem
@@ -12,19 +14,20 @@ import java.lang.reflect.InvocationTargetException
 import java.nio.file.Path
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class StubStaticFunctionTest {
-    companion object {
+    private companion object {
         private const val FUNCTION_CLASS = "net.corda.gradle.StaticFunctionsToStub"
 
         private val unwantedInline = isMethod("unwantedInlineToStub", Any::class.java, String::class.java, Class::class.java)
         private val defaultUnwantedInline = isMethod("unwantedInlineToStub\$default", Any::class.java, String::class.java, Class::class.java, Integer.TYPE, Any::class.java)
-        private lateinit var testProject: JarFilterProject
+    }
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "stub-static-function").build()
-        }
+    private lateinit var testProject: JarFilterProject
+
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "stub-static-function").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/StubValPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/StubValPropertyTest.kt
@@ -4,20 +4,23 @@ import net.corda.gradle.unwanted.HasUnwantedVal
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class StubValPropertyTest {
-    companion object {
+    private companion object {
         private const val PROPERTY_CLASS = "net.corda.gradle.HasValPropertyForStub"
-        private lateinit var testProject: JarFilterProject
+    }
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "stub-val-property").build()
-        }
+    private lateinit var testProject: JarFilterProject
+
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "stub-val-property").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/StubVarPropertyTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/StubVarPropertyTest.kt
@@ -4,21 +4,24 @@ import net.corda.gradle.unwanted.HasUnwantedVar
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.test.assertFailsWith
 
+@TestInstance(PER_CLASS)
 class StubVarPropertyTest {
-    companion object {
+    private companion object {
         private const val GETTER_CLASS = "net.corda.gradle.HasUnwantedGetForStub"
         private const val SETTER_CLASS = "net.corda.gradle.HasUnwantedSetForStub"
-        private lateinit var testProject: JarFilterProject
+    }
 
-        @BeforeAll
-        @JvmStatic
-        fun setup(@TempDir testProjectDir: Path) {
-            testProject = JarFilterProject(testProjectDir, "stub-var-property").build()
-        }
+    private lateinit var testProject: JarFilterProject
+
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path) {
+        testProject = JarFilterProject(testProjectDir, "stub-var-property").build()
     }
 
     @Test

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/UnwantedCacheTest.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/UnwantedCacheTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-
 class UnwantedCacheTest {
     private companion object {
         private const val CLASS_NAME = "org.testing.MyClass"


### PR DESCRIPTION
Use JUnit's `@TestInstance(PER_CLASS)` annotation to avoid needing `@BeforeAll` methods to be `static`.

There is no functional change to any of the plugins.