### PR TITLE
NOTICK: Retire the flask plugin for 7.0.0.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Version 7
 
+* Compatible with Gradle 7.2+.
+* Replace `cordapp-cpk`, `cordapp-cpb` with `cordapp-cpk2`, `cordapp-cpb2`.
+* Retire the `flask` plugin.
+
 ## Version 6
 
 ### Version 6.0.0

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,10 +28,10 @@ include 'cordapp-cpk2'
 //include 'cordapp'
 include 'jar-filter'
 include 'jar-filter:unwanteds'
-include 'flask'
-include 'flask:flask-common'
-include 'flask:flask-heartbeat-agent'
-include 'flask:flask-launcher'
+//include 'flask'
+//include 'flask:flask-common'
+//include 'flask:flask-heartbeat-agent'
+//include 'flask:flask-launcher'
 
 gradleEnterprise {
     buildScan {

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1,7 +1,5 @@
 cordapp-cpk2
 cordapp-cpk2/net.corda.plugins.cordapp-cpk2.gradle.plugin
 cordapp-cpb2/net.corda.plugins.cordapp-cpb2.gradle.plugin
-flask
-flask/net.corda.plugins.flask.gradle.plugin
 quasar-utils
 quasar-utils/net.corda.plugins.quasar-utils.gradle.plugin


### PR DESCRIPTION
Corda 5 no longer needs the flask plugin.