### PR TITLE
NOTICK: Set Test org.gradle.java.home based on correct Java toolchain.

### DIFF
--- a/cordapp-cpk2/build.gradle
+++ b/cordapp-cpk2/build.gradle
@@ -12,10 +12,10 @@ plugins {
 description 'Configures this project to create a CPK CorDapp'
 
 ext {
-    osgi_service_component_version = '1.4.0'
+    osgi_service_component_version = '1.5.0'
     test_persistence_api_version = '2.2'
     test_hibernate_version = '5.4.32.Final'
-    test_kotlin_version = '1.4.32'
+    test_kotlin_version = '1.7.10'
     corda_guava_version = '20.0'
 }
 
@@ -109,7 +109,6 @@ processTestResources {
             'corda_slf4j_version': slf4j_version,
             'osgi_version': osgi_version,
             'kotlin_version': test_kotlin_version,
-            'java_home': System.getProperty('java.home'),
             'bnd_version': bnd_version
         ])
     }

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/CordappWithEmbeddedTransitivesTest.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/CordappWithEmbeddedTransitivesTest.kt
@@ -27,7 +27,7 @@ class CordappWithEmbeddedTransitivesTest {
         private const val hostVersion = "1.2.3-SNAPSHOT"
         private const val slf4jVersion = "2.0.0-alpha1"
 
-        private const val kotlinOsgiVersion = "version=\"[1.4,2)\""
+        private const val kotlinOsgiVersion = "version=\"[1.7,2)\""
         private const val commonsIoOsgiVersion = "version=\"[1.4,2)\""
         private const val slf4jOsgiVersion = "version=\"[2.0,3)\""
         private const val cordaOsgiVersion = "version=\"[5.0,6)\""

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/CordappWithPlatformTest.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/CordappWithPlatformTest.kt
@@ -21,7 +21,7 @@ import java.nio.file.Path
 @TestInstance(PER_CLASS)
 class CordappWithPlatformTest {
     private companion object {
-        private const val kotlinOsgiVersion = "version=\"[1.4,2)\""
+        private const val kotlinOsgiVersion = "version=\"[1.7,2)\""
         private const val cordaOsgiVersion = "version=\"[5.0,6)\""
 
         private const val cordappVersion = "3.2.1-SNAPSHOT"

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/GradleProject.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/GradleProject.kt
@@ -271,6 +271,11 @@ class GradleProject(private val projectDir: Path, private val reporter: TestRepo
     }
 
     private fun getGradleArgs(args: Array<out String>): List<String> {
-        return arrayListOf(taskName, "--info", "--stacktrace", "-g", testGradleUserHome, *args)
+        return arrayListOf(taskName, "--info", "--stacktrace",
+            // We only need to set org.gradle.java.home if we're not debugging.
+            "-Porg.gradle.java.home=${System.getProperty("java.home")}",
+            "-g", testGradleUserHome,
+            *args
+        )
     }
 }

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/SimpleKotlinCordappTest.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/SimpleKotlinCordappTest.kt
@@ -27,7 +27,7 @@ class SimpleKotlinCordappTest {
 
         private const val ioOsgiVersion = "version=\"[1.4,2)\""
         private const val guavaOsgiVersion = "version=\"[29.0,30)\""
-        private const val kotlinOsgiVersion = "version=\"[1.4,2)\""
+        private const val kotlinOsgiVersion = "version=\"[1.7,2)\""
         private const val cordaOsgiVersion = "version=\"[5.0,6)\""
         private const val cordappOsgiVersion = "version=\"1.0.1\""
     }

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/TransitiveCordappsTest.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/TransitiveCordappsTest.kt
@@ -34,7 +34,7 @@ class TransitiveCordappsTest {
         private const val cpk2Type = "api"
 
         private const val ioOsgiVersion = "version=\"[1.4,2)\""
-        private const val kotlinOsgiVersion = "version=\"[1.4,2)\""
+        private const val kotlinOsgiVersion = "version=\"[1.7,2)\""
         private const val cordaOsgiVersion = "version=\"[5.0,6)\""
         private const val cordappOsgiVersion = "version=\"1.0.1\""
     }

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/TransitiveRemoteCordappsTest.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/TransitiveRemoteCordappsTest.kt
@@ -35,7 +35,7 @@ class TransitiveRemoteCordappsTest {
         private const val cpk2Type = "api"
 
         private const val ioOsgiVersion = "version=\"[1.4,2)\""
-        private const val kotlinOsgiVersion = "version=\"[1.4,2)\""
+        private const val kotlinOsgiVersion = "version=\"[1.7,2)\""
         private const val cordaOsgiVersion = "version=\"[5.0,6)\""
         private const val cordappOsgiVersion = "version=\"1.0.1\""
     }

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/VerifyCordappDependencyTest.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/VerifyCordappDependencyTest.kt
@@ -26,7 +26,7 @@ class VerifyCordappDependencyTest {
         private const val cordappVersion = "1.1.1-SNAPSHOT"
         private const val hostVersion = "2.0.0-SNAPSHOT"
 
-        private const val kotlinOsgiVersion = "version=\"[1.4,2)\""
+        private const val kotlinOsgiVersion = "version=\"[1.7,2)\""
         private const val cordaOsgiVersion = "version=\"[5.0,6)\""
         private const val cordappOsgiVersion = "version=\"[1.1,2)\""
         private const val hostOsgiVersion = "version=\"2.0.0\""

--- a/cordapp-cpk2/src/test/resources/gradle.properties
+++ b/cordapp-cpk2/src/test/resources/gradle.properties
@@ -1,7 +1,6 @@
 # Placeholder for common Gradle properties.
 org.gradle.jvmargs=-XX:+UseG1GC -Xmx512m
 org.gradle.caching=false
-org.gradle.java.home=$java_home
 org.gradle.java.installations.auto-download=false
 
 artifactory_contextUrl=https://software.r3.com/artifactory

--- a/cordapp-cpk2/src/test/resources/kotlin.gradle
+++ b/cordapp-cpk2/src/test/resources/kotlin.gradle
@@ -1,10 +1,15 @@
-import static org.gradle.api.JavaVersion.VERSION_11
+pluginManager.withPlugin('org.jetbrains.kotlin.jvm') {
+    kotlin {
+        jvmToolchain {
+            languageVersion = JavaLanguageVersion.of(11)
+        }
+    }
 
-tasks.named('compileKotlin', AbstractCompile) {
-    kotlinOptions {
-        jvmTarget = VERSION_11
-        apiVersion = '1.4'
-        languageVersion = '1.4'
-        freeCompilerArgs = ['-Xjvm-default=all']
+    tasks.named('compileKotlin') {
+        kotlinOptions {
+            apiVersion = '1.7'
+            languageVersion = '1.7'
+            freeCompilerArgs = ['-Xjvm-default=all']
+        }
     }
 }

--- a/jar-filter/build.gradle
+++ b/jar-filter/build.gradle
@@ -17,8 +17,8 @@ repositories {
 
 ext {
     kotlin_metadata_version = '0.4.2'
-    test_kotlin_api_version = '1.4'
-    test_kotlin_version = '1.7.0'
+    test_kotlin_api_version = '1.5'
+    test_kotlin_version = '1.7.10'
 }
 
 gradlePlugin {
@@ -76,7 +76,6 @@ tasks.named('compileTestKotlin') {
 processTestResources {
     filesMatching('gradle.properties') {
         expand(['jacocoAgent': configurations.jacocoRuntime.asPath.replace('\\', '/'),
-                'java_home': System.getProperty('java.home'),
                 'javax_annotations_version': javax_annotations_version,
                 'kotlin_api_version': test_kotlin_api_version,
                 'kotlin_version': test_kotlin_version,

--- a/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/Utilities.kt
+++ b/jar-filter/src/test/kotlin/net/corda/gradle/jarfilter/Utilities.kt
@@ -37,7 +37,13 @@ private val testGradleUserHome: String get() = testGradleUserHomeValue
     ?: throw TestAbortedException("System property 'test.gradle.user.home' not set.")
 
 fun getGradleArgsForTasks(vararg taskNames: String): MutableList<String> = getBasicArgsForTasks(*taskNames).apply { add("--info") }
-fun getBasicArgsForTasks(vararg taskNames: String): MutableList<String> = mutableListOf(*taskNames, "--stacktrace", "-g", testGradleUserHome)
+fun getBasicArgsForTasks(vararg taskNames: String): MutableList<String> = mutableListOf(
+    *taskNames,
+    // We only need to set org.gradle.java.home if we're not debugging.
+    "-Porg.gradle.java.home=${System.getProperty("java.home")}",
+    "-g", testGradleUserHome,
+    "--stacktrace"
+)
 
 /**
  * We must execute [GradleRunner][org.gradle.testkit.runner.GradleRunner]

--- a/jar-filter/src/test/resources/gradle.properties
+++ b/jar-filter/src/test/resources/gradle.properties
@@ -1,6 +1,5 @@
 org.gradle.jvmargs=-XX:+UseG1GC -Xmx512m -javaagent:"$jacocoAgent"=destfile="$buildDir/jacoco/test.exec",includes=net/corda/gradle/jarfilter/**
 org.gradle.java.installations.auto-download=false
-org.gradle.java.home=${java_home}
 org.gradle.caching=false
 
 kotlin.incremental=false


### PR DESCRIPTION
Set the `org.gradle.java.home` property for Gradle's test toolkit via the `GradleRunner` instead of `gradle.properties`, because we need to use the toolchain from the `Test` task.

Also upgrade the tests to use Kotlin 1.7.10.