### PR TITLE
NOTICK: Replace commons-logging with jcl-over-slf4j for Docker client.

### DIFF
--- a/cordformation/build.gradle
+++ b/cordformation/build.gradle
@@ -23,14 +23,6 @@ repositories {
 
 configurations {
     noderunner
-
-    all {
-        resolutionStrategy {
-            dependencySubstitution {
-                substitute module('commons-logging:commons-logging') with module("org.slf4j:jcl-over-slf4j:$slf4j_version")
-            }
-        }
-    }
 }
 
 /**
@@ -103,7 +95,10 @@ dependencies {
     // Docker-compose file generation
     implementation "org.yaml:snakeyaml:$snake_yaml_version"
     // DockerFile Generation
-    implementation "com.spotify:docker-client:$docker_client_version"
+    implementation("com.spotify:docker-client:$docker_client_version") {
+        exclude group: 'commons-logging', module: 'commons-logging'
+    }
+    implementation "org.slf4j:jcl-over-slf4j:$slf4j_version"
 
     noderunner "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 


### PR DESCRIPTION
Replace Gradle's dependency substitution with an exclusion so that the change is also propagated to Cordformation's POM.