### PR TITLE
CORE-5068: Verify that every CPK library is also a bundle.

### DIFF
--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappPlugin.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/CordappPlugin.kt
@@ -56,6 +56,7 @@ class CordappPlugin @Inject constructor(
         private const val DEPENDENCY_CONSTRAINTS_TASK_NAME = "cordappDependencyConstraints"
         private const val DEPENDENCY_CALCULATOR_TASK_NAME = "cordappDependencyCalculator"
         private const val CPK_DEPENDENCIES_TASK_NAME = "cordappCPKDependencies"
+        private const val VERIFY_LIBRARIES_TASK_NAME = "verifyLibraries"
         private const val VERIFY_BUNDLE_TASK_NAME = "verifyBundle"
         private const val CORDAPP_COMPONENT_NAME = "cordapp"
         private const val CORDAPP_EXTENSION_NAME = "cordapp"
@@ -359,6 +360,13 @@ class CordappPlugin @Inject constructor(
         }
 
         /**
+         * Check that all of this CPK's libraries are actually bundles.
+         */
+        val verifyLibraries = project.tasks.register(VERIFY_LIBRARIES_TASK_NAME, VerifyLibraries::class.java) { verify ->
+            verify.setDependenciesFrom(calculatorTask)
+        }
+
+        /**
          * Ask Bnd to "sanity-check" this new bundle.
          */
         val verifyBundle = project.tasks.register(VERIFY_BUNDLE_TASK_NAME, VerifyBundle::class.java) { verify ->
@@ -369,6 +377,7 @@ class CordappPlugin @Inject constructor(
             project.gradle.taskGraph.whenReady(copyJarEnabledTo(verify))
         }
         jarTask.configure { jar ->
+            jar.dependsOn(verifyLibraries)
             jar.finalizedBy(verifyBundle)
         }
 

--- a/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/VerifyLibraries.kt
+++ b/cordapp-cpk/src/main/kotlin/net/corda/plugins/cpk/VerifyLibraries.kt
@@ -1,0 +1,69 @@
+package net.corda.plugins.cpk
+
+import java.io.File
+import java.util.jar.Attributes
+import java.util.jar.Attributes.Name
+import javax.inject.Inject
+import org.gradle.api.DefaultTask
+import org.gradle.api.InvalidUserDataException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.FileCollection
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity.RELATIVE
+import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
+import org.osgi.framework.Constants.BUNDLE_MANIFESTVERSION
+import org.osgi.framework.Constants.BUNDLE_SYMBOLICNAME
+import org.osgi.framework.Constants.BUNDLE_VERSION
+
+@Suppress("UnstableApiUsage", "MemberVisibilityCanBePrivate")
+open class VerifyLibraries @Inject constructor(objects: ObjectFactory) : DefaultTask() {
+    init {
+        description = "Verifies that a CPK's libraries are all bundles."
+        group = CORDAPP_TASK_GROUP
+    }
+
+    private val _libraries: ConfigurableFileCollection = objects.fileCollection()
+    val libraries: FileCollection
+        @PathSensitive(RELATIVE)
+        @SkipWhenEmpty
+        @InputFiles
+        get() = _libraries
+
+    /**
+     * Don't eagerly configure the [DependencyCalculator] task, even if
+     * someone eagerly configures this [VerifyLibraries] by accident.
+     */
+    internal fun setDependenciesFrom(task: TaskProvider<DependencyCalculator>) {
+        _libraries.setFrom(
+            /**
+             * These jars are the contents of this CPK's lib/ folder.
+             */
+            task.flatMap(DependencyCalculator::libraries)
+        )
+        _libraries.disallowChanges()
+        dependsOn(task)
+    }
+
+    @TaskAction
+    fun verify() {
+        for (library in libraries.files) {
+            with(library.manifest.mainAttributes) {
+                requireAttribute(BUNDLE_MANIFESTVERSION, library)
+                requireAttribute(BUNDLE_SYMBOLICNAME, library)
+                requireAttribute(BUNDLE_VERSION, library)
+            }
+        }
+    }
+
+    private fun Attributes.requireAttribute(attrName: String, library: File) {
+        if (!containsKey(Name(attrName))) {
+            logger.error("Library {} is not an OSGi bundle. Try declaring it as a 'cordaEmbedded' dependency instead.",
+                library.name)
+            throw InvalidUserDataException("Library ${library.name} has no $attrName attribute")
+        }
+    }
+}

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithNonBundleLibraryTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/CordappWithNonBundleLibraryTest.kt
@@ -1,0 +1,42 @@
+package net.corda.plugins.cpk
+
+import java.nio.file.Path
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.TaskOutcome.FAILED
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.junit.jupiter.api.TestReporter
+import org.junit.jupiter.api.io.TempDir
+
+@TestInstance(PER_CLASS)
+class CordappWithNonBundleLibraryTest {
+    private companion object {
+        private const val cordappVersion = "4.2.5-SNAPSHOT"
+        private const val slf4jVersion = "1.7.36"
+    }
+
+    private lateinit var testProject: GradleProject
+
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("cordapp-non-bundle-library")
+            .buildAndFail(
+                "-Pcommons_collections_version=$commonsCollectionsVersion",
+                "-Pcommons_io_version=$commonsIoVersion",
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcordapp_version=$cordappVersion",
+                "-Pslf4j_version=$slf4jVersion"
+            )
+    }
+
+    @Test
+    fun testLibraryIsRejected() {
+        assertThat(testProject.outcomeOf("verifyLibraries")).isEqualTo(FAILED)
+        assertThat(testProject.outputLines).anyMatch { line ->
+            line.startsWith("Library embeddable-library.jar is not an OSGi bundle.")
+        }
+    }
+}

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/GradleProject.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/GradleProject.kt
@@ -221,6 +221,9 @@ class GradleProject(private val projectDir: Path, private val reporter: TestRepo
     var output: String = ""
         private set
 
+    val outputLines: List<String>
+        get() = output.split(System.lineSeparator())
+
     fun resultFor(taskName: String): BuildTask {
         return result.task(":$taskName") ?: fail("No outcome for $taskName task")
     }

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/SimpleCordappTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/SimpleCordappTest.kt
@@ -90,7 +90,7 @@ class SimpleCordappTest {
 
     @Test
     fun `test signing passwords are not logged`() {
-        assertThat(testProject.output.split(System.lineSeparator())).anyMatch { line ->
+        assertThat(testProject.outputLines).anyMatch { line ->
             line.startsWith(SIGNING_TAG)
         }.noneMatch { line ->
             line.startsWith(SIGNING_TAG)

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/SimpleKotlinCordappTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/SimpleKotlinCordappTest.kt
@@ -94,11 +94,15 @@ class SimpleKotlinCordappTest {
                 "com.example.contract;uses:=\"kotlin,net.corda.v5.ledger.contracts,net.corda.v5.ledger.transactions\";$cordappOsgiVersion",
                 "com.example.contract.states;uses:=\"kotlin,net.corda.v5.application.identity,net.corda.v5.ledger.contracts\";$cordappOsgiVersion"
             )
+            assertThatHeader(getValue("Private-Package")).containsAll(
+                "com.google.errorprone.annotations;",
+                "com.google.errorprone.annotations.concurrent;",
+                "com.google.j2objc.annotations;"
+            )
             assertEquals("osgi.ee;filter:=\"(&(osgi.ee=JavaSE)(version=11))\"", getValue(REQUIRE_CAPABILITY))
             assertEquals("Test-Licence", getValue(BUNDLE_LICENSE))
             assertEquals("R3", getValue(BUNDLE_VENDOR))
             assertEquals("true", getValue("Sealed"))
-            assertNull(getValue("Private-Package"))
         }
     }
 }

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/TransitiveRemoteCordappsTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/TransitiveRemoteCordappsTest.kt
@@ -71,7 +71,7 @@ class TransitiveRemoteCordappsTest {
             )
 
         // Check that we could still read all of Gradle's MavenPom properties.
-        assertThat(publisherProject.output.split(System.lineSeparator()))
+        assertThat(publisherProject.outputLines)
             .noneMatch { it.startsWith("INTERNAL API:") }
 
         testProject = GradleProject(testProjectDir, reporter)

--- a/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithDependentCordappTest.kt
+++ b/cordapp-cpk/src/test/kotlin/net/corda/plugins/cpk/WithDependentCordappTest.kt
@@ -59,7 +59,7 @@ class WithDependentCordappTest {
         assertEquals(CORDA_GUAVA_VERSION, testProject.properties.getProperty("corda_guava_version"))
         assertNotEquals(cordaSlf4jVersion, librarySlf4jVersion)
 
-        assertThat(testProject.output.split(System.lineSeparator()))
+        assertThat(testProject.outputLines)
             .contains("COMPILE-WORKFLOW> biz.aQute.bnd.annotation-${bndVersion}.jar")
             .contains("COMPILE-WORKFLOW> guava-${guavaVersion}.jar")
             .contains("COMPILE-WORKFLOW> cordapp.jar")

--- a/cordapp-cpk/src/test/resources/cordapp-api-library/cordapp/build.gradle
+++ b/cordapp-cpk/src/test/resources/cordapp-api-library/cordapp/build.gradle
@@ -26,4 +26,7 @@ tasks.named('jar', Jar) {
 dependencies {
     cordaProvided project(':corda-api')
     api "com.google.guava:guava:$contract_guava_version"
+    cordaEmbedded 'com.google.errorprone:error_prone_annotations'
+    cordaEmbedded 'com.google.j2objc:j2objc-annotations'
+    cordaEmbedded 'com.google.guava:listenablefuture'
 }

--- a/cordapp-cpk/src/test/resources/cordapp-non-bundle-library/build.gradle
+++ b/cordapp-cpk/src/test/resources/cordapp-non-bundle-library/build.gradle
@@ -10,9 +10,10 @@ version = cordapp_version
 
 cordapp {
     targetPlatformVersion = platform_version.toInteger()
+    minimumPlatformVersion = platform_version.toInteger()
 
     contract {
-        name = 'CorDapp With Guava'
+        name = 'CorDapp Non-Bundle Library'
         versionId = cordapp_contract_version.toInteger()
         licence = 'Test-Licence'
         vendor = 'R3'
@@ -20,13 +21,9 @@ cordapp {
 }
 
 dependencies {
-    cordaProvided project(':corda-api')
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
-    implementation("com.google.guava:guava:$guava_version") {
-        transitive = false
-    }
+    implementation project(':embeddable-library')
 }
 
-tasks.named('jar', Jar) {
-    archiveBaseName = 'cordapp-with-guava'
+jar {
+    archiveBaseName = 'cordapp-non-bundle-library'
 }

--- a/cordapp-cpk/src/test/resources/cordapp-non-bundle-library/settings.gradle
+++ b/cordapp-cpk/src/test/resources/cordapp-non-bundle-library/settings.gradle
@@ -1,0 +1,4 @@
+rootProject.name = 'cordapp-non-bundle-library'
+
+include 'embeddable-library'
+project(':embeddable-library').projectDir = file('../resources/test/embeddable-library')

--- a/cordapp-cpk/src/test/resources/simple-kotlin-cordapp/build.gradle
+++ b/cordapp-cpk/src/test/resources/simple-kotlin-cordapp/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
     implementation "commons-io:commons-io:$commons_io_version"
     implementation "com.google.guava:guava:$guava_version"
+    cordaEmbedded 'com.google.errorprone:error_prone_annotations'
+    cordaEmbedded 'com.google.j2objc:j2objc-annotations'
+    cordaEmbedded 'com.google.guava:listenablefuture'
 }
 
 jar {

--- a/cordapp-cpk/src/test/resources/with-dependent-cordapp/build.gradle
+++ b/cordapp-cpk/src/test/resources/with-dependent-cordapp/build.gradle
@@ -36,7 +36,9 @@ jar {
 dependencies {
     cordapp project(':cordapp')
     cordaProvided project(':corda-api')
-    implementation "com.google.guava:guava:$guava_version"
+    implementation("com.google.guava:guava:$guava_version") {
+        transitive = false
+    }
 }
 
 // Copy the DependencyConstraints XML from ':cordapp' into our build directory.

--- a/cordapp-cpk/src/test/resources/with-dependent-cordapp/library/build.gradle
+++ b/cordapp-cpk/src/test/resources/with-dependent-cordapp/library/build.gradle
@@ -12,7 +12,9 @@ jar {
 
 dependencies {
     // Corda depends on Guava via Quasar.
-    implementation "com.google.guava:guava:$library_guava_version"
+    implementation("com.google.guava:guava:$library_guava_version") {
+        transitive = false
+    }
 
     // Corda depends on a more recent version of SLF4J API.
     api "org.slf4j:slf4j-api:$slf4j_version"


### PR DESCRIPTION
Prevent CPKs from including library jars which are not OSGi bundles. The CPK cannot possibly use these jars since their lack of OSGi metadata would prevent the `verifyBundle` task from resolving their contents. Most likely, they are simply transitive "junk" dependencies.