### PR TITLE
CORE-6321: Update changelog and README for quasar-utils.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ you with a `runnodes` script to boot it all up afterwards.
 - [`net.corda.plugins.quasar-utils`](quasar-utils/README.rst)\
 This plugin configures a Gradle module to use Quasar. Specifically:
     - It allows you to specify the Maven group and version of
-the `quasar-core-osgi` artifacts to use.
-    - Adds the `quasar-core-osgi` artifact, along with all of its transitive
+the `quasar-core` artifact to use.
+    - Adds the `quasar-core` artifact, along with all of its transitive
 dependencies, to Gradle's `cordaRuntimeOnly` configuration.
-    - Adds the `quasar-core-osgi` artifact to Gradle's `cordaProvided`
+    - Adds the `quasar-core` artifact to Gradle's `cordaProvided`
 configuration without any of its transitive dependencies.
-    - Applies the `quasar-core-osgi` Java agent to all of the module's
+    - Applies the `quasar-core` Java agent to all of the module's
 `JavaExec` tasks.
-    - Applies the `quasar-core-osgi` Java agent to all of the module's
+    - Applies the `quasar-core` Java agent to all of the module's
 `Test` tasks.
     - Provides a `quasar` Gradle extension so that you can configure
 which packages the Quasar Java agent should not instrument at runtime.

--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@
 ### Version 6.0.0
 
 * Compatible with Gradle 6.7+.
-* `quasar-utils`: Upgrade to use Quasar 0.8.7_r3 OSGi bundles.
+* `quasar-utils`: Upgrade to use Quasar 0.8.7_r3.
 * `quasar-utils`: Support configurable `@Suspendable` annotation.
 * `quasar-utils`: Optional instrumentation of `Test` and `JavaExec` tasks.
 * `cordapp-cpk`: Generate CPK format CorDapps. Requires Gradle 6.7+.

--- a/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarPlugin.groovy
+++ b/quasar-utils/src/main/groovy/net/corda/plugins/quasar/QuasarPlugin.groovy
@@ -28,7 +28,7 @@ import static org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME
 import static org.gradle.api.plugins.JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME
 
 /**
- * QuasarPlugin creates "quasar" and "quasarAgent" configurations and adds Quasar as a dependency.
+ * QuasarPlugin creates "quasar" configuration and adds Quasar as a dependency.
  */
 @CompileStatic
 class QuasarPlugin implements Plugin<Project> {


### PR DESCRIPTION
Replace mentions of `quasar-core-osgi` with `quasar-core`, and remove other OSGi-related references.