### PR TITLE
CORDA-4263: Allow cordformation to recognise jars with -jdk11 appendix.

### DIFF
--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
@@ -38,7 +38,7 @@ class Cordformation : Plugin<Project> {
         }
 
         fun createJarRegex(jarName: String, releaseVersion: String): Regex {
-            return "\\Q$jarName\\E(-enterprise)?(-jdk11)?-\\Q$releaseVersion\\E(-.+)?\\.jar\$".toRegex()
+            return "\\Q$jarName\\E(-enterprise)?(-jdk1[17])?-\\Q$releaseVersion\\E(-.+)?\\.jar\$".toRegex()
         }
 
         /**

--- a/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Cordformation.kt
@@ -37,18 +37,23 @@ class Cordformation : Plugin<Project> {
             return outputFile
         }
 
+        fun createJarRegex(jarName: String, releaseVersion: String): Regex {
+            return "\\Q$jarName\\E(-enterprise)?(-jdk11)?-\\Q$releaseVersion\\E(-.+)?\\.jar\$".toRegex()
+        }
+
         /**
          * Gets a current built corda jar file
          *
          * @param project The project environment this plugin executes in.
          * @param jarName The name of the JAR you wish to access.
-         * @return A file handle to the file in the JAR.
+         * @return A [File] for the requested jar artifact.
          */
         fun verifyAndGetRuntimeJar(project: Project, jarName: String): File {
             val releaseVersion = project.findRootProperty("corda_release_version")
                     ?: throw IllegalStateException("Could not find a valid declaration of \"corda_release_version\"")
-            // need to cater for optional classifier (eg. corda-4.3-jdk11.jar)
-            val pattern = "\\Q$jarName\\E(-enterprise)?-\\Q$releaseVersion\\E(-.+)?\\.jar\$".toRegex()
+            // need to cater for optional classifier (e.g. corda-4.3-jdk11.jar)
+            // also for optional archive appendix of '-jdk11' (e.g. corda-jdk11-4.3.jar)
+            val pattern = createJarRegex(jarName, releaseVersion)
             val maybeJar = project.configurations.getByName(RUNTIME_CLASSPATH_CONFIGURATION_NAME).filter {
                 it.toString().contains(pattern)
             }

--- a/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
@@ -7,6 +7,7 @@ import net.corda.core.serialization.SerializationDefaults
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.internal.SerializationEnvironment
+import net.corda.plugins.Cordformation.Companion.createJarRegex
 import net.corda.serialization.internal.AMQP_P2P_CONTEXT
 import net.corda.serialization.internal.SerializationFactoryImpl
 import org.assertj.core.api.Assertions.assertThat
@@ -155,7 +156,7 @@ class CordformTest : BaseformTest() {
         val jarName = "corda"
 
         var releaseVersion = "4.3"
-        var pattern = "\\Q$jarName\\E(-enterprise)?-\\Q$releaseVersion\\E(-.+)?\\.jar\$".toRegex().pattern
+        var pattern = createJarRegex(jarName, releaseVersion).toPattern()
         assertThat("corda-4.3.jar").containsPattern(pattern)
         assertThat("corda-4.3.jar").containsPattern(pattern)
         assertThat("corda-4.3.jarBla").doesNotContainPattern(pattern)
@@ -165,14 +166,16 @@ class CordformTest : BaseformTest() {
         assertThat("bla\\bla\\bla\\corda-enterprise-4.3.jar").containsPattern(pattern)
         assertThat("corda-enterprise-4.3.jar").containsPattern(pattern)
         assertThat("corda-enterprise-4.3-jdk11.jar").containsPattern(pattern)
+        assertThat("corda-jdk11-4.3.jar").containsPattern(pattern)
+        assertThat("corda-enterprise-jdk11-4.3.jar").containsPattern(pattern)
 
         releaseVersion = "4.3-RC01"
-        pattern = "\\Q$jarName\\E(-enterprise)?-\\Q$releaseVersion\\E(-.+)?\\.jar\$".toRegex().pattern
+        pattern = createJarRegex(jarName, releaseVersion).toPattern()
         assertThat("corda-4.3-RC01.jar").containsPattern(pattern)
         assertThat("corda-4.3RC01.jar").doesNotContainPattern(pattern)
 
         releaseVersion = "4.3.20190925"
-        pattern = "\\Q$jarName\\E(-enterprise)?-\\Q$releaseVersion\\E(-.+)?\\.jar\$".toRegex().pattern
+        pattern = createJarRegex(jarName, releaseVersion).toPattern()
         assertThat("corda-4.3.20190925.jar").containsPattern(pattern)
         assertThat("corda-4.3.20190925-TEST.jar").containsPattern(pattern)
     }


### PR DESCRIPTION
Allow `cordformation` to deploy Corda jars that have been published with archive appendix of `jdk11`.