### PR TITLE
CORE-6321: Revert quasar-utils to using original Quasar agent.

### DIFF
--- a/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarExtension.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarExtension.groovy
@@ -39,14 +39,9 @@ class QuasarExtension {
     final Property<Boolean> instrumentJavaExec
 
     /**
-     * Dependency notation for the Quasar bundle to use.
-     */
-    final Provider<Map<String, String>> dependency
-
-    /**
      * Dependency notation for the Quasar agent to use.
      */
-    final Provider<Map<String, String>> agent
+    final Provider<Map<String, String>> dependency
 
     /**
      * Runtime options for the Quasar agent:
@@ -79,10 +74,6 @@ class QuasarExtension {
         version = objects.property(String).convention(defaultVersion)
         dependency = group.zip(version) { grp, ver ->
             [ group: grp, name: QUASAR_ARTIFACT_NAME, version: ver, ext: 'jar' ] as Map<String, String>
-        }
-        agent = dependency.map {
-            it['classifier'] = 'agent'
-            it
         }
         instrumentTests = objects.property(Boolean).convention(true)
         instrumentJavaExec = objects.property(Boolean).convention(true)

--- a/quasar-utils/src/test/groovy/net/corda/plugins/quasar/QuasarPluginTest.groovy
+++ b/quasar-utils/src/test/groovy/net/corda/plugins/quasar/QuasarPluginTest.groovy
@@ -49,7 +49,7 @@ apply from: 'repositories.gradle'
 task show {
     doFirst {
         def configs = configurations.matching {
-            it.name in ['quasar', 'quasarAgent', 'cordaRuntimeOnly', 'compileOnly', 'cordaProvided','compileClasspath', 'runtimeClasspath']
+            it.name in ['quasar', 'cordaRuntimeOnly', 'compileOnly', 'cordaProvided','compileClasspath', 'runtimeClasspath']
         }
         configs.collectEntries { [(it.name):it.incoming.dependencies] }.each { name, dependencies ->
             dependencies.each { dep ->
@@ -62,13 +62,12 @@ task show {
 }
 """, "show"
         assertThat(output).containsOnlyOnce(
-            "quasar: co.paralleluniverse:quasar-core-osgi:jar:${QUASAR_VERSION}:".toString(),
-            "quasarAgent: co.paralleluniverse:quasar-core-osgi:jar:${QUASAR_VERSION}:agent".toString(),
-            "cordaRuntimeOnly: co.paralleluniverse:quasar-core-osgi:jar:${QUASAR_VERSION}:".toString(),
-            "runtimeClasspath: co.paralleluniverse:quasar-core-osgi:jar:${QUASAR_VERSION}:".toString(),
-            "compileOnly: co.paralleluniverse:quasar-core-osgi:jar:${QUASAR_VERSION}:".toString(),
-            "cordaProvided: co.paralleluniverse:quasar-core-osgi:jar:${QUASAR_VERSION}:".toString(),
-            "compileClasspath: co.paralleluniverse:quasar-core-osgi:jar:${QUASAR_VERSION}:".toString()
+            "quasar: co.paralleluniverse:quasar-core:jar:${QUASAR_VERSION}:".toString(),
+            "cordaRuntimeOnly: co.paralleluniverse:quasar-core:jar:${QUASAR_VERSION}:".toString(),
+            "runtimeClasspath: co.paralleluniverse:quasar-core:jar:${QUASAR_VERSION}:".toString(),
+            "compileOnly: co.paralleluniverse:quasar-core:jar:${QUASAR_VERSION}:".toString(),
+            "cordaProvided: co.paralleluniverse:quasar-core:jar:${QUASAR_VERSION}:".toString(),
+            "compileClasspath: co.paralleluniverse:quasar-core:jar:${QUASAR_VERSION}:".toString()
         )
     }
 
@@ -97,7 +96,7 @@ apply from: 'repositories.gradle'
 task show {
     doFirst {
         def configs = configurations.matching {
-            it.name in ['quasar', 'quasarAgent', 'cordaRuntimeOnly', 'compileOnly', 'cordaProvided', 'compileClasspath', 'runtimeClasspath']
+            it.name in ['quasar', 'cordaRuntimeOnly', 'compileOnly', 'cordaProvided', 'compileClasspath', 'runtimeClasspath']
         }
         configs.collectEntries { [(it.name):it.incoming.dependencies] }.each { name, dependencies ->
             dependencies.each { dep ->
@@ -110,13 +109,12 @@ task show {
 }
 """, "show"
         assertThat(output).containsOnlyOnce(
-            "quasar: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
-            "quasarAgent: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:agent".toString(),
-            "cordaRuntimeOnly: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
-            "runtimeClasspath: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
-            "compileOnly: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
-            "cordaProvided: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
-            "compileClasspath: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString()
+            "quasar: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
+            "cordaRuntimeOnly: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
+            "runtimeClasspath: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
+            "compileOnly: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
+            "cordaProvided: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
+            "compileClasspath: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString()
         )
     }
 
@@ -146,7 +144,7 @@ quasar {
 task show {
     doFirst {
         def configs = configurations.matching {
-            it.name in ['quasar', 'quasarAgent', 'cordaRuntimeOnly', 'compileOnly', 'cordaProvided', 'compileClasspath', 'runtimeClasspath']
+            it.name in ['quasar', 'cordaRuntimeOnly', 'compileOnly', 'cordaProvided', 'compileClasspath', 'runtimeClasspath']
         }
         configs.collectEntries { [(it.name):it.incoming.dependencies] }.each { name, dependencies ->
             dependencies.each { dep ->
@@ -159,13 +157,12 @@ task show {
 }
 """, "show"
         assertThat(output).containsOnlyOnce(
-            "quasar: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
-            "quasarAgent: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:agent".toString(),
-            "cordaRuntimeOnly: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
-            "runtimeClasspath: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
-            "compileOnly: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
-            "cordaProvided: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
-            "compileClasspath: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString()
+            "quasar: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
+            "cordaRuntimeOnly: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
+            "runtimeClasspath: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
+            "compileOnly: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
+            "cordaProvided: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
+            "compileClasspath: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString()
         )
     }
 
@@ -185,7 +182,6 @@ task show {
     doFirst {
         def configs = configurations.matching { it.name in [
             'quasar',
-            'quasarAgent',
             'compileClasspath',
             'runtimeClasspath'
         ] }
@@ -198,7 +194,6 @@ task show {
 }
 """, "show"
         assertThat(output.findAll { it.startsWith("quasar:") }).hasSize(1)
-        assertThat(output.findAll { it.startsWith("quasarAgent:") }).hasSize(1)
         assertThat(output.findAll { it.startsWith("compileClasspath:") }).hasSize(1)
         assertThat(output.findAll { it.startsWith("runtimeClasspath:") }.size()).isGreaterThan(1)
     }
@@ -236,7 +231,7 @@ test {
 }
 """, "test"
         assertThat(output).anyMatch {
-            it.startsWith("TEST-JVM: -javaagent:") && it.contains("quasar-core-osgi-") && it.endsWith(".jar")
+            it.startsWith("TEST-JVM: -javaagent:") && it.contains("quasar-core-") && it.endsWith(".jar")
         }.anyMatch {
             it == "TEST-JVM: -Dco.paralleluniverse.fibers.verifyInstrumentation"
         }

--- a/quasar-utils/src/test/groovy/net/corda/plugins/quasar/QuasarSuspendableTest.groovy
+++ b/quasar-utils/src/test/groovy/net/corda/plugins/quasar/QuasarSuspendableTest.groovy
@@ -44,7 +44,7 @@ quasar {
 task show {
     doFirst {
         def configs = configurations.matching {
-            it.name in ['quasar', 'quasarAgent', 'cordaRuntimeOnly', 'compileOnly', 'cordaProvided', 'compileClasspath', 'runtimeClasspath']
+            it.name in ['quasar', 'cordaRuntimeOnly', 'compileOnly', 'cordaProvided', 'compileClasspath', 'runtimeClasspath']
         }
         configs.collectEntries { [(it.name):it.incoming.dependencies] }.each { name, dependencies ->
             dependencies.each { dep ->
@@ -57,14 +57,13 @@ task show {
 }
 """, "show"
         assertThat(output).containsOnlyOnce(
-            "quasar: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
-            "quasarAgent: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:agent".toString(),
+            "quasar: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
         ).doesNotContain(
-            "cordaRuntimeOnly: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
-            "runtimeClasspath: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
-            "compileOnly: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
-            "cordaProvided: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
-            "compileClasspath: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString()
+            "cordaRuntimeOnly: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
+            "runtimeClasspath: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
+            "compileOnly: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
+            "cordaProvided: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
+            "compileClasspath: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString()
         )
     }
 
@@ -87,7 +86,7 @@ quasar {
 task show {
     doFirst {
         def configs = configurations.matching {
-            it.name in ['quasar', 'quasarAgent', 'cordaRuntimeOnly', 'compileOnly', 'cordaProvided', 'compileClasspath', 'runtimeClasspath']
+            it.name in ['quasar', 'cordaRuntimeOnly', 'compileOnly', 'cordaProvided', 'compileClasspath', 'runtimeClasspath']
         }
         configs.collectEntries { [(it.name):it.incoming.dependencies] }.each { name, dependencies ->
             dependencies.each { dep ->
@@ -104,13 +103,12 @@ task show {
 }
 """, "show"
         assertThat(output).containsOnlyOnce(
-            "quasar: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
-            "quasarAgent: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:agent".toString(),
-            "cordaRuntimeOnly: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
-            "runtimeClasspath: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
-            "compileOnly: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
-            "cordaProvided: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString(),
-            "compileClasspath: co.paralleluniverse:quasar-core-osgi:jar:${quasarVersion}:".toString()
+            "quasar: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
+            "cordaRuntimeOnly: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
+            "runtimeClasspath: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
+            "compileOnly: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
+            "cordaProvided: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString(),
+            "compileClasspath: co.paralleluniverse:quasar-core:jar:${quasarVersion}:".toString()
         )
         assertThat(output).containsOnlyOnce("QUASAR-ARG: []")
     }


### PR DESCRIPTION
The OSGi-aware Quasar agent has been replaced by an OSGi framework extension, and will soon cease to exist. Update `quasar-utils` to use the original Quasar agent instead,