### PR TITLE
CORDA-4263: Allow cordformation to recognise jars with -jdk11 appendix.

### DIFF
--- a/cordformation/README.md
+++ b/cordformation/README.md
@@ -9,7 +9,7 @@ Gradle configurations:
 - `cordapp` for any CorDapps you wish to deploy, excluding any CorDapp built by the local project.
 - `cordaDriver` for any artifacts that must be added to each node's `drivers/` directory, e.g. database drivers or the
   Corda shell.
-- `corda` for the Corda artifact itself.
+- `corda` for the Corda artifact itself, or the Corda TestServer.
 - `cordaBootstrapper` for Corda's Bootstrapper artifact, i.e. a compatible version of `corda-node-api`. You may also
   wish to include an implementation of SLF4J here for the Bootstrapper to use, e.g. `slf4j-simple`.
 

--- a/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Baseform.kt
@@ -42,6 +42,8 @@ abstract class Baseform(
     protected companion object {
         const val nodeJarName = "corda.jar"
         const val GROUP_NAME = "Cordformation"
+
+        private val CORDA_EXPRESSION = "^corda-(?!(testserver-|webserver-)).*\\.jar\$".toRegex()
     }
 
     init {
@@ -163,7 +165,7 @@ abstract class Baseform(
      * Installs the corda fat JAR to the root directory, for the network bootstrapper to use.
      */
     protected fun installCordaJar() {
-        val cordaJar = Cordformation.verifyAndGetRuntimeJar(project, "corda")
+        val cordaJar = Cordformation.verifyAndGetRuntimeJar(project.configurations, CORDA_EXPRESSION)
         fs.copy {
             it.apply {
                 from(cordaJar)

--- a/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
+++ b/cordformation/src/main/kotlin/net/corda/plugins/Node.kt
@@ -47,6 +47,7 @@ open class Node @Inject constructor(
         private const val LOGS_DIR_NAME = "logs"
         private const val CPK_TASK_NAME = "cpk"
 
+        private val TESTSERVER_PATTERN = "^corda-(testserver|webserver)-.*\\.jar\$".toRegex()
         private val WHITESPACE = "\\s++".toRegex()
 
         /**
@@ -461,12 +462,8 @@ open class Node @Inject constructor(
         } ?: run {
             // If no webserver JAR is provided, the default development webserver is used.
             task.logger.lifecycle("Using default development webserver.")
-            try {
-                Cordformation.verifyAndGetRuntimeJar(task.project, "corda-testserver")
-            } catch (e: IllegalStateException) {
-                task.logger.lifecycle("Detecting older version of corda. Falling back to the old webserver.")
-                Cordformation.verifyAndGetRuntimeJar(task.project, "corda-webserver")
-            }
+            val configurations = task.project.configurations
+            Cordformation.verifyAndGetRuntimeJar(configurations, TESTSERVER_PATTERN)
         }
 
         fs.copy {

--- a/cordformation/src/test/kotlin/net/corda/plugins/BaseformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/BaseformTest.kt
@@ -16,7 +16,6 @@ import java.net.URL
 import java.nio.file.Files
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
-import java.nio.file.Paths
 
 abstract class BaseformTest {
     @TempDir
@@ -85,11 +84,13 @@ abstract class BaseformTest {
         } ?: throw NoSuchFileException(resourceName)
     }
 
-    fun getNodeLogFile( nodeName: String, fileName: String ): Path = Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "nodes", nodeName, "logs", fileName)
-    fun getNodeCordappJar(nodeName: String, cordappJarName: String): Path = Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "nodes", nodeName, "cordapps", "$cordappJarName.jar")
-    fun getNodeCordappConfig(nodeName: String, cordappJarName: String): Path = Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "nodes", nodeName, "cordapps", "config", "$cordappJarName.conf")
-    fun getNetworkParameterOverrides(nodeName: String): Path = Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "nodes", nodeName, "network-parameters")
-    fun getNodeConfigFile(nodeName: String): Path = Paths.get(testProjectDir.toAbsolutePath().toString(), "build", "nodes", nodeName, "node.conf")
+    fun getNodeDir(nodeName: String): Path = testProjectDir.toAbsolutePath().resolve("build").resolve("nodes").resolve(nodeName)
+    fun getNodeFile(nodeName: String, fileName: String): Path = getNodeDir(nodeName).resolve(fileName)
+    fun getNodeLogFile(nodeName: String, fileName: String ): Path = getNodeDir(nodeName).resolve("logs").resolve(fileName)
+    fun getNodeCordappJar(nodeName: String, cordappJarName: String): Path = getNodeDir(nodeName).resolve("cordapps").resolve("$cordappJarName.jar")
+    fun getNodeCordappConfig(nodeName: String, cordappJarName: String): Path = getNodeDir(nodeName).resolve("cordapps").resolve("config").resolve("$cordappJarName.conf")
+    fun getNetworkParameterOverrides(nodeName: String): Path = getNodeFile(nodeName, "network-parameters")
+    fun getNodeConfigFile(nodeName: String): Path = getNodeFile(nodeName, "node.conf")
 
     fun getNodeConfig(nodeName: String): Config {
         val configFile = getNodeConfigFile(nodeName)

--- a/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
+++ b/cordformation/src/test/kotlin/net/corda/plugins/CordformTest.kt
@@ -148,29 +148,14 @@ class CordformTest : BaseformTest() {
     }
 
     @Test
-    fun `regex matching used by verifyAndGetRuntimeJar()`() {
-        val jarName = "corda"
+    fun `deploy node with testserver`() {
+        val runner = getStandardGradleRunnerFor("DeploySingleNodeWithTestServer.gradle")
 
-        var releaseVersion = "4.3"
-        var pattern = "\\Q$jarName\\E(-enterprise)?-\\Q$releaseVersion\\E(-.+)?\\.jar\$".toRegex().pattern
-        assertThat("corda-4.3.jar").containsPattern(pattern)
-        assertThat("corda-4.3.jar").containsPattern(pattern)
-        assertThat("corda-4.3.jarBla").doesNotContainPattern(pattern)
-        assertThat("bla\\bla\\bla\\corda-4.3.jar").containsPattern(pattern)
-        assertThat("corda-4.3-jdk11.jar").containsPattern(pattern)
-        assertThat("corda-4.3jdk11.jar").doesNotContainPattern(pattern)
-        assertThat("bla\\bla\\bla\\corda-enterprise-4.3.jar").containsPattern(pattern)
-        assertThat("corda-enterprise-4.3.jar").containsPattern(pattern)
-        assertThat("corda-enterprise-4.3-jdk11.jar").containsPattern(pattern)
+        val result = runner.build()
+        println(result.output)
 
-        releaseVersion = "4.3-RC01"
-        pattern = "\\Q$jarName\\E(-enterprise)?-\\Q$releaseVersion\\E(-.+)?\\.jar\$".toRegex().pattern
-        assertThat("corda-4.3-RC01.jar").containsPattern(pattern)
-        assertThat("corda-4.3RC01.jar").doesNotContainPattern(pattern)
-
-        releaseVersion = "4.3.20190925"
-        pattern = "\\Q$jarName\\E(-enterprise)?-\\Q$releaseVersion\\E(-.+)?\\.jar\$".toRegex().pattern
-        assertThat("corda-4.3.20190925.jar").containsPattern(pattern)
-        assertThat("corda-4.3.20190925-TEST.jar").containsPattern(pattern)
+        assertThat(result.task(":deployNodes")?.outcome).isEqualTo(SUCCESS)
+        assertThat(getNodeFile(notaryNodeName, "corda.jar")).isRegularFile
+        assertThat(getNodeFile(notaryNodeName, "corda-testserver.jar")).isRegularFile
     }
 }

--- a/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithTestServer.gradle
+++ b/cordformation/src/test/resources/net/corda/plugins/DeploySingleNodeWithTestServer.gradle
@@ -1,0 +1,23 @@
+plugins {
+    id 'net.corda.plugins.cordformation'
+}
+
+dependencies {
+    corda "$corda_group:corda:$corda_release_version"
+    corda "$corda_group:corda-testserver:$corda_release_version"
+    cordaBootstrapper "$corda_group:corda-node-api:$corda_release_version"
+    cordaBootstrapper "org.slf4j:slf4j-simple:$slf4j_version"
+}
+
+tasks.register('deployNodes', net.corda.plugins.Cordform) {
+    node {
+        name 'O=Notary Service,L=Zurich,C=CH'
+        notary = [validating : true]
+        p2pPort 10002
+        rpcSettings {
+            port 10003
+            adminAddress "localhost:10004"
+        }
+        webPort 10010
+    }
+}


### PR DESCRIPTION
Allow `cordformation` to deploy Corda jars that have been published with archive appendix of `jdk11`.