### PR TITLE
NOTICK: Removing --all-sub-projects arg from SNYK_COMMANDS

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -8,5 +8,5 @@ cordaPipeline(
     slimBuild: true,
     stableUnstableRepoPattern: false,
     nexusAppId :'corda-gradle-plugins-7.0.0',
-    snykAdditionalCommands: "--all-sub-projects --configuration-matching='^runtimeClasspath\$' -d"
+    snykAdditionalCommands: "--configuration-matching='^runtimeClasspath\$' -d"
     )


### PR DESCRIPTION
Description:
Removing --all-sub-projects arg from SNYK_COMMANDS as recently we updated snykDeltaScan to use the --file arg and both being added causes multiple vulnerability reports to be generated by snyk test which means when the result is piped to snyk delta the execution fails.

Tested Against:
https://ci01.dev.r3.com/job/Corda-Gradle-Build-Plugins/job/corda-gradle-plugins/job/PR-561/5/
