### PR TITLE
NOTICK: Warn users to apply the cordapp-configuration plugin.

### DIFF
--- a/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/CordappPlugin.kt
+++ b/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/CordappPlugin.kt
@@ -322,6 +322,11 @@ class CordappPlugin @Inject constructor(
             }
             jar.doFirst { t ->
                 t as Jar
+
+                if (!osgi.configured) {
+                    t.logger.warn("CORDAPP PLUGIN NOT CONFIGURED! Please apply '$CORDAPP_CONFIG_PLUGIN_ID' plugin to root project.")
+                }
+
                 t.fileMode = Integer.parseInt("444", 8)
                 t.dirMode = Integer.parseInt("555", 8)
                 t.manifestContentCharset = "UTF-8"

--- a/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/CordappUtils.kt
+++ b/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/CordappUtils.kt
@@ -20,6 +20,7 @@ import java.util.jar.JarFile
 import java.util.jar.Manifest
 
 const val CORDAPP_CPK_PLUGIN_ID = "net.corda.plugins.cordapp-cpk2"
+const val CORDAPP_CONFIG_PLUGIN_ID = "net.corda.cordapp.cordapp-configuration"
 const val CORDAPP_TASK_GROUP = "Cordapp"
 
 const val CORDA_API_GROUP = "net.corda"

--- a/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/OsgiExtension.kt
+++ b/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/OsgiExtension.kt
@@ -9,6 +9,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskInputs
 import org.gradle.api.tasks.bundling.Jar
 import org.osgi.framework.Constants.BUNDLE_CLASSPATH
@@ -36,7 +37,6 @@ fun TaskInputs.nested(nestName: String, osgi: OsgiExtension) {
 @Suppress("UnstableApiUsage", "MemberVisibilityCanBePrivate", "unused")
 open class OsgiExtension(objects: ObjectFactory, jar: Jar) {
     private companion object {
-        private const val CORDAPP_CONFIG_PLUGIN_ID = "net.corda.cordapp.cordapp-configuration"
         private const val CORDAPP_CONFIG_FILENAME = "cordapp-configuration.properties"
 
         private val CORDA_CLASSES = "^Corda-.+-Classes\$".toRegex()
@@ -97,6 +97,10 @@ open class OsgiExtension(objects: ObjectFactory, jar: Jar) {
         fun optional(value: String): String = "$value;resolution:=optional"
         fun emptyVersion(value: String): String = "$value;version='[0,0)'"
     }
+
+    @get:Internal // Annotated for documentation purposes only.
+    var configured: Boolean = false
+        private set
 
     private val _noPackages: SetProperty<String> = objects.setProperty(String::class.java)
         .apply(SetProperty<String>::disallowChanges)
@@ -321,6 +325,11 @@ open class OsgiExtension(objects: ObjectFactory, jar: Jar) {
              * Apply our OSGi "consumer policy" when importing these packages.
              */
             config[IMPORT_POLICY_PACKAGES]?.let(::parsePackages)?.also(_policyPackages::set)
+
+            /**
+             * Show we have received our configuration.
+             */
+            configured = true
         }
     }
 


### PR DESCRIPTION
Log a warning should users try to build CorDapps without also applying Corda's `net.corda.cordapp.cordapp-configuration` plugin.