### PR TITLE
NOTICK: Switch Jenkins pipeline to using authenticated Gradle wrapper.

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -43,6 +43,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
+                authenticateGradleWrapper()
                 sh './gradlew --no-daemon -s --no-build-cache clean build'
             }
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://gradleproxy:gradleproxy@software.r3.com/artifactory/gradle-proxy/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Only Jenkins will now download Gradle from Artifactory.