### PR TITLE
NOTICK: Backport cordformation test fixes from 5.1.x branch.

### DIFF
--- a/cordformation/build.gradle
+++ b/cordformation/build.gradle
@@ -175,6 +175,7 @@ dependencies {
     testImplementation "org.assertj:assertj-core:$assertj_version"
     testImplementation "net.corda:corda-serialization:$corda_release_version"
     testRuntimeOnly "net.corda:corda-node-api:$corda_release_version"
+    testRuntimeOnly project(':cordapp')
 }
 
 tasks.named('validateTaskProperties', ValidateTaskProperties) {

--- a/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
@@ -29,8 +29,9 @@ class CordformTest : BaseformTest() {
         installResource("testkeystore")
 
         val result = runner.build()
+        println(result.output)
 
-        assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":deployNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeCordappJar(notaryNodeName, "corda-finance-workflows-$financeReleaseVersion")).isRegularFile()
         assertThat(getNodeCordappJar(notaryNodeName, "corda-finance-contracts-$financeReleaseVersion")).isRegularFile()
         assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile()
@@ -57,8 +58,9 @@ class CordformTest : BaseformTest() {
         val runner = getStandardGradleRunnerFor("DeploySingleNodeWithCordappBackwardsCompatibility.gradle")
 
         val result = runner.build()
+        println(result.output)
 
-        assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":deployNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile()
         assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile()
@@ -75,8 +77,9 @@ class CordformTest : BaseformTest() {
         )
 
         val result = runner.build()
+        println(result.output)
 
-        assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":deployNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeLogFile(notaryNodeName, "node-run-migration.log")).isRegularFile()
         assertThat(getNodeLogFile(notaryNodeName, "node-schema-cordform.log")).isRegularFile()
         assertThat(getNodeLogFile(notaryNodeName, "node-info-gen.log")).isRegularFile()
@@ -87,8 +90,9 @@ class CordformTest : BaseformTest() {
         val runner = getStandardGradleRunnerFor("DeploySingleNodeWithCordapp.gradle")
 
         val result = runner.build()
+        println(result.output)
 
-        assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":deployNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile()
         assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile()
@@ -99,9 +103,11 @@ class CordformTest : BaseformTest() {
         val runner = getStandardGradleRunnerFor("DeploySingleNodeWithCordappWithOU.gradle")
 
         val result = runner.build()
+        println(result.output)
+
         val notaryFullName = "${notaryNodeName}_${notaryNodeUnitName}"
 
-        assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":deployNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeCordappJar(notaryFullName, cordaFinanceWorkflowsJarName)).isRegularFile()
         assertThat(getNodeCordappJar(notaryFullName, cordaFinanceContractsJarName)).isRegularFile()
         assertThat(getNetworkParameterOverrides(notaryFullName)).isRegularFile()
@@ -112,8 +118,9 @@ class CordformTest : BaseformTest() {
         val runner = getStandardGradleRunnerFor("DeploySingleNodeWithCordappConfig.gradle")
 
         val result = runner.build()
+        println(result.output)
 
-        assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":deployNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile()
         assertThat(getNodeCordappConfig(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
@@ -122,13 +129,25 @@ class CordformTest : BaseformTest() {
 
     @Test
     fun `deploy the locally built cordapp with cordapp config`() {
-        val runner = getStandardGradleRunnerFor("DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle")
+        val projectCordappBaseName = "project-cordapp"
+        val projectCordappVersion = "1.2-SNAPSHOT"
 
-        val result = runner.build()
+        val result = getStandardGradleRunnerFor("DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle",
+            taskName = "deployNodes",
+            extraArgs = *arrayOf(
+                "-PprojectCordappBaseName=$projectCordappBaseName",
+                "-PprojectCordappVersion=$projectCordappVersion"
+            )
+        ).build()
+        println(result.output)
 
-        assertThat(result.task(":deployNodes")!!.outcome).isEqualTo(SUCCESS)
-        assertThat(getNodeCordappJar(notaryNodeName, localCordappJarName)).isRegularFile()
-        assertThat(getNodeCordappConfig(notaryNodeName, localCordappJarName)).isRegularFile()
+        val projectCordappName = "${projectCordappBaseName}-${projectCordappVersion}"
+
+        assertThat(result.task(":jar")?.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":deployNodes")?.outcome).isEqualTo(SUCCESS)
+        assertThat(getNodeCordappJar(notaryNodeName, projectCordappName)).isRegularFile()
+        assertThat(getNodeCordappConfig(notaryNodeName, projectCordappName)).isRegularFile()
+        assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile()
     }
 
     @Test

--- a/cordformation/src/test/kotlin/net/corda/plugins/DockerImageTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/DockerImageTest.kt
@@ -1,7 +1,7 @@
 package net.corda.plugins
 
 import org.assertj.core.api.Assertions.assertThat
-import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.junit.jupiter.api.Test
 import java.nio.file.Paths
 
@@ -11,8 +11,9 @@ class DockerImageTest :BaseformTest() {
         val runner = getStandardGradleRunnerFor("DeployDockerImage.gradle", "dockerImage")
 
         val result = runner.build()
-        assertThat(result.task(":dockerImage")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.task(":dockerImage")?.outcome).isEqualTo(SUCCESS)
         assertThat(Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker", "Dockerfile")).isRegularFile()
+        println(result.output)
 
         val dockerfile = Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker", "Dockerfile").toFile()
         val text = dockerfile.readText()
@@ -25,8 +26,9 @@ class DockerImageTest :BaseformTest() {
         val runner = getStandardGradleRunnerFor("DeployDockerImage.gradle", "dockerImage")
         installResource("dummyJar.jar")
         val result = runner.build()
+        println(result.output)
 
-        assertThat(result.task(":dockerImage")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.task(":dockerImage")?.outcome).isEqualTo(SUCCESS)
         assertThat(Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker","corda-finance-contracts-4.8.jar")).isRegularFile()
         assertThat(Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker","corda-finance-workflows-4.8.jar")).isRegularFile()
         assertThat(Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "docker","dummyJar.jar")).isRegularFile()

--- a/cordformation/src/test/kotlin/net/corda/plugins/DockerformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/DockerformTest.kt
@@ -18,8 +18,9 @@ class DockerformTest : BaseformTest() {
                 "prepareDockerNodes")
 
         val result = runner.buildAndFail()
+        println(result.output)
 
-        assertThat(result.task(":prepareDockerNodes")!!.outcome).isEqualTo(FAILED)
+        assertThat(result.task(":prepareDockerNodes")?.outcome).isEqualTo(FAILED)
         assertThat(result.output).contains("Caused by: org.gradle.api.InvalidUserDataException: No value has been specified for property 'dockerImage'.")
     }
 
@@ -30,9 +31,10 @@ class DockerformTest : BaseformTest() {
             "prepareDockerNodes")
 
         val result = runner.build()
+        println(result.output)
         val notaryFullName = "${notaryNodeName}_${notaryNodeUnitName}"
 
-        assertThat(result.task(":prepareDockerNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":prepareDockerNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeCordappJar(notaryFullName, cordaFinanceWorkflowsJarName)).isRegularFile()
         assertThat(getNodeCordappJar(notaryFullName, cordaFinanceContractsJarName)).isRegularFile()
         assertThat(getNetworkParameterOverrides(notaryFullName)).isRegularFile()
@@ -45,8 +47,9 @@ class DockerformTest : BaseformTest() {
                 "prepareDockerNodes")
 
         val result = runner.build()
+        println(result.output)
 
-        assertThat(result.task(":prepareDockerNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":prepareDockerNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile()
         assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile()
@@ -61,8 +64,9 @@ class DockerformTest : BaseformTest() {
         val bigCorporationNodeName = "BigCorporation"
 
         val result = runner.build()
+        println(result.output)
 
-        assertThat(result.task(":prepareDockerNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":prepareDockerNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile()
         assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile()
@@ -83,8 +87,9 @@ class DockerformTest : BaseformTest() {
         val bigCorporationNodeName = "BigCorporation"
 
         val result = runner.build()
+        println(result.output)
 
-        assertThat(result.task(":prepareDockerNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":prepareDockerNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile()
         assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile()
@@ -103,8 +108,9 @@ class DockerformTest : BaseformTest() {
                 "prepareDockerNodes")
 
         val result = runner.build()
+        println(result.output)
 
-        assertThat(result.task(":prepareDockerNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":prepareDockerNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile()
         assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile()
@@ -118,8 +124,9 @@ class DockerformTest : BaseformTest() {
                 "prepareDockerNodes")
 
         val result = runner.build()
+        println(result.output)
 
-        assertThat(result.task(":prepareDockerNodes")!!.outcome).isEqualTo(SUCCESS)
+        assertThat(result.task(":prepareDockerNodes")?.outcome).isEqualTo(SUCCESS)
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceWorkflowsJarName)).isRegularFile()
         assertThat(getNodeCordappJar(notaryNodeName, cordaFinanceContractsJarName)).isRegularFile()
         assertThat(getNetworkParameterOverrides(notaryNodeName)).isRegularFile()
@@ -165,7 +172,8 @@ class DockerformTest : BaseformTest() {
                 "prepareDockerNodes")
 
         val result = runner.build()
-        assertThat(result.task(":prepareDockerNodes")!!.outcome).isEqualTo(SUCCESS)
+        println(result.output)
+        assertThat(result.task(":prepareDockerNodes")?.outcome).isEqualTo(SUCCESS)
 
         val dockerComposePath = getDockerCompose()
 
@@ -210,7 +218,8 @@ class DockerformTest : BaseformTest() {
                 "prepareDockerNodes")
 
         val result = runner.build()
-        assertThat(result.task(":prepareDockerNodes")!!.outcome).isEqualTo(SUCCESS)
+        println(result.output)
+        assertThat(result.task(":prepareDockerNodes")?.outcome).isEqualTo(SUCCESS)
 
         val dockerComposePath = getDockerCompose()
 

--- a/cordformation/src/test/kotlin/net/corda/plugins/KotlinCordformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/KotlinCordformTest.kt
@@ -7,12 +7,24 @@ import org.junit.jupiter.api.Test
 class KotlinCordformTest : BaseformTest() {
     @Test
     fun `two nodes with cordapp dependency - backwards compatibility`() {
-        val runner = getStandardGradleRunnerFor("CompatibilityKotlinDSL.gradle.kts")
+        val projectCordappBaseName = "local-cordapp"
+        val projectCordappVersion = "1.2.3-SNAPSHOT"
 
-        val result = runner.build()
+        val result = getStandardGradleRunnerFor("CompatibilityKotlinDSL.gradle.kts",
+            taskName = "deployNodes",
+            extraArgs = *arrayOf(
+                "-PprojectCordappBaseName=$projectCordappBaseName",
+                "-PprojectCordappVersion=$projectCordappVersion"
+            )
+        ).build()
+        println(result.output)
 
-        // Check task succeeded
-        assertThat(result.task(":deployNodes")!!.outcome)
+        val projectCordappName = "${projectCordappBaseName}-${projectCordappVersion}"
+
+        // Check tasks succeeded
+        assertThat(result.task(":jar")?.outcome)
+            .isEqualTo(SUCCESS)
+        assertThat(result.task(":deployNodes")?.outcome)
             .isEqualTo(SUCCESS)
 
         // Check Notary node deployment
@@ -22,9 +34,9 @@ class KotlinCordformTest : BaseformTest() {
             .isRegularFile()
         assertThat(getNodeCordappConfig(notaryNodeName, cordaFinanceWorkflowsJarName))
             .isRegularFile()
-        assertThat(getNodeCordappJar(notaryNodeName, localCordappJarName))
+        assertThat(getNodeCordappJar(notaryNodeName, projectCordappName))
             .doesNotExist()
-        assertThat(getNodeCordappConfig(notaryNodeName, localCordappJarName))
+        assertThat(getNodeCordappConfig(notaryNodeName, projectCordappName))
             .doesNotExist()
         assertThatConfig(getNodeConfig(notaryNodeName))
             .hasPath("rpcSettings.address", "localhost:60001")
@@ -37,9 +49,9 @@ class KotlinCordformTest : BaseformTest() {
             .isRegularFile()
         assertThat(getNodeCordappConfig(bankNodeName, cordaFinanceWorkflowsJarName))
             .isRegularFile()
-        assertThat(getNodeCordappJar(bankNodeName, localCordappJarName))
+        assertThat(getNodeCordappJar(bankNodeName, projectCordappName))
             .isRegularFile()
-        assertThat(getNodeCordappConfig(bankNodeName, localCordappJarName))
+        assertThat(getNodeCordappConfig(bankNodeName, projectCordappName))
             .isRegularFile()
         assertThatConfig(getNodeConfig(bankNodeName))
             .hasPath("rpcSettings.address", "localhost:10001")
@@ -51,9 +63,10 @@ class KotlinCordformTest : BaseformTest() {
         val runner = getStandardGradleRunnerFor("DeployTwoNodeCordapp.gradle.kts")
 
         val result = runner.build()
+        println(result.output)
 
         // Check task succeeded
-        assertThat(result.task(":deployNodes")!!.outcome)
+        assertThat(result.task(":deployNodes")?.outcome)
             .isEqualTo(SUCCESS)
 
         // Check Notary node deployment

--- a/cordformation/src/test/resources/net/corda/plugins/CompatibilityKotlinDSL.gradle.kts
+++ b/cordformation/src/test/resources/net/corda/plugins/CompatibilityKotlinDSL.gradle.kts
@@ -5,6 +5,7 @@ import net.corda.plugins.RpcSettings
 
 plugins {
     id("net.corda.plugins.cordformation")
+    id("net.corda.plugins.cordapp")
 }
 
 apply(from = "repositories.gradle")
@@ -12,6 +13,18 @@ apply(from = "repositories.gradle")
 val corda_group: String by project
 val corda_release_version: String by project
 val slf4j_version: String by project
+val projectCordappBaseName: String by project
+val projectCordappVersion: String by project
+
+cordapp {
+    targetPlatformVersion.set(100)
+    contract {
+        name.set(projectCordappBaseName)
+        versionId.set(1)
+        licence.set("Test Licence")
+        vendor.set("R3 Ltd")
+    }
+}
 
 dependencies {
     cordapp("$corda_group:corda-finance-contracts:$corda_release_version")
@@ -22,7 +35,8 @@ dependencies {
 }
 
 tasks.named<Jar>("jar") {
-    archiveBaseName.set("locally-built-cordapp")
+    archiveBaseName.set(projectCordappBaseName)
+    archiveVersion.set(projectCordappVersion)
 }
 
 tasks.register<Cordform>("deployNodes") {

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithLocallyBuildCordappAndConfig.gradle
@@ -1,8 +1,19 @@
 plugins {
     id 'net.corda.plugins.cordformation'
+    id 'net.corda.plugins.cordapp'
 }
 
 apply from: 'repositories.gradle'
+
+cordapp {
+    targetPlatformVersion = 100
+    contract {
+        name = projectCordappBaseName
+        versionId = 1
+        licence = 'Test Licence'
+        vendor = 'R3 Ltd'
+    }
+}
 
 dependencies {
     cordaRuntime "$corda_group:corda:$corda_release_version"
@@ -10,11 +21,13 @@ dependencies {
     cordaRuntime "org.slf4j:slf4j-simple:$slf4j_version"
 }
 
-jar {
-    baseName 'locally-built-cordapp'
+def jar = tasks.named('jar', Jar) {
+    archiveBaseName = projectCordappBaseName
+    archiveVersion = projectCordappVersion
 }
 
-task deployNodes(type: net.corda.plugins.Cordform, dependsOn: [jar]) {
+tasks.register('deployNodes', net.corda.plugins.Cordform) {
+    dependsOn jar
     node {
         name 'O=Notary Service,L=Zurich,C=CH'
         notary = [validating : true]
@@ -24,6 +37,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: [jar]) {
             adminAddress "localhost:10004"
         }
         projectCordapp {
+            deploy = true
             config "a=b"
         }
     }

--- a/cordformation/src/test/resources/net/corda/plugins/DeployTwoNodeCordapp.gradle.kts
+++ b/cordformation/src/test/resources/net/corda/plugins/DeployTwoNodeCordapp.gradle.kts
@@ -22,8 +22,6 @@ dependencies {
 }
 
 tasks.register<Cordform>("deployNodes") {
-    dependsOn.add("jar")
-
     nodeDefaults {
         projectCordapp {
             deploy = false


### PR DESCRIPTION
Cordformation tests that deploy locally-built CorDapps should apply our actual `net.corda.plugins.cordapp` plugin. Back-port this functionality from CORDA-4262 on the `release/5.1` branch.