### PR TITLE
NOTICK: Use env.CHANGE_ID rather than changeRequest() to ID if we are in a PR build

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -101,7 +101,7 @@ pipeline {
     post {
         always {
             script {
-                if(!changeRequest()){
+                if(!env.CHANGE_ID) {
                     snykSecurityScan.generateHtmlElements()
                 }
             }


### PR DESCRIPTION
changeRequest() seems to not be triggering correctly in all use cases -  use CHANGE_ID instead as this is only set by Jenkins in PR builds it simply will not exist otherwise
