### PR TITLE
NOTICK: Revert Artifactory configuration breakage.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -263,9 +263,9 @@ artifactory {
     publish {
         contextUrl = artifactory_contextUrl
         repository {
-            repoKey = project.findProperty('corda.artifactory.repokey') ?: System.getenv('CORDA_PUBLISH_REPOSITORY_KEY')
-            username = project.findProperty('corda.artifactory.username') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
-            password = project.findProperty('corda.artifactory.password') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')
+            repoKey = System.getenv('CORDA_PUBLISH_REPOSITORY_KEY') ?: 'corda-dev'
+            username = project.findProperty('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
+            password = project.findProperty('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')
         }
     }
 }


### PR DESCRIPTION
The Gradle properties `cordaArtifactoryUsername` and `cordaArtifactoryPassword` are standard names that cannot be changed unilaterally without breaking things.