### PR TITLE
CORE-4748: Create cordapp component for publishing CPKs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ file. Both the OSGi bundle and the CPK archive are signed. The plugin also
 provides a `cordapp` Gradle extension so that you can configure your CorDapp's
 metadata.
 
-    <sup>Requires Gradle 6.6</sup>
+    <sup>Requires Gradle 6.7</sup>
 
 - [`net.corda.plugins.cordapp`](cordapp/README.md)\
 This plugin packages your CorDapp classes into a single jar file, along with

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpb/CpbPlugin.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpb/CpbPlugin.kt
@@ -37,6 +37,7 @@ class CpbPlugin : Plugin<Project> {
         val attributor = Attributor(project.objects)
 
         val cpbConfiguration = project.configurations.create(CPB_CONFIGURATION_NAME)
+            .setDescription("Additional CPK dependencies to include inside the CPB.")
             .extendsFrom(allCordappsConfiguration)
             .setVisible(false)
             .apply {
@@ -76,7 +77,7 @@ class CpbPlugin : Plugin<Project> {
                 isCanBeConsumed = false
             }
 
-        project.configurations.maybeCreate(CORDA_CPB_CONFIGURATION_NAME)
+        project.configurations.create(CORDA_CPB_CONFIGURATION_NAME)
             .attributes(attributor::forCpb)
             .isCanBeResolved = false
 

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappPlugin.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappPlugin.kt
@@ -59,7 +59,7 @@ class CordappPlugin @Inject constructor(
         private const val CORDAPP_COMPONENT_NAME = "cordapp"
         private const val CORDAPP_EXTENSION_NAME = "cordapp"
         private const val OSGI_EXTENSION_NAME = "osgi"
-        private const val MIN_GRADLE_VERSION = "6.6"
+        private const val MIN_GRADLE_VERSION = "6.7"
         private const val UNKNOWN = "Unknown"
 
         private val CORDAPP_BUILD_CONFIGURATIONS: List<String> = unmodifiableList(listOf(

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappPlugin.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappPlugin.kt
@@ -13,10 +13,14 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency.ARCHIVES_CONFIGURATION
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.component.ConfigurationVariantDetails
+import org.gradle.api.component.SoftwareComponentFactory
 import org.gradle.api.file.DuplicatesStrategy.FAIL
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.java.archives.Attributes
 import org.gradle.api.plugins.AppliedPlugin
+import org.gradle.api.plugins.JavaBasePlugin.UNPUBLISHABLE_VARIANT_ARTIFACTS
+import org.gradle.api.plugins.JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME
 import org.gradle.api.plugins.JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME
 import org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME
 import org.gradle.api.plugins.JavaPlugin.JAR_TASK_NAME
@@ -40,7 +44,10 @@ import kotlin.math.max
  * Generate a new CPK format CorDapp for use in Corda.
  */
 @Suppress("Unused", "UnstableApiUsage")
-class CordappPlugin @Inject constructor(private val layouts: ProjectLayout): Plugin<Project> {
+class CordappPlugin @Inject constructor(
+    private val layouts: ProjectLayout,
+    private val softwareComponentFactory: SoftwareComponentFactory
+): Plugin<Project> {
     private companion object {
         private const val UNKNOWN_PLATFORM_VERSION = -1
         private const val CORDA_PLATFORM_VERSION = "Corda-Platform-Version"
@@ -49,6 +56,7 @@ class CordappPlugin @Inject constructor(private val layouts: ProjectLayout): Plu
         private const val DEPENDENCY_CALCULATOR_TASK_NAME = "cordappDependencyCalculator"
         private const val CPK_DEPENDENCIES_TASK_NAME = "cordappCPKDependencies"
         private const val VERIFY_BUNDLE_TASK_NAME = "verifyBundle"
+        private const val CORDAPP_COMPONENT_NAME = "cordapp"
         private const val CORDAPP_EXTENSION_NAME = "cordapp"
         private const val OSGI_EXTENSION_NAME = "osgi"
         private const val MIN_GRADLE_VERSION = "6.6"
@@ -82,7 +90,7 @@ class CordappPlugin @Inject constructor(private val layouts: ProjectLayout): Plu
     private lateinit var cordapp: CordappExtension
 
     override fun apply(project: Project) {
-        project.logger.info("Configuring ${project.name} as a CorDapp")
+        project.logger.info("Configuring {} as a CorDapp", project.name)
 
         if (GradleVersion.current() < GradleVersion.version(MIN_GRADLE_VERSION)) {
             throw GradleException("Gradle version ${GradleVersion.current().version} is below the supported minimum version $MIN_GRADLE_VERSION. Please update Gradle or consider using Gradle wrapper if it is provided with the project. More information about CorDapp build system can be found here: $CORDAPP_DOCUMENTATION_URL")
@@ -105,11 +113,21 @@ class CordappPlugin @Inject constructor(private val layouts: ProjectLayout): Plu
             // Gradle resolves project dependencies into the correct artifacts.
             val attributor = Attributor(project.objects)
 
+            // Create the outgoing configuration, and add it to custom software component.
+            val cordaCPK = create(CORDA_CPK_CONFIGURATION_NAME)
+                .attributes(attributor::forCpk)
+                .also {
+                    it.isCanBeResolved = false
+                }
+            val component = softwareComponentFactory.adhoc(CORDAPP_COMPONENT_NAME).also { adhoc ->
+                adhoc.addVariantsFromConfiguration(getByName(API_ELEMENTS_CONFIGURATION_NAME), CordappVariantMapping("compile"))
+                adhoc.addVariantsFromConfiguration(getByName(RUNTIME_ELEMENTS_CONFIGURATION_NAME), CordappVariantMapping("runtime"))
+                adhoc.addVariantsFromConfiguration(cordaCPK) {}
+            }
+            project.components.add(component)
+
             // This definition of cordaRuntimeOnly must be kept aligned with the one in the quasar-utils plugin.
             createRuntimeOnlyConfiguration(CORDA_RUNTIME_ONLY_CONFIGURATION_NAME)
-            maybeCreate(CORDA_CPK_CONFIGURATION_NAME)
-                .attributes(attributor::forCpk)
-                .isCanBeResolved = false
 
             getByName(COMPILE_ONLY_CONFIGURATION_NAME).withDependencies { dependencies ->
                 val bndDependency = project.dependencies.create("biz.aQute.bnd:biz.aQute.bnd.annotation:" + cordapp.bndVersion.get())
@@ -437,6 +455,15 @@ class CordappPlugin @Inject constructor(private val layouts: ProjectLayout): Plu
             throw InvalidUserDataException("CorDapp `versionId` must not be smaller than 1.")
         }
         return value
+    }
+}
+
+private class CordappVariantMapping(private val mavenScope: String) : Action<ConfigurationVariantDetails> {
+    override fun execute(variant: ConfigurationVariantDetails) {
+        if (variant.configurationVariant.artifacts.any { it.type in UNPUBLISHABLE_VARIANT_ARTIFACTS }) {
+            variant.skip()
+        }
+        variant.mapToMavenScope(mavenScope)
     }
 }
 

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/PublishAfterEvaluationHandler.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/PublishAfterEvaluationHandler.kt
@@ -69,6 +69,7 @@ class PublishAfterEvaluationHandler(rootProject: Project) : Action<Gradle> {
                     cpk.groupId = toCompanionGroupId(pub.groupId, pub.artifactId)
                     cpk.artifactId = toCompanionArtifactId(pub.artifactId)
                     cpk.version = pub.version
+                    cpk.maybeSetAlias(true)
                     cpk.pom { pom ->
                         val pubPom = pub.pom
 
@@ -127,6 +128,19 @@ class PublishAfterEvaluationHandler(rootProject: Project) : Action<Gradle> {
                     publish(project.tasks, pub, publicationProvider)
                 }
             }
+    }
+
+    /**
+     * The [setAlias][org.gradle.api.publish.maven.internal.publication.MavenPublicationInternal.setAlias]
+     * method belongs to Gradle's internal API, and so we cannot rely on it existing. We therefore try to
+     * invoke it using reflection.
+     */
+    private fun MavenPublication.maybeSetAlias(alias: Boolean) {
+        try {
+            this::class.java.getMethod("setAlias", Boolean::class.javaPrimitiveType).invoke(this, alias)
+        } catch (e: Exception) {
+            logger.warn("INTERNAL API: Cannot set alias for MavenPublication[$name]", e)
+        }
     }
 
     /**

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithPlatformTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithPlatformTest.kt
@@ -1,6 +1,7 @@
 package net.corda.plugins.cpk
 
 import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -39,6 +40,7 @@ class CordappWithPlatformTest {
         publisherProject = GradleProject(publisherProjectDir, reporter)
             .withTestName("publish-platform")
             .withTaskName("publishAllPublicationsToTestRepository")
+            .withTaskOutcome(UP_TO_DATE)
             .build(
                 "-Pcorda_api_version=$cordaApiVersion",
                 "-Prepository_dir=$repositoryDir"

--- a/cordapp-cpk/src/test/resources/corda-api/build.gradle
+++ b/cordapp-cpk/src/test/resources/corda-api/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
     id 'biz.aQute.bnd.builder'
     id 'java-library'
+    id 'maven-publish'
 }
 apply from: '../javaTarget.gradle'
 apply from: '../kotlin.gradle'
@@ -34,5 +35,17 @@ tasks.named('jar', Jar) {
 Bundle-SymbolicName: net.corda.api
 Bundle-Name: Fake Corda APIs
 '''
+    }
+}
+
+publishing {
+    publications {
+        cordaApi(MavenPublication) {
+            from components.kotlin
+
+            pom {
+                name = 'Corda API'
+            }
+        }
     }
 }

--- a/cordapp-cpk/src/test/resources/corda-platform/build.gradle
+++ b/cordapp-cpk/src/test/resources/corda-platform/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java-platform'
+    id 'maven-publish'
 }
 
 group = 'net.corda'
@@ -19,6 +20,18 @@ rootProject.allprojects {
         pluginManager.withPlugin('java-library') {
             dependencies {
                 api platform(project(':corda-platform'))
+            }
+        }
+    }
+}
+
+publishing {
+    publications {
+        cordaPlatform(MavenPublication) {
+            from components.javaPlatform
+
+            pom {
+                name = 'Corda Platform'
             }
         }
     }

--- a/cordapp-cpk/src/test/resources/external-cordapp/build.gradle
+++ b/cordapp-cpk/src/test/resources/external-cordapp/build.gradle
@@ -25,16 +25,11 @@ allprojects {
                 url = maven_repository_dir
             }
         }
-        publications {
-            maven(MavenPublication) {
-                pluginManager.withPlugin('java-platform') {
-                    from components.javaPlatform
-                }
-                pluginManager.withPlugin('java') {
-                    from components.java
-                }
-                pluginManager.withPlugin('net.corda.plugins.cordapp-cpk') {
-                    artifact tasks.named('cpk', Jar)
+
+        pluginManager.withPlugin('net.corda.plugins.cordapp-cpk') {
+            publications {
+                maven(MavenPublication) {
+                    from components.cordapp
                 }
             }
         }

--- a/cordapp-cpk/src/test/resources/hash-selection/cordapp/build.gradle
+++ b/cordapp-cpk/src/test/resources/hash-selection/cordapp/build.gradle
@@ -50,39 +50,34 @@ allprojects {
                 }
             }
 
-            publications {
-                maven(MavenPublication) {
-                    pluginManager.withPlugin('java') {
-                        from components.java
-                    }
+            pluginManager.withPlugin('net.corda.plugins.cordapp-cpk') {
+                publications {
+                    maven(MavenPublication) {
+                        from components.cordapp
 
-                    // Publish any CPK that this project may have.
-                    pluginManager.withPlugin('net.corda.plugins.cordapp-cpk') {
-                        artifact tasks.named('cpk', Jar)
-                    }
-
-                    pom {
-                        name = 'Hash Selection CorDapp'
-                        url = 'https://com.example.cordapp'
-                        scm {
+                        pom {
+                            name = 'Hash Selection CorDapp'
                             url = 'https://com.example.cordapp'
-                        }
-                        organization {
-                            name = 'Example-Name'
-                            url = 'https://example.com'
-                        }
-                        licenses {
-                            license {
-                                name = 'Apache-2.0'
-                                url = 'https://www.apache.org/licenses/LICENSE-2.0'
-                                distribution = 'repo'
+                            scm {
+                                url = 'https://com.example.cordapp'
                             }
-                        }
-                        developers {
-                            developer {
-                                id = 'Example-Id'
+                            organization {
                                 name = 'Example-Name'
-                                email = 'dev@example.com'
+                                url = 'https://example.com'
+                            }
+                            licenses {
+                                license {
+                                    name = 'Apache-2.0'
+                                    url = 'https://www.apache.org/licenses/LICENSE-2.0'
+                                    distribution = 'repo'
+                                }
+                            }
+                            developers {
+                                developer {
+                                    id = 'Example-Id'
+                                    name = 'Example-Name'
+                                    email = 'dev@example.com'
+                                }
                             }
                         }
                     }

--- a/cordapp-cpk/src/test/resources/publish-platform/build.gradle
+++ b/cordapp-cpk/src/test/resources/publish-platform/build.gradle
@@ -1,6 +1,3 @@
-apply from: 'repositories.gradle'
-apply from: 'javaTarget.gradle'
-
 group = 'com.example'
 
 allprojects {
@@ -18,23 +15,6 @@ allprojects {
                 maven {
                     name = 'Test'
                     url = repository_dir
-                }
-            }
-
-            publications {
-                maven(MavenPublication) {
-                    pluginManager.withPlugin('java-platform') {
-                        from components.javaPlatform
-                    }
-
-                    pluginManager.withPlugin('java') {
-                        from components.java
-                    }
-
-                    // Publish any CPK that this project may have.
-                    pluginManager.withPlugin('net.corda.plugins.cordapp-cpk') {
-                        artifact tasks.named('cpk', Jar)
-                    }
                 }
             }
         }

--- a/cordapp-cpk/src/test/resources/transitive-cordapps/build.gradle
+++ b/cordapp-cpk/src/test/resources/transitive-cordapps/build.gradle
@@ -25,43 +25,34 @@ allprojects {
                 }
             }
 
-            publications {
-                maven(MavenPublication) {
-                    pluginManager.withPlugin('java-platform') {
-                        from components.javaPlatform
-                    }
+            pluginManager.withPlugin('net.corda.plugins.cordapp-cpk') {
+                publications {
+                    maven(MavenPublication) {
+                        from components.cordapp
 
-                    pluginManager.withPlugin('java') {
-                        from components.java
-                    }
-
-                    // Publish any CPK that this project may have.
-                    pluginManager.withPlugin('net.corda.plugins.cordapp-cpk') {
-                        artifact tasks.named('cpk', Jar)
-                    }
-
-                    pom {
-                        name = 'Transitive CorDapps'
-                        url = 'https://com.example.cordapp'
-                        scm {
+                        pom {
+                            name = 'Transitive CorDapps'
                             url = 'https://com.example.cordapp'
-                        }
-                        organization {
-                            name = 'Example-Name'
-                            url = 'https://example.com'
-                        }
-                        licenses {
-                            license {
-                                name = 'Apache-2.0'
-                                url = 'https://www.apache.org/licenses/LICENSE-2.0'
-                                distribution = 'repo'
+                            scm {
+                                url = 'https://com.example.cordapp'
                             }
-                        }
-                        developers {
-                            developer {
-                                id = 'Example-Id'
+                            organization {
                                 name = 'Example-Name'
-                                email = 'dev@example.com'
+                                url = 'https://example.com'
+                            }
+                            licenses {
+                                license {
+                                    name = 'Apache-2.0'
+                                    url = 'https://www.apache.org/licenses/LICENSE-2.0'
+                                    distribution = 'repo'
+                                }
+                            }
+                            developers {
+                                developer {
+                                    id = 'Example-Id'
+                                    name = 'Example-Name'
+                                    email = 'dev@example.com'
+                                }
                             }
                         }
                     }

--- a/cordapp-cpk/src/test/resources/without-transitive-cordapps/build.gradle
+++ b/cordapp-cpk/src/test/resources/without-transitive-cordapps/build.gradle
@@ -24,19 +24,10 @@ allprojects {
             }
         }
 
-        publications {
-            maven(MavenPublication) {
-                pluginManager.withPlugin('java-library') {
-                    from components.java
-                }
-
-                pluginManager.withPlugin('java-platform') {
-                    from components.javaPlatform
-                }
-
-                // Publish any CPK that this project may have.
-                pluginManager.withPlugin('net.corda.plugins.cordapp-cpk') {
-                    artifact tasks.named('cpk', Jar)
+        pluginManager.withPlugin('net.corda.plugins.cordapp-cpk') {
+            publications {
+                maven(MavenPublication) {
+                    from components.cordapp
                 }
             }
         }


### PR DESCRIPTION
Create a new `SoftwareComponent` called "cordapp" for publishing the CPK artifacts. This simplifies how to declare the contents of the `MavenPublication`, i.e.
```groovy
publishing {
    publications {
        maven(MavenPublication) {
            from components.cordapp
        }
    }
}
```