### PR TITLE
CORE-6551: Add applyImportPolicies to CPK plugin's task inputs.

### DIFF
--- a/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/OsgiExtension.kt
+++ b/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/OsgiExtension.kt
@@ -31,6 +31,7 @@ fun TaskInputs.nested(nestName: String, osgi: OsgiExtension) {
     property("${nestName}.autoExport", osgi.autoExport)
     property("${nestName}.exports", osgi.exports)
     property("${nestName}.embeddedJars", osgi.embeddedJars)
+    property("${nestName}.applyImportPolicies", osgi.applyImportPolicies)
     property("${nestName}.imports", osgi.imports)
     property("${nestName}.scanCordaClasses", osgi.scanCordaClasses)
     property("${nestName}.symbolicName", osgi.symbolicName)
@@ -224,6 +225,7 @@ open class OsgiExtension(objects: ObjectFactory, jar: Jar) {
         }
     }
 
+    @get:Input
     val applyImportPolicies: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
 
     private val activePolicies: Provider<out Map<String, String>>


### PR DESCRIPTION
Add the `applyImportPolicies` property to the jar task's inputs when creating CPKs. This is largely for "completeness" because the policies are included into the `Import-Package` instruction anyway. However, it does allow Gradle to rebuild CPKs if this flag changes, which is what developers would expect to happen even if it makes no difference to Gradle.