### PR TITLE
CORDA-4262: Fix task dependency for cordformation's project CorDapp.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 ## Version 5.1
 
+### Version 5.1.1
+
+* `cordformation`: CORDA-4262 - Fix Gradle exception when applied with `cordapp` plugin.
+
+### Version 5.1.0
+
 * Upgrade plugins to be compatible with Gradle 7.2.
 
 ## Version 5

--- a/cordformation/build.gradle
+++ b/cordformation/build.gradle
@@ -175,6 +175,7 @@ dependencies {
     testImplementation "org.assertj:assertj-core:$assertj_version"
     testImplementation "net.corda:corda-serialization:$corda_release_version"
     testRuntimeOnly "net.corda:corda-node-api:$corda_release_version"
+    testRuntimeOnly project(':cordapp')
 }
 
 task createNodeRunner(type: Jar) {

--- a/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
@@ -46,6 +46,7 @@ abstract class Baseform(
 
     init {
         group = GROUP_NAME
+
         // Ensure everything in our configurations that needs
         // to be built is available before this task executes.
         with(project.configurations) {
@@ -54,8 +55,9 @@ abstract class Baseform(
                 getByName(DEPLOY_CORDAPP_CONFIGURATION_NAME).buildDependencies
             )
 
+            // Ensure that any CorDapp this project may have is also built.
             project.pluginManager.withPlugin(CORDAPP_PLUGIN_ID) {
-                dependsOn(getByName(CORDA_CORDAPP_CONFIGURATION_NAME).buildDependencies)
+                dependsOn(getByName(CORDA_CORDAPP_CONFIGURATION_NAME).artifacts)
             }
         }
     }

--- a/cordformation/src/test/kotlin/net/corda/plugins/BaseformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/BaseformTest.kt
@@ -8,25 +8,40 @@ import net.corda.serialization.internal.amqp.AbstractAMQPSerializationScheme
 import net.corda.serialization.internal.amqp.amqpMagic
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.fail
 import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.net.URI
+import java.net.URL
 import java.nio.file.Files
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
 import java.nio.file.Paths
 
-open class BaseformTest {
+abstract class BaseformTest {
     @TempDir
     lateinit var testProjectDir: Path
 
     companion object {
         const val cordaFinanceWorkflowsJarName = "corda-finance-workflows-4.8"
         const val cordaFinanceContractsJarName = "corda-finance-contracts-4.8"
-        const val localCordappJarName = "locally-built-cordapp"
         const val bankNodeName = "BankOfCorda"
         const val notaryNodeName = "NotaryService"
         const val notaryNodeUnitName = "OrgUnit"
 
         private val testGradleUserHome = System.getProperty("test.gradle.user.home", ".")
+
+        private const val CORDAPP_PLUGIN_ID = "net.corda.plugins.cordapp"
+        private val cordappPluginJar = File(extractFileURI(
+            this::class.java.classLoader.getResource("META-INF/gradle-plugins/${CORDAPP_PLUGIN_ID}.properties")
+                ?: fail("Gradle plugin '${CORDAPP_PLUGIN_ID}' not found.")
+        ))
+
+        private fun extractFileURI(jarURL: URL): URI {
+            assertThat(jarURL.protocol).isEqualTo("jar")
+            val jarPath = jarURL.path
+            return URI.create(jarPath.substring(0, jarPath.indexOf("!/")))
+        }
     }
 
     fun getStandardGradleRunnerFor(
@@ -48,10 +63,13 @@ open class BaseformTest {
         installResource("gradle.properties")
         installResource("postgres.gradle")
         return GradleRunner.create()
-                .withDebug(!isKotlin) // Debugging Kotlin DSL scripts breaks TestKit?!
-                .withProjectDir(testProjectDir.toFile())
-                .withArguments(taskName, "-s", "--info", "-g", testGradleUserHome, *extraArgs)
-                .withPluginClasspath()
+            .withDebug(!isKotlin) // Debugging Kotlin DSL scripts breaks TestKit?!
+            .withProjectDir(testProjectDir.toFile())
+            .withArguments(taskName, "-s", "--info", "-g", testGradleUserHome, *extraArgs)
+            .withPluginClasspath()
+            .let { runner ->
+                runner.withPluginClasspath(runner.pluginClasspath + cordappPluginJar)
+            }
     }
 
     private fun createBuildFile(buildFileResourceName: String, buildFile: Path): Long {

--- a/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
@@ -29,8 +29,9 @@ class CordformTest : BaseformTest() {
         installResource("testkeystore")
 
         val result = runner.build()
+        println(result.output)
 
-        assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":deployNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeCordappJar(notaryNodeName, "corda-finance-workflows-$financeReleaseVersion")).isRegularFile
         assertThat(getNodeCordappJar(notaryNodeName, "corda-finance-contracts-$financeReleaseVersion")).isRegularFile
         assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile
@@ -57,8 +58,9 @@ class CordformTest : BaseformTest() {
         val runner = getStandardGradleRunnerFor("DeploySingleNodeWithCordappBackwardsCompatibility.gradle")
 
         val result = runner.build()
+        println(result.output)
 
-        assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":deployNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile
         assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile
@@ -75,8 +77,9 @@ class CordformTest : BaseformTest() {
         )
 
         val result = runner.build()
+        println(result.output)
 
-        assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":deployNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeLogFile(notaryNodeName, "node-run-migration.log")).isRegularFile
         assertThat(getNodeLogFile(notaryNodeName, "node-schema-cordform.log")).isRegularFile
         assertThat(getNodeLogFile(notaryNodeName, "node-info-gen.log")).isRegularFile
@@ -87,8 +90,9 @@ class CordformTest : BaseformTest() {
         val runner = getStandardGradleRunnerFor("DeploySingleNodeWithCordapp.gradle")
 
         val result = runner.build()
+        println(result.output)
 
-        assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":deployNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile
         assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile
@@ -99,9 +103,10 @@ class CordformTest : BaseformTest() {
         val runner = getStandardGradleRunnerFor("DeploySingleNodeWithCordappWithOU.gradle")
 
         val result = runner.build()
+        println(result.output)
         val notaryFullName = "${notaryNodeName}_${notaryNodeUnitName}"
 
-        assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":deployNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeCordappJar(notaryFullName, cordaFinanceWorkflowsJarName)).isRegularFile
         assertThat(getNodeCordappJar(notaryFullName, cordaFinanceContractsJarName)).isRegularFile
         assertThat(getNetworkParameterOverrides(notaryFullName)).isRegularFile
@@ -112,8 +117,9 @@ class CordformTest : BaseformTest() {
         val runner = getStandardGradleRunnerFor("DeploySingleNodeWithCordappConfig.gradle")
 
         val result = runner.build()
+        println(result.output)
 
-        assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":deployNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile
         assertThat(getNodeCordappConfig(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile
@@ -122,13 +128,23 @@ class CordformTest : BaseformTest() {
 
     @Test
     fun `deploy the locally built cordapp with cordapp config`() {
-        val runner = getStandardGradleRunnerFor("DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle")
+        val projectCordappBaseName = "project-cordapp"
+        val projectCordappVersion = "1.2-SNAPSHOT"
 
-        val result = runner.build()
+        val result = getStandardGradleRunnerFor("DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle",
+            taskName = "deployNodes",
+            "-PprojectCordappBaseName=$projectCordappBaseName",
+            "-PprojectCordappVersion=$projectCordappVersion"
+        ).build()
+        println(result.output)
 
-        assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(SUCCESS)
-        assertThat(getNodeCordappJar(notaryNodeName, localCordappJarName)).isRegularFile
-        assertThat(getNodeCordappConfig(notaryNodeName, localCordappJarName)).isRegularFile
+        val projectCordappName = "${projectCordappBaseName}-${projectCordappVersion}"
+
+        assertThat(result.task(":jar")?.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":deployNodes")?.outcome).isEqualTo(SUCCESS)
+        assertThat(getNodeCordappJar(notaryNodeName, projectCordappName)).isRegularFile
+        assertThat(getNodeCordappConfig(notaryNodeName, projectCordappName)).isRegularFile
+        assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile
     }
 
     @Test

--- a/cordformation/src/test/kotlin/net/corda/plugins/DockerImageTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/DockerImageTest.kt
@@ -1,7 +1,7 @@
 package net.corda.plugins
 
 import org.assertj.core.api.Assertions.assertThat
-import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.junit.jupiter.api.Test
 import java.nio.file.Paths
 
@@ -11,7 +11,8 @@ class DockerImageTest :BaseformTest() {
         val runner = getStandardGradleRunnerFor("DeployDockerImage.gradle", "dockerImage")
 
         val result = runner.build()
-        assertThat(result.task(":dockerImage")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        println(result.output)
+        assertThat(result.task(":dockerImage")?.outcome).isEqualTo(SUCCESS)
         assertThat(Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker", "Dockerfile")).isRegularFile
 
         val dockerfile = Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker", "Dockerfile").toFile()
@@ -25,8 +26,9 @@ class DockerImageTest :BaseformTest() {
         val runner = getStandardGradleRunnerFor("DeployDockerImage.gradle", "dockerImage")
         installResource("dummyJar.jar")
         val result = runner.build()
+        println(result.output)
 
-        assertThat(result.task(":dockerImage")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.task(":dockerImage")?.outcome).isEqualTo(SUCCESS)
         assertThat(Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker","corda-finance-contracts-4.8.jar")).isRegularFile
         assertThat(Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker","corda-finance-workflows-4.8.jar")).isRegularFile
         assertThat(Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker","dummyJar.jar")).isRegularFile

--- a/cordformation/src/test/kotlin/net/corda/plugins/DockerformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/DockerformTest.kt
@@ -18,8 +18,9 @@ class DockerformTest : BaseformTest() {
                 "prepareDockerNodes")
 
         val result = runner.buildAndFail()
+        println(result.output)
 
-        assertThat(result.task(":prepareDockerNodes")!!.outcome).isEqualTo(FAILED)
+        assertThat(result.task(":prepareDockerNodes")?.outcome).isEqualTo(FAILED)
         assertThat(result.output)
             .contains("In plugin 'net.corda.plugins.cordformation' type 'net.corda.plugins.Dockerform' property 'dockerImage' doesn't have a configured value.")
     }
@@ -31,9 +32,10 @@ class DockerformTest : BaseformTest() {
             "prepareDockerNodes")
 
         val result = runner.build()
+        println(result.output)
         val notaryFullName = "${notaryNodeName}_${notaryNodeUnitName}"
 
-        assertThat(result.task(":prepareDockerNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":prepareDockerNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeCordappJar(notaryFullName, cordaFinanceWorkflowsJarName)).isRegularFile
         assertThat(getNodeCordappJar(notaryFullName, cordaFinanceContractsJarName)).isRegularFile
         assertThat(getNetworkParameterOverrides(notaryFullName)).isRegularFile
@@ -46,8 +48,9 @@ class DockerformTest : BaseformTest() {
                 "prepareDockerNodes")
 
         val result = runner.build()
+        println(result.output)
 
-        assertThat(result.task(":prepareDockerNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":prepareDockerNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile
         assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile
@@ -62,8 +65,9 @@ class DockerformTest : BaseformTest() {
         val bigCorporationNodeName = "BigCorporation"
 
         val result = runner.build()
+        println(result.output)
 
-        assertThat(result.task(":prepareDockerNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":prepareDockerNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile
         assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile
@@ -84,8 +88,9 @@ class DockerformTest : BaseformTest() {
         val bigCorporationNodeName = "BigCorporation"
 
         val result = runner.build()
+        println(result.output)
 
-        assertThat(result.task(":prepareDockerNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":prepareDockerNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile
         assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile
@@ -104,8 +109,9 @@ class DockerformTest : BaseformTest() {
                 "prepareDockerNodes")
 
         val result = runner.build()
+        println(result.output)
 
-        assertThat(result.task(":prepareDockerNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":prepareDockerNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile
         assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile
@@ -119,8 +125,9 @@ class DockerformTest : BaseformTest() {
                 "prepareDockerNodes")
 
         val result = runner.build()
+        println(result.output)
 
-        assertThat(result.task(":prepareDockerNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":prepareDockerNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile
         assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile
@@ -166,7 +173,8 @@ class DockerformTest : BaseformTest() {
                 "prepareDockerNodes")
 
         val result = runner.build()
-        assertThat(result.task(":prepareDockerNodes")!!.outcome).isEqualTo(SUCCESS)
+        println(result.output)
+        assertThat(result.task(":prepareDockerNodes")?.outcome).isEqualTo(SUCCESS)
 
         val dockerComposePath = getDockerCompose()
 
@@ -211,7 +219,8 @@ class DockerformTest : BaseformTest() {
                 "prepareDockerNodes")
 
         val result = runner.build()
-        assertThat(result.task(":prepareDockerNodes")!!.outcome).isEqualTo(SUCCESS)
+        println(result.output)
+        assertThat(result.task(":prepareDockerNodes")?.outcome).isEqualTo(SUCCESS)
 
         val dockerComposePath = getDockerCompose()
 

--- a/cordformation/src/test/kotlin/net/corda/plugins/KotlinCordformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/KotlinCordformTest.kt
@@ -10,9 +10,10 @@ class KotlinCordformTest : BaseformTest() {
         val runner = getStandardGradleRunnerFor("DeployTwoNodeCordapp.gradle.kts")
 
         val result = runner.build()
+        println(result.output)
 
         // Check task succeeded
-        assertThat(result.task(":deployNodes")!!.outcome)
+        assertThat(result.task(":deployNodes")?.outcome)
             .isEqualTo(SUCCESS)
 
         // Check Notary node deployment

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
@@ -1,13 +1,15 @@
 plugins {
     id 'net.corda.plugins.cordformation'
-
-    // We should really be apply the `net.corda.plugins.cordapp` plugin here.
-    id 'java-library'
+    id 'net.corda.plugins.cordapp'
 }
 
-configurations {
-    cordaCordapp {
-        canBeResolved = false
+cordapp {
+    targetPlatformVersion = 100
+    contract {
+        name = projectCordappBaseName
+        versionId = 1
+        licence = 'Test Licence'
+        vendor = 'R3 Ltd'
     }
 }
 
@@ -17,16 +19,12 @@ dependencies {
     cordaBootstrapper "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
-def jar = tasks.named('jar', Jar) {
-    archiveBaseName = 'locally-built-cordapp'
-}
-
-artifacts {
-    cordaCordapp jar
+tasks.named('jar', Jar) {
+    archiveBaseName = projectCordappBaseName
+    archiveVersion = projectCordappVersion
 }
 
 tasks.register('deployNodes', net.corda.plugins.Cordform) {
-    dependsOn jar
     node {
         name 'O=Notary Service,L=Zurich,C=CH'
         notary = [validating : true]
@@ -36,6 +34,7 @@ tasks.register('deployNodes', net.corda.plugins.Cordform) {
             adminAddress "localhost:10004"
         }
         projectCordapp {
+            deploy = true
             config "a=b"
         }
     }


### PR DESCRIPTION
The `cordaCordapp` configuration is intended to be "consumed" rather than "resolved". Therefore create `BaseForm`'s task dependency using the configuration's `artifacts` instead of its `buildDependencies`.

And even better, I've worked out how to include our `net.corda.plugins.cordapp` plugin in a `net.corda.plugins.cordformation` test.