### PR TITLE
CORE-8937: Instruct Bnd not to add any extra headers into the CPK manifest.

### DIFF
--- a/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/CordappPlugin.kt
+++ b/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/CordappPlugin.kt
@@ -2,6 +2,7 @@ package net.corda.plugins.cpk2
 
 import aQute.bnd.gradle.BndBuilderPlugin
 import aQute.bnd.gradle.BundleTaskExtension
+import aQute.bnd.osgi.Constants.NOEXTRAHEADERS
 import net.corda.plugins.cpk2.SignJar.Companion.sign
 import org.gradle.api.Action
 import org.gradle.api.GradleException
@@ -51,6 +52,7 @@ class CordappPlugin @Inject constructor(
 ): Plugin<Project> {
     private companion object {
         private const val UNKNOWN_PLATFORM_VERSION = -1
+        private const val EXCLUDE_EXTRA_HEADERS = "$NOEXTRAHEADERS=true"
         private const val CORDA_PLATFORM_VERSION = "Corda-Platform-Version"
         private const val PLUGIN_PROPERTIES = "cordapp-cpk2.properties"
         private const val DEPENDENCY_CALCULATOR_TASK_NAME = "cordappDependencyCalculator"
@@ -307,6 +309,9 @@ class CordappPlugin @Inject constructor(
                 // Set the CPK version tag to the same value as Bundle-Version.
                 bnd(CORDAPP_VERSION_INSTRUCTION)
 
+                // Instruct Bnd not to add any extra manifest headers concerning JDK or Bnd versions.
+                bnd(EXCLUDE_EXTRA_HEADERS)
+
                 // Disable the bndfile property, which could clobber our bnd instructions.
                 bndfile.fileValue(null).disallowChanges()
 
@@ -340,6 +345,7 @@ class CordappPlugin @Inject constructor(
                     mustContainAll(osgi.embeddedJars.get().parseInstructions())
                     mustContainAll(osgi.scanCordaClasses.get().parseInstructions())
                     mustContain(CORDAPP_VERSION_INSTRUCTION)
+                    mustContain(EXCLUDE_EXTRA_HEADERS)
                 }
 
                 t.fileMode = Integer.parseInt("444", 8)

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/SimpleCordappTest.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/SimpleCordappTest.kt
@@ -1,5 +1,9 @@
 package net.corda.plugins.cpk2
 
+import aQute.bnd.osgi.Constants.BND_LASTMODIFIED
+import aQute.bnd.osgi.Constants.CREATED_BY
+import aQute.bnd.osgi.Constants.PRIVATE_PACKAGE
+import aQute.bnd.osgi.Constants.TOOL
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -78,7 +82,10 @@ class SimpleCordappTest {
             assertEquals("Test-Licence", getValue(BUNDLE_LICENSE))
             assertEquals("R3", getValue(BUNDLE_VENDOR))
             assertEquals("true", getValue("Sealed"))
-            assertNull(getValue("Private-Package"))
+            assertNull(getValue(PRIVATE_PACKAGE))
+            assertNull(getValue(BND_LASTMODIFIED))
+            assertNull(getValue(CREATED_BY))
+            assertNull(getValue(TOOL))
         }
     }
 

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/SimpleKotlinCordappTest.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/SimpleKotlinCordappTest.kt
@@ -1,7 +1,11 @@
 package net.corda.plugins.cpk2
 
+import aQute.bnd.osgi.Constants.BND_LASTMODIFIED
+import aQute.bnd.osgi.Constants.CREATED_BY
+import aQute.bnd.osgi.Constants.TOOL
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -96,6 +100,9 @@ class SimpleKotlinCordappTest {
             assertEquals("Test-Licence", getValue(BUNDLE_LICENSE))
             assertEquals("R3", getValue(BUNDLE_VENDOR))
             assertEquals("true", getValue("Sealed"))
+            assertNull(getValue(BND_LASTMODIFIED))
+            assertNull(getValue(CREATED_BY))
+            assertNull(getValue(TOOL))
         }
     }
 }


### PR DESCRIPTION
The `Created-By` and `Tool` manifest attributes break the reproducibility of CPK builds across different JDKs or versions of Bnd. Instruct Bnd not to include them into the CPKs.