### PR TITLE
NOTICK: Upgrade Gradle publish plugin and commons-compress.

### DIFF
--- a/cordformation/build.gradle
+++ b/cordformation/build.gradle
@@ -23,6 +23,14 @@ repositories {
 
 configurations {
     noderunner
+
+    all {
+        resolutionStrategy {
+            dependencySubstitution {
+                substitute module('commons-logging:commons-logging') with module("org.slf4j:jcl-over-slf4j:$slf4j_version")
+            }
+        }
+    }
 }
 
 /**
@@ -76,11 +84,26 @@ pluginBundle {
 }
 
 dependencies {
+    constraints {
+        implementation "org.slf4j:slf4j-api:$slf4j_version"
+        implementation('org.apache.commons:commons-compress:1.21') {
+            because 'CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090'
+        }
+        testRuntimeOnly('org.apache.logging.log4j:log4j-core:2.17.2') {
+            because 'CVE-2021-44228, CVE-2021-45046, CVE-2021-45105, CVE-2021-44832'
+        }
+    }
+
     // Gradle plugins written in Kotlin will always use Gradle's
     // own provided Kotlin libraries at runtime. So ensure that
     // we don't add Kotlin as a dependency in our published POM.
     compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation "com.typesafe:config:$typesafe_config_version"
+
+    // Docker-compose file generation
+    implementation "org.yaml:snakeyaml:$snake_yaml_version"
+    // DockerFile Generation
+    implementation "com.spotify:docker-client:$docker_client_version"
 
     noderunner "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
@@ -92,10 +115,6 @@ dependencies {
     testImplementation "org.assertj:assertj-core:$assertj_version"
     testImplementation "net.corda:corda-serialization:$corda_release_version"
     testRuntimeOnly "net.corda:corda-node-api:$corda_release_version"
-    // Docker-compose file generation
-    implementation "org.yaml:snakeyaml:$snake_yaml_version"
-    //DockerFile Generation
-    implementation "com.spotify:docker-client:$docker_client_version"
 }
 
 tasks.named('validateTaskProperties', ValidateTaskProperties) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,15 +9,16 @@ kotlin_version=1.3.41
 dokka_version=1.4.32
 snake_yaml_version=1.29
 commons_io_version=2.11.0
-assertj_version=3.16.1
-junit_jupiter_version=5.8.1
+assertj_version=3.22.0
+junit_jupiter_version=5.8.2
 hamcrest_version=2.1
 asm_version=9.0
 docker_client_version=8.15.1
+slf4j_version=1.7.36
 javax_annotations_version=1.3.2
 
 bintray_version=1.8.5
 artifactory_version=4.21.0
-gradle_publish_version=0.16.0
+gradle_publish_version=0.21.0
 
 artifactory_contextUrl=https://software.r3.com/artifactory


### PR DESCRIPTION
Perform the following upgrades:
- Gradle publish-plugin 0.16.0 -> 0.21.0
- commons-compress -> 1.21
- JUnit 5.8.1 -> 5.8.2
- AssertJ 3.16.1 -> 3.22.0