### PR TITLE
NOTICK: Upgrade Kotlin JVM Metadata library to 0.3.0.

### DIFF
--- a/jar-filter/build.gradle
+++ b/jar-filter/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 ext {
-    kotlin_metadata_version = '0.2.0'
+    kotlin_metadata_version = '0.3.0'
     test_kotlin_api_version = '1.4'
     test_kotlin_version = '1.4.32'
 }

--- a/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/KotlinAwareVisitor.kt
+++ b/jar-filter/src/main/kotlin/net/corda/gradle/jarfilter/KotlinAwareVisitor.kt
@@ -15,7 +15,6 @@ const val KOTLIN_METADATA_DATA_FIELD_NAME = "d1"
 const val KOTLIN_METADATA_STRINGS_FIELD_NAME = "d2"
 const val KOTLIN_KIND_FIELD_NAME = "k"
 const val KOTLIN_METADATA_VERSION_NAME = "mv"
-const val KOTLIN_BYTECODE_VERSION_NAME = "bv"
 const val KOTLIN_METADATA_EXTRA_INT_NAME = "xi"
 const val KOTLIN_METADATA_EXTRA_STRING_NAME = "xs"
 const val KOTLIN_METADATA_PACKAGE_NAME= "pn"
@@ -35,7 +34,6 @@ abstract class KotlinAwareVisitor(
     private var extraString: String? = null
     private var packageName: String? = null
     private var metadataVersion: IntArray? = null
-    private var bytecodeVersion: IntArray? = null
 
     open val hasUnwantedElements: Boolean get() = kotlinMetadata.isNotEmpty()
     protected open val level: LogLevel = LogLevel.INFO
@@ -58,7 +56,6 @@ abstract class KotlinAwareVisitor(
                 val header = KotlinClassHeader(
                     classKind,
                     metadataVersion,
-                    bytecodeVersion,
                     data1,
                     data2,
                     extraString,
@@ -121,7 +118,6 @@ abstract class KotlinAwareVisitor(
         override fun visit(name: String?, value: Any?) {
             when (name) {
                 KOTLIN_KIND_FIELD_NAME -> classKind = value as Int
-                KOTLIN_BYTECODE_VERSION_NAME -> bytecodeVersion = value as IntArray?
                 KOTLIN_METADATA_VERSION_NAME -> metadataVersion = value as IntArray?
                 KOTLIN_METADATA_PACKAGE_NAME -> packageName = value as String?
                 KOTLIN_METADATA_EXTRA_INT_NAME -> extraInt = value as Int?

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/asm/MetadataTools.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/asm/MetadataTools.kt
@@ -25,7 +25,6 @@ fun <T: Any, X: Any> Class<in T>.metadataAs(template: Class<in X>): ByteArray {
         KotlinClassHeader(
             m.kind,
             m.metadataVersion,
-            m.bytecodeVersion,
             m.data1,
             m.data2.map { s ->
                 when {
@@ -66,7 +65,6 @@ private fun Class<*>.readMetadata(): KotlinClassHeader {
     return KotlinClassHeader(
         kind = metadata.kind,
         metadataVersion = metadata.metadataVersion,
-        bytecodeVersion = metadata.bytecodeVersion,
         data1 = metadata.data1,
         data2 = metadata.data2,
         extraString = metadata.extraString,


### PR DESCRIPTION
Upgrade Kotlin JVM Metadata library 0.2.0 -> 0.3.0.

This is the most up-to-date version that is still compatible with Kotlin 1.4.