### PR TITLE
CORDA-4254: Upgrade default Quasar version to 0.7.15_r3.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ### Version 5.0.16
 
+* `quasar-utils`: Upgrade default Quasar version to 0.7.15_r3.
+
 ### Version 5.0.15
 
 * `cordformation`: Append OU to Docker container name using '-' instead of '_'.

--- a/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarPlugin.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarPlugin.groovy
@@ -26,7 +26,7 @@ class QuasarPlugin implements Plugin<Project> {
     private static final String QUASAR = "quasar"
     private static final String MINIMUM_GRADLE_VERSION = "5.1"
     @PackageScope static final String defaultGroup = "co.paralleluniverse"
-    @PackageScope static final String defaultVersion = "0.7.13_r3"
+    @PackageScope static final String defaultVersion = "0.7.15_r3"
     @PackageScope static final String defaultClassifier = ""
 
     private final ObjectFactory objects


### PR DESCRIPTION
Update `quasar-utils` plugin to use Quasar 0.7.15_r3 by default.