### PR TITLE
CORE-6614: Remove Kotlin from :jar-filter:unwanteds runtimeClasspath.

### DIFF
--- a/jar-filter/unwanteds/build.gradle
+++ b/jar-filter/unwanteds/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    api 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 }
 
 tasks.named('jar', Jar) {


### PR DESCRIPTION
The `:jar-filter:unwanteds` is a test artifact that is built using Kotlin. Snyk really has no business scanning it in the first place, but converting its Kotlin dependency from `api` to `compileOnly` should suffice for now since Snyk should only be scanning the `runtimeClasspath` configurations.