### PR TITLE
NOTICK: Refactor how we create Corda's configurations, hopefully for clarity.

### DIFF
--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappPlugin.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappPlugin.kt
@@ -25,6 +25,7 @@ import org.gradle.api.plugins.JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME
 import org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME
 import org.gradle.api.plugins.JavaPlugin.JAR_TASK_NAME
 import org.gradle.api.plugins.JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME
+import org.gradle.api.plugins.JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME
@@ -128,7 +129,10 @@ class CordappPlugin @Inject constructor(
             project.components.add(component)
 
             // This definition of cordaRuntimeOnly must be kept aligned with the one in the quasar-utils plugin.
-            createRuntimeOnlyConfiguration(CORDA_RUNTIME_ONLY_CONFIGURATION_NAME)
+            val cordaRuntimeOnly = createBasicConfiguration(CORDA_RUNTIME_ONLY_CONFIGURATION_NAME)
+                .setDescription("Runtime-only dependencies which do not belong to this CorDapp.")
+                .setTransitive(false)
+            getByName(RUNTIME_ONLY_CONFIGURATION_NAME).extendsFrom(cordaRuntimeOnly)
 
             getByName(COMPILE_ONLY_CONFIGURATION_NAME).withDependencies { dependencies ->
                 val bndDependency = project.dependencies.create("biz.aQute.bnd:biz.aQute.bnd.annotation:" + cordapp.bndVersion.get())

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappUtils.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappUtils.kt
@@ -11,7 +11,6 @@ import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.artifacts.ResolvedConfiguration
 import org.gradle.api.artifacts.ResolvedDependency
 import org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME
-import org.gradle.api.plugins.JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME
 import org.gradle.api.specs.Spec
 import org.w3c.dom.Document
 import org.w3c.dom.Element
@@ -100,19 +99,13 @@ fun Dependency.toMaven(): String {
     return builder.toString()
 }
 
-private fun ConfigurationContainer.createChildConfiguration(name: String, parent: Configuration): Configuration {
+fun ConfigurationContainer.createBasicConfiguration(name: String): Configuration {
     return maybeCreate(name)
-        .setTransitive(false)
         .setVisible(false)
         .also { configuration ->
             configuration.isCanBeConsumed = false
             configuration.isCanBeResolved = false
-            parent.extendsFrom(configuration)
         }
-}
-
-fun ConfigurationContainer.createRuntimeOnlyConfiguration(name: String): Configuration {
-    return createChildConfiguration(name, getByName(RUNTIME_ONLY_CONFIGURATION_NAME))
 }
 
 /**
@@ -125,16 +118,12 @@ fun ConfigurationContainer.createCompileConfiguration(name: String): Configurati
 }
 
 private fun ConfigurationContainer.createCompileConfiguration(name: String, testSuffix: String): Configuration {
-    return maybeCreate(name)
-        .setVisible(false)
-        .also { configuration ->
-            configuration.isCanBeConsumed = false
-            configuration.isCanBeResolved = false
-            getByName(COMPILE_ONLY_CONFIGURATION_NAME).extendsFrom(configuration)
-            matching { it.name.endsWith(testSuffix) }.configureEach { cfg ->
-                cfg.extendsFrom(configuration)
-            }
+    return createBasicConfiguration(name).also { configuration ->
+        getByName(COMPILE_ONLY_CONFIGURATION_NAME).extendsFrom(configuration)
+        matching { it.name.endsWith(testSuffix) }.configureEach { cfg ->
+            cfg.extendsFrom(configuration)
         }
+    }
 }
 
 /**

--- a/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarExtension.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarExtension.groovy
@@ -1,5 +1,6 @@
 package net.corda.plugins.quasar
 
+import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
@@ -9,6 +10,7 @@ import javax.inject.Inject
 
 import static net.corda.plugins.quasar.QuasarPlugin.QUASAR_ARTIFACT_NAME
 
+@CompileStatic
 class QuasarExtension {
 
     /**
@@ -70,13 +72,13 @@ class QuasarExtension {
         String defaultGroup,
         String defaultVersion,
         String defaultSuspendable,
-        Iterable<? extends String> initialPackageExclusions,
-        Iterable<? extends String> initialClassLoaderExclusions
+        Iterable<String> initialPackageExclusions,
+        Iterable<String> initialClassLoaderExclusions
     ) {
         group = objects.property(String).convention(defaultGroup)
         version = objects.property(String).convention(defaultVersion)
         dependency = group.zip(version) { grp, ver ->
-            [ group: grp, name: QUASAR_ARTIFACT_NAME, version: ver, ext: 'jar' ]
+            [ group: grp, name: QUASAR_ARTIFACT_NAME, version: ver, ext: 'jar' ] as Map<String, String>
         }
         agent = dependency.map {
             it['classifier'] = 'agent'
@@ -92,12 +94,12 @@ class QuasarExtension {
         excludePackages.set(initialPackageExclusions)
         excludeClassLoaders = objects.listProperty(String)
         excludeClassLoaders.set(initialClassLoaderExclusions)
-        options = excludePackages.flatMap { packages ->
-            excludeClassLoaders.flatMap { classLoaders ->
+        options = excludePackages.flatMap { List<String> packages ->
+            excludeClassLoaders.flatMap { List<String> classLoaders ->
                 debug.flatMap { isDebug ->
                     verbose.flatMap { isVerbose ->
                         suspendableAnnotation.orElse('').map { ann ->
-                            def builder = new StringBuilder('=')
+                            final def builder = new StringBuilder('=')
                             if (isDebug) {
                                 builder.append('d')
                             }

--- a/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarPlugin.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarPlugin.groovy
@@ -1,5 +1,6 @@
 package net.corda.plugins.quasar
 
+import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 import org.gradle.api.Action
 import org.gradle.api.GradleException
@@ -10,6 +11,7 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.DependencySet
+import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.logging.Logger
 import org.gradle.api.model.ObjectFactory
@@ -26,6 +28,7 @@ import static org.gradle.api.plugins.JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME
 /**
  * QuasarPlugin creates "quasar" and "quasarAgent" configurations and adds Quasar as a dependency.
  */
+@CompileStatic
 class QuasarPlugin implements Plugin<Project> {
 
     private static final String QUASAR = 'quasar'
@@ -71,89 +74,85 @@ class QuasarPlugin implements Plugin<Project> {
     }
 
     private void addQuasarDependencies(Project project, QuasarAdapter adapter) {
-        def quasar = project.configurations.create(QUASAR)
-        quasar.visible = false
-        quasar.withDependencies { dependencies ->
-            def quasarDependency = adapter.createDependency { dep ->
-                dep.transitive = false
+        def configurations = project.configurations
+        configurations.create(QUASAR)
+            .setVisible(false)
+            .withDependencies { dependencies ->
+                def quasarDependency = adapter.createDependency { ModuleDependency dep ->
+                    dep.transitive = false
+                }
+                dependencies.add(quasarDependency)
             }
-            dependencies.add(quasarDependency)
-        }
 
-        def quasarAgent = project.configurations.create(QUASAR_AGENT)
-        quasarAgent.visible = false
-        quasarAgent.withDependencies { dependencies ->
-            def quasarAgentDependency = adapter.createAgent { dep ->
-                dep.transitive = false
+        configurations.create(QUASAR_AGENT)
+            .setVisible(false)
+            .withDependencies { dependencies ->
+                def quasarAgentDependency = adapter.createAgent { ModuleDependency dep ->
+                    dep.transitive = false
+                }
+                dependencies.add(quasarAgentDependency)
             }
-            dependencies.add(quasarAgentDependency)
-        }
 
-        // If we're building a JAR then also add the Quasar bundle to the appropriate configurations.
-        project.pluginManager.withPlugin('java') {
-            // Add Quasar bundle to the compile classpath WITHOUT any of its transitive dependencies.
-            // This definition of cordaProvided must be kept aligned with the one in the corda-cpk plugin.
-            def cordaProvided = createCompileConfiguration(CORDA_PROVIDED_CONFIGURATION_NAME, project.configurations)
-            cordaProvided.withDependencies(new QuasarAction(adapter, false))
-
+        // This definition of cordaRuntimeOnly must be consistent with the one in the cordapp-cpk plugin.
+        def cordaRuntimeOnly = createBasicConfiguration(CORDA_RUNTIME_ONLY_CONFIGURATION_NAME, configurations)
             // Instrumented code needs both the Quasar bundle and its transitive dependencies at runtime.
-            // The definition of cordaRuntimeOnly must be kept aligned with the one in the corda-cpk plugin.
-            def cordaRuntimeOnly = createRuntimeOnlyConfiguration(CORDA_RUNTIME_ONLY_CONFIGURATION_NAME, project.configurations)
-            cordaRuntimeOnly.withDependencies(new QuasarAction(adapter, true))
+            .withDependencies(new QuasarAction(adapter, true))
+            .setTransitive(false)
+
+        // This definition of cordaProvided must be consistent with the one in the cordapp-cpk plugin.
+        def cordaProvided = createBasicConfiguration(CORDA_PROVIDED_CONFIGURATION_NAME, configurations)
+            // Add Quasar bundle WITHOUT any of its transitive dependencies.
+            .withDependencies(new QuasarAction(adapter, false))
+
+        // If we're building a JAR then also add the Quasar bundle to the appropriate Java configurations.
+        // This is also consistent with the cordapp-cpk plugin, which applies the 'java' plugin too.
+        project.pluginManager.withPlugin('java') {
+            // Adds the Quasar bundle to the compileClasspath WITHOUT its transitive dependencies.
+            configurations[COMPILE_ONLY_CONFIGURATION_NAME].extendsFrom(cordaProvided)
+
+            // These are "testing" configurations, e.g. 'testImplementation'.
+            configurations.matching { Configuration cfg -> cfg.name.endsWith('Implementation') }.configureEach { cfg ->
+                cfg.extendsFrom(cordaProvided)
+            }
+
+            // Adds the Quasar bundle to the runtimeClasspath WITH its transitive dependencies.
+            configurations[RUNTIME_ONLY_CONFIGURATION_NAME].extendsFrom(cordaRuntimeOnly)
         }
     }
 
     private void configureQuasarTasks(Project project, QuasarAdapter adapter) {
         def quasarAgent = project.configurations[QUASAR_AGENT]
-        project.tasks.withType(Test).configureEach {
-            doFirst {
+        project.tasks.withType(Test).configureEach { Test task ->
+            task.doFirst { Test t ->
                 if (adapter.instrumentingTests) {
                     if (adapter.withoutSuspendableAnnotation) {
                         adapter.warnNoSuspendableAnnotation()
                     }
 
-                    jvmArgs "-javaagent:${quasarAgent.singleFile}${adapter.options}",
+                    t.jvmArgs "-javaagent:${quasarAgent.singleFile}${adapter.options}",
                             "-Dco.paralleluniverse.fibers.verifyInstrumentation"
                 }
             }
         }
-        project.tasks.withType(JavaExec).configureEach {
-            doFirst {
+        project.tasks.withType(JavaExec).configureEach { JavaExec task ->
+            task.doFirst { JavaExec je ->
                 if (adapter.instrumentingJavaExec) {
                     if (adapter.withoutSuspendableAnnotation) {
                         adapter.warnNoSuspendableAnnotation()
                     }
 
-                    jvmArgs "-javaagent:${quasarAgent.singleFile}${adapter.options}",
+                    je.jvmArgs "-javaagent:${quasarAgent.singleFile}${adapter.options}",
                             "-Dco.paralleluniverse.fibers.verifyInstrumentation"
                 }
             }
         }
     }
 
-    private static Configuration createRuntimeOnlyConfiguration(String name, ConfigurationContainer configurations) {
-        Configuration configuration = configurations.maybeCreate(name)
-            .setTransitive(false)
-            .setVisible(false)
-        configuration.canBeConsumed = false
-        configuration.canBeResolved = false
-        configurations.getByName(RUNTIME_ONLY_CONFIGURATION_NAME).extendsFrom(configuration)
-        return configuration
-    }
-
-    private static Configuration createCompileConfiguration(String name, ConfigurationContainer configurations) {
-        return createCompileConfiguration(name, "Implementation", configurations)
-    }
-
-    private static Configuration createCompileConfiguration(String name, String testSuffix, ConfigurationContainer configurations) {
+    private static Configuration createBasicConfiguration(String name, ConfigurationContainer configurations) {
         Configuration configuration = configurations.maybeCreate(name)
             .setVisible(false)
         configuration.canBeConsumed = false
         configuration.canBeResolved = false
-        configurations.getByName(COMPILE_ONLY_CONFIGURATION_NAME).extendsFrom(configuration)
-        configurations.matching { it.name.endsWith(testSuffix) }.configureEach { cfg ->
-            cfg.extendsFrom(configuration)
-        }
         return configuration
     }
 
@@ -161,6 +160,7 @@ class QuasarPlugin implements Plugin<Project> {
      * Define operations to perform using {@link QuasarExtension}
      * once Gradle's configuration phase is complete.
      */
+    @CompileStatic
     private static final class QuasarAdapter {
         private final AtomicBoolean warnFlag
         private final QuasarExtension quasar
@@ -213,6 +213,7 @@ Adding ${QUASAR_ARTIFACT_NAME} to the classpath, to make Quasar's built-in @Susp
         }
     }
 
+    @CompileStatic
     private static final class QuasarAction implements Action<DependencySet> {
         private final QuasarAdapter adapter
         private final boolean isTransitive
@@ -227,7 +228,7 @@ Adding ${QUASAR_ARTIFACT_NAME} to the classpath, to make Quasar's built-in @Susp
         void execute(DependencySet dependencies) {
             if (adapter.withoutSuspendableAnnotation) {
                 adapter.warnNoSuspendableAnnotation()
-                def quasarDependency = adapter.createDependency { dep ->
+                def quasarDependency = adapter.createDependency { ModuleDependency dep ->
                     dep.transitive = isTransitive
                 }
                 dependencies.add(quasarDependency)

--- a/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarPlugin.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarPlugin.groovy
@@ -20,8 +20,10 @@ import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.testing.Test
 import org.gradle.util.GradleVersion
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.stream.StreamSupport
 import javax.inject.Inject
 
+import static java.util.stream.Collectors.toList
 import static org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME
 import static org.gradle.api.plugins.JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME
 
@@ -66,7 +68,10 @@ class QuasarPlugin implements Plugin<Project> {
             throw new InvalidUserDataException("quasar_classloader_exclusions property must be an Iterable<String>")
         }
         def quasarExtension = project.extensions.create(QUASAR, QuasarExtension, objects,
-            quasarGroup, quasarVersion, quasarSuspendable, quasarPackageExclusions, quasarClassLoaderExclusions)
+            quasarGroup, quasarVersion, quasarSuspendable,
+            toStrings(quasarPackageExclusions as Iterable<?>),
+            toStrings(quasarClassLoaderExclusions as Iterable<?>)
+        )
 
         QuasarAdapter quasarAdapter = new QuasarAdapter(quasarExtension, project.dependencies, project.logger)
         addQuasarDependencies(project, quasarAdapter)
@@ -154,6 +159,12 @@ class QuasarPlugin implements Plugin<Project> {
         configuration.canBeConsumed = false
         configuration.canBeResolved = false
         return configuration
+    }
+
+    private static List<String> toStrings(Iterable<?> items) {
+        return StreamSupport.stream(items.spliterator(), false)
+            .map { it?.toString()?.trim() }
+            .collect(toList())
     }
 
     /**


### PR DESCRIPTION
The `quasar-utils` plugin will now always create the `cordaProvided` and `cordaRuntimeOnly` configurations, and will adjust their definitions appropriately if/when the `java` plugin is also applied. This brings the plugin's behaviour more into line with its 5.1.0-SNAPSHOT version.

Also simplify how the `cordapp-cpk` plugin creates its `cordaRuntimeOnly` configuration, so that the code is more obviously the same, and ensure that Quasar's "exclusions" parameters are all genuine `String` objects.