### PR TITLE
CORE-6551: Allow us to adjust the "version mask" when importing packages into CPKs.

### DIFF
--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/ConfigureCordaMetadataTest.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/ConfigureCordaMetadataTest.kt
@@ -17,6 +17,7 @@ class ConfigureCordaMetadataTest {
         private const val CORDAPP_VERSION = "1.1.1-SNAPSHOT"
         private const val HIBERNATE_ANNOTATIONS_PACKAGE = "org.hibernate.annotations"
         private const val HIBERNATE_PROXY_PACKAGE = "org.hibernate.proxy"
+        private const val KOTLIN_OSGI_VERSION = "version=[1.7,1.8)"
         private const val CORDA_OSGI_VERSION = "version=[5,6)"
     }
 
@@ -57,6 +58,7 @@ class ConfigureCordaMetadataTest {
                 .containsPackageWithAttributes("net.corda.v5.application.identity", CORDA_OSGI_VERSION)
                 .containsPackageWithAttributes("net.corda.v5.ledger.contracts", CORDA_OSGI_VERSION)
                 .containsPackageWithAttributes("net.corda.v5.ledger.transactions", CORDA_OSGI_VERSION)
+                .containsPackageWithAttributes("kotlin", KOTLIN_OSGI_VERSION)
             assertThatHeader(getValue(DYNAMICIMPORT_PACKAGE))
                 .doesNotContainPackage(HIBERNATE_ANNOTATIONS_PACKAGE, HIBERNATE_PROXY_PACKAGE)
                 .containsPackageWithAttributes("org.testing")

--- a/cordapp-cpk2/src/test/resources/cordapp-configuration/src/main/resources/net/corda/cordapp/cordapp-configuration.properties
+++ b/cordapp-cpk2/src/test/resources/cordapp-configuration/src/main/resources/net/corda/cordapp/cordapp-configuration.properties
@@ -3,5 +3,7 @@ Required-Packages=org.testing,\
   com.foo.bar
 
 # Deliberately using two wildcard packages here, for test purposes.
+# Also testing a non-default version range policy for Kotlin packages.
 Import-Policy-Packages=net.corda.v5.application.*,\
-  net.corda.v5.ledger.*
+  net.corda.v5.ledger.*,\
+  kotlin.*;range='[==,=+)'


### PR DESCRIPTION
We may not wish for CPKs to import _every_ package with version mask "[==,+)". Allow us more flexibility to configure this per package via the Corda APIs' `cordapp-configuration` Gradle plugin.

Note that this only modifies the plugin's capabilities, not its current behaviour.