### PR TITLE
CORE-4355: Restore "CorDapp library dependency" log output

### DIFF
--- a/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/DependencyCalculator.kt
+++ b/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/DependencyCalculator.kt
@@ -156,9 +156,7 @@ open class DependencyCalculator @Inject constructor(objects: ObjectFactory) : De
         _libraries.apply {
             setFrom(packageFiles - bundledFiles)
             disallowChanges()
-        }
-
-        for (library in _libraries) {
+        }.forEach { library ->
             logger.info("CorDapp library dependency: {}", library.name)
         }
 

--- a/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/DependencyCalculator.kt
+++ b/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/DependencyCalculator.kt
@@ -158,6 +158,10 @@ open class DependencyCalculator @Inject constructor(objects: ObjectFactory) : De
             disallowChanges()
         }
 
+        for (library in _libraries) {
+            logger.info("CorDapp library dependency: {}", library.name)
+        }
+
         // Finally, work out which jars we have used that have not been packaged into our CPK.
         // We still ignore anything that was for "compile only", because we only want to validate packages
         // that will be available at runtime.

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/CordappGradleConfigurationsTest.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/CordappGradleConfigurationsTest.kt
@@ -74,30 +74,40 @@ class CordappGradleConfigurationsTest {
 
     @Test
     fun testApiIncluded() {
+        assertThat(testProject.output)
+            .contains("CorDapp library dependency: javax.annotation-api-1.3.2.jar")
         assertThat(dependencies)
             .anyMatch { it.name == "lib/javax.annotation-api-1.3.2.jar" }
     }
 
     @Test
     fun testImplementationIncluded() {
+        assertThat(testProject.output)
+            .contains("CorDapp library dependency: javax.persistence-api-2.2.jar")
         assertThat(dependencies)
             .anyMatch { it.name == "lib/javax.persistence-api-2.2.jar" }
     }
 
     @Test
     fun testRuntimeOnlyIncluded() {
+        assertThat(testProject.output)
+            .contains("CorDapp library dependency: validation-api-1.1.0.Final.jar")
         assertThat(dependencies)
             .anyMatch { it.name == "lib/validation-api-1.1.0.Final.jar" }
     }
 
     @Test
     fun testCordaRuntimeOnlyExcluded() {
+        assertThat(testProject.output)
+            .doesNotContain("CorDapp library dependency: javax.servlet-api-3.1.0.jar")
         assertThat(dependencies)
             .noneMatch { it.name == "lib/javax.servlet-api-3.1.0.jar" }
     }
 
     @Test
     fun testCordaProvidedExcluded() {
+        assertThat(testProject.output)
+            .doesNotContain("CorDapp library dependency: guava-20.0.jar")
         assertThat(dependencies)
             .noneMatch { it.name == "lib/guava-20.0.jar" }
     }


### PR DESCRIPTION
Restore the library log message and the tests covering the log messages.