### PR TITLE
CORE-4781: Update cordapp-cpk to add explicit compileOnly dependency for osgi.annotation.

### DIFF
--- a/cordapp-cpk/README.md
+++ b/cordapp-cpk/README.md
@@ -241,7 +241,7 @@ enabled to ensure that every `Import-Package` element has an associated version 
 The `cordapp-cpk` plugin automatically adds these dependencies to the CorDapp:
 ```groovy
 compileOnly "biz.aQute.bnd:biz.aQute.bnd.annotation:$bndVersion"
-compileOnly "org.osgi:osgi.annotation:8.0.0"
+compileOnly "org.osgi:osgi.annotation:8.1.0"
 ```
 
 These annotations [control how Bnd will generate OSGi metadata](https://bnd.bndtools.org/chapters/230-manifest-annotations.html)

--- a/cordapp-cpk/build.gradle
+++ b/cordapp-cpk/build.gradle
@@ -102,6 +102,15 @@ tasks.named('javadoc', Javadoc) {
     enabled = false
 }
 
+processResources {
+    filesMatching('**/cordapp-cpk.properties') {
+        expand([
+            'osgi_version': osgi_version,
+            'bnd_version': bnd_version
+        ])
+    }
+}
+
 processTestResources {
     filesMatching('gradle.properties') {
         expand([

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappExtension.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappExtension.kt
@@ -28,6 +28,7 @@ fun TaskInputs.nested(nestName: String, cordapp: CordappExtension) {
 open class CordappExtension @Inject constructor(
     objects: ObjectFactory,
     providers: ProviderFactory,
+    osgiVersion: String,
     bndVersion: String
 ) {
     /**
@@ -68,6 +69,9 @@ open class CordappExtension @Inject constructor(
 
     @get:Input
     val bndVersion: Property<String> = objects.property(String::class.java).convention(bndVersion)
+
+    @get:Input
+    val osgiVersion: Property<String> = objects.property(String::class.java).convention(osgiVersion)
 
     /**
      * This property only provides the default value for [CPKDependenciesTask.hashAlgorithm]

--- a/cordapp-cpk/src/main/resources/net/corda/plugins/cpk/cordapp-cpk.properties
+++ b/cordapp-cpk/src/main/resources/net/corda/plugins/cpk/cordapp-cpk.properties
@@ -1,0 +1,2 @@
+osgiVersion=$osgi_version
+bndVersion=$bnd_version

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ hamcrest_version=2.2
 asm_version=9.2
 slf4j_version=1.7.36
 javax_annotations_version=1.3.2
-osgi_version=8.0.0
+osgi_version=8.1.0
 bnd_version=6.2.0
 
 artifactory_version=4.21.0


### PR DESCRIPTION
Add `osgi.annotation` as an explicit `compileOnly` dependency rather than relying on Bnd to introduce it as a transitive dependency of `biz.aQute.bnd.annotation`. Also update the `cordapp` extension so that we can choose the version of `osgi.annotation` to use.  (Defaults to `8.1.0`, to match the transitive dependency of `biz.aQute.bnd.annotation:6.2.0`.)