### PR TITLE
NOTICK: Protect Bnd instructions from being clobbered accidentally.

### DIFF
--- a/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/CordappPlugin.kt
+++ b/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/CordappPlugin.kt
@@ -304,6 +304,9 @@ class CordappPlugin @Inject constructor(
                 // Set the CPK version tag to the same value as Bundle-Version.
                 bnd("$CPK_CORDAPP_VERSION: \${$BUNDLE_VERSION}")
 
+                // Disable the bndfile property, which could clobber our bnd instructions.
+                bndfile.fileValue(null).disallowChanges()
+
                 // Accessing the Gradle [Project] during the task execution
                 // phase is incompatible with Gradle's configuration cache.
                 // Prevent this task from accessing the project's properties.

--- a/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/OsgiExtension.kt
+++ b/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/OsgiExtension.kt
@@ -210,7 +210,7 @@ open class OsgiExtension(objects: ObjectFactory, jar: Jar) {
 
     private fun declareEmbeddedJars(locations: Set<FileSystemLocation>): String {
         return if (locations.isNotEmpty()) {
-            val includeResource = StringJoiner(",", "-includeresource:", System.lineSeparator())
+            val includeResource = StringJoiner(",", "-includeresource.cordapp:", System.lineSeparator())
             val bundleClassPath = StringJoiner(",", "$BUNDLE_CLASSPATH=", System.lineSeparator()).add(".")
             for (location in locations) {
                 val file = location.asFile


### PR DESCRIPTION
Prevent CPK developers from accidentally clobbering our Bnd instructions - as much as possible, anyway.