### PR TITLE
NOTICK: Bump version due to issue with transitive dependencies no longer being available 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ osgi_version=8.1.0
 bnd_version=6.3.1
 jacksonVersion=2.13.4
 
-artifactory_version=4.21.0
+artifactory_version=4.29.2
 gradle_publish_version=0.21.0
 
 artifactory_contextUrl=https://software.r3.com/artifactory


### PR DESCRIPTION
the following transitive dependency from older versions of this plugin is no longer available,   `org.jfrog.buildinfo:build-info-extractor:2.23.0`

Bumping to latest plugin version resolves this  as this is no longer on dependency graph 