### PR TITLE
CORE-10230: Automatically include JetBrains annotations as compile-only dependency.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Version 7.0.2
 
 * `cordapp-cpk2`: Upgrade to Bnd 6.4.0.
+* `cordapp-cpk2`: Include JetBrains annotations as a compile-only dependency.
 * `quasar-utils`: Upgrade to use Quasar 0.8.9_r3.
 
 ### Version 7.0.1

--- a/cordapp-cpk2/build.gradle
+++ b/cordapp-cpk2/build.gradle
@@ -107,6 +107,7 @@ tasks.named('javadoc', Javadoc) {
 processResources {
     filesMatching('**/cordapp-cpk2.properties') {
         expand([
+            'jetbrains_annotations_version': jetbrains_annotations_version,
             'osgi_version': osgi_version,
             'bnd_version': bnd_version
         ])
@@ -122,6 +123,7 @@ processTestResources {
             'corda_guava_version': corda_guava_version,
             'corda_slf4j_version': slf4j_version,
             'osgi_version': osgi_version,
+            'jetbrains_annotations_version': jetbrains_annotations_version,
             'kotlin_version': test_kotlin_version,
             'bnd_version': bnd_version
         ])

--- a/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpb2/CpbPlugin.kt
+++ b/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpb2/CpbPlugin.kt
@@ -14,7 +14,7 @@ import org.gradle.api.artifacts.Dependency.ARCHIVES_CONFIGURATION
 import org.gradle.api.plugins.JavaPlugin.JAR_TASK_NAME
 import org.gradle.api.tasks.bundling.Jar
 
-@Suppress("Unused", "UnstableApiUsage")
+@Suppress("Unused")
 class CpbPlugin : Plugin<Project> {
 
     companion object {

--- a/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/CPKDependenciesTask.kt
+++ b/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/CPKDependenciesTask.kt
@@ -28,7 +28,7 @@ import java.util.Base64
 import java.util.jar.JarFile
 import javax.inject.Inject
 
-@Suppress("UnstableApiUsage", "MemberVisibilityCanBePrivate")
+@Suppress("MemberVisibilityCanBePrivate")
 @DisableCachingByDefault
 open class CPKDependenciesTask @Inject constructor(objects: ObjectFactory) : DefaultTask() {
     private companion object {

--- a/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/CordappData.kt
+++ b/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/CordappData.kt
@@ -19,7 +19,7 @@ fun TaskInputs.nested(nestName: String, data: CordappData) {
     property("${nestName}.licence", data.licence).optional(true)
 }
 
-@Suppress("UnstableApiUsage", "Unused")
+@Suppress("Unused")
 open class CordappData @Inject constructor(objects: ObjectFactory) {
     @get:Optional
     @get:Input

--- a/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/CordappExtension.kt
+++ b/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/CordappExtension.kt
@@ -22,14 +22,17 @@ fun TaskInputs.nested(nestName: String, cordapp: CordappExtension) {
     nested("${nestName}.signing", cordapp.signing)
     property("${nestName}.sealing", cordapp.sealing)
     property("${nestName}.bndVersion", cordapp.bndVersion)
+    property("${nestName}.osgiVersion", cordapp.osgiVersion)
+    property("${nestName}.jetbrainsAnnotationsVersion", cordapp.jetbrainsAnnotationsVersion)
 }
 
-@Suppress("UnstableApiUsage", "Unused", "PlatformExtensionReceiverOfInline")
+@Suppress("Unused")
 open class CordappExtension @Inject constructor(
     objects: ObjectFactory,
     providers: ProviderFactory,
     osgiVersion: String,
-    bndVersion: String
+    bndVersion: String,
+    jetbrainsAnnotationsVersion: String
 ) {
     /**
      * Top-level CorDapp attributes
@@ -72,6 +75,9 @@ open class CordappExtension @Inject constructor(
 
     @get:Input
     val osgiVersion: Property<String> = objects.property(String::class.java).convention(osgiVersion)
+
+    @get:Input
+    val jetbrainsAnnotationsVersion: Property<String> = objects.property(String::class.java).convention(jetbrainsAnnotationsVersion)
 
     /**
      * This property only provides the default value for [CPKDependenciesTask.hashAlgorithm], which is

--- a/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/CordappPlugin.kt
+++ b/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/CordappPlugin.kt
@@ -111,7 +111,11 @@ class CordappPlugin @Inject constructor(
 
         // Create our plugin's "cordapp" extension.
         cordapp = with(pluginProperties) {
-            project.extensions.create(CORDAPP_EXTENSION_NAME, CordappExtension::class.java, getValue("osgiVersion"), getValue("bndVersion"))
+            project.extensions.create(CORDAPP_EXTENSION_NAME, CordappExtension::class.java,
+                getValue("osgiVersion"),
+                getValue("bndVersion"),
+                getValue("jetbrainsAnnotationsVersion")
+            )
         }
 
         project.configurations.apply {
@@ -144,6 +148,9 @@ class CordappPlugin @Inject constructor(
 
                 val osgiDependency = project.dependencies.create("org.osgi:osgi.annotation:" + cordapp.osgiVersion.get())
                 dependencies.add(osgiDependency)
+
+                val jetbrainsDependency = project.dependencies.create("org.jetbrains:annotations:" + cordapp.jetbrainsAnnotationsVersion.get())
+                dependencies.add(jetbrainsDependency)
             }
 
             // We will ALWAYS want to compile against bundles, and not classes.

--- a/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/DependencyCalculator.kt
+++ b/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/DependencyCalculator.kt
@@ -21,7 +21,6 @@ import java.io.File
 import java.util.Collections.unmodifiableSet
 import javax.inject.Inject
 
-@Suppress("UnstableApiUsage")
 @DisableCachingByDefault
 open class DependencyCalculator @Inject constructor(objects: ObjectFactory) : DefaultTask() {
     private companion object {
@@ -126,7 +125,7 @@ open class DependencyCalculator @Inject constructor(objects: ObjectFactory) : De
         val (cordaDeps, nonCordaDeps) = runtimeDeps.groupBy { dep ->
             isCordaProvided(dep.group, dep.name)
         }.let { group ->
-            Pair(group[CORDA] ?: emptySet<Dependency>(), group[NON_CORDA] ?: emptySet<Dependency>())
+            Pair(group[CORDA] ?: emptySet(), group[NON_CORDA] ?: emptySet())
         }
 
         // Compute the set of resolved artifacts that will define this CorDapp.

--- a/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/OsgiExtension.kt
+++ b/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/OsgiExtension.kt
@@ -37,7 +37,7 @@ fun TaskInputs.nested(nestName: String, osgi: OsgiExtension) {
     property("${nestName}.symbolicName", osgi.symbolicName)
 }
 
-@Suppress("UnstableApiUsage", "MemberVisibilityCanBePrivate", "unused")
+@Suppress("MemberVisibilityCanBePrivate", "unused")
 open class OsgiExtension(objects: ObjectFactory, jar: Jar) {
     private companion object {
         private const val CORDAPP_CONFIG_FILENAME = "cordapp-configuration.properties"

--- a/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/PublishAfterEvaluationHandler.kt
+++ b/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/PublishAfterEvaluationHandler.kt
@@ -57,7 +57,6 @@ class PublishAfterEvaluationHandler(rootProject: Project) : Action<Gradle> {
         }
     }
 
-    @Suppress("UnstableApiUsage")
     private fun publishCompanionFor(project: Project) {
         val publications = (project.extensions.findByType(PublishingExtension::class.java) ?: return).publications
         val pomXmlWriter = PomXmlWriter(project.configurations)

--- a/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/SignJar.kt
+++ b/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/SignJar.kt
@@ -28,7 +28,7 @@ import java.nio.file.Paths
 import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 import javax.inject.Inject
 
-@Suppress("Unused", "UnstableApiUsage", "MemberVisibilityCanBePrivate")
+@Suppress("Unused", "MemberVisibilityCanBePrivate")
 @DisableCachingByDefault
 open class SignJar @Inject constructor(objects: ObjectFactory) : DefaultTask() {
     companion object {

--- a/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/Signing.kt
+++ b/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/Signing.kt
@@ -22,7 +22,7 @@ fun TaskInputs.nested(nestName: String, signing: Signing) {
     nested("${nestName}.options", signing.options)
 }
 
-@Suppress("UnstableApiUsage", "Unused", "PlatformExtensionReceiverOfInline")
+@Suppress("Unused")
 open class Signing @Inject constructor(objects: ObjectFactory, providers: ProviderFactory) {
 
     @get:Input

--- a/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/VerifyBundle.kt
+++ b/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/VerifyBundle.kt
@@ -35,7 +35,7 @@ import java.io.File
 import java.util.function.Function
 import javax.inject.Inject
 
-@Suppress("UnstableApiUsage", "MemberVisibilityCanBePrivate")
+@Suppress("MemberVisibilityCanBePrivate")
 @DisableCachingByDefault
 open class VerifyBundle @Inject constructor(objects: ObjectFactory) : DefaultTask() {
 

--- a/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/VerifyLibraries.kt
+++ b/cordapp-cpk2/src/main/kotlin/net/corda/plugins/cpk2/VerifyLibraries.kt
@@ -20,7 +20,7 @@ import org.osgi.framework.Constants.BUNDLE_MANIFESTVERSION
 import org.osgi.framework.Constants.BUNDLE_SYMBOLICNAME
 import org.osgi.framework.Constants.BUNDLE_VERSION
 
-@Suppress("UnstableApiUsage", "MemberVisibilityCanBePrivate")
+@Suppress("MemberVisibilityCanBePrivate")
 @DisableCachingByDefault
 open class VerifyLibraries @Inject constructor(objects: ObjectFactory) : DefaultTask() {
     init {

--- a/cordapp-cpk2/src/main/resources/net/corda/plugins/cpk2/cordapp-cpk2.properties
+++ b/cordapp-cpk2/src/main/resources/net/corda/plugins/cpk2/cordapp-cpk2.properties
@@ -1,2 +1,3 @@
+jetbrainsAnnotationsVersion=$jetbrains_annotations_version
 osgiVersion=$osgi_version
 bndVersion=$bnd_version

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/CordappGradleConfigurationsTest.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/CordappGradleConfigurationsTest.kt
@@ -9,9 +9,9 @@ import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.TestReporter
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
-import java.util.stream.Collectors.toList
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
+import kotlin.streams.asSequence
 
 @TestInstance(PER_CLASS)
 class CordappGradleConfigurationsTest {
@@ -62,8 +62,9 @@ class CordappGradleConfigurationsTest {
         assertThat(cordapp).isRegularFile
 
         dependencies = ZipFile(cordapp.toFile()).use { zip ->
-            zip.stream().filter { entry -> entry.name.startsWith("META-INF/privatelib/") && !entry.isDirectory }
-               .collect(toList())
+            zip.stream().asSequence().filter { entry ->
+                entry.name.startsWith("META-INF/privatelib/") && !entry.isDirectory
+            }.toList()
         }
     }
 

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/WithDependentCordappTest.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/WithDependentCordappTest.kt
@@ -55,17 +55,23 @@ class WithDependentCordappTest {
         val testProject = buildProject(guavaVersion, libraryGuavaVersion, testProjectDir, reporter)
         val cordaSlf4jVersion = testProject.properties.getProperty("corda_slf4j_version")
         val bndVersion = testProject.properties.getProperty("bnd_version")
+        val osgiVersion = testProject.properties.getProperty("osgi_version")
+        val jetbrainsAnnotationsVersion = testProject.properties.getProperty("jetbrains_annotations_version")
         assertEquals(CORDA_GUAVA_VERSION, testProject.properties.getProperty("corda_guava_version"))
         assertNotEquals(cordaSlf4jVersion, librarySlf4jVersion)
 
         assertThat(testProject.outputLines)
             .contains("COMPILE-WORKFLOW> biz.aQute.bnd.annotation-${bndVersion}.jar")
+            .contains("COMPILE-WORKFLOW> osgi.annotation-${osgiVersion}.jar")
+            .contains("COMPILE-WORKFLOW> annotations-${jetbrainsAnnotationsVersion}.jar")
             .contains("COMPILE-WORKFLOW> guava-${guavaVersion}.jar")
             .contains("COMPILE-WORKFLOW> cordapp.jar")
             .contains("EXTERNAL-WORKFLOW> corda-api-${cordaApiVersion}.jar")
             .contains("EXTERNAL-WORKFLOW> slf4j-api-${cordaSlf4jVersion}.jar")
             .contains("EXTERNAL-WORKFLOW> cordapp.jar")
             .contains("COMPILE-CONTRACT> biz.aQute.bnd.annotation-${bndVersion}.jar")
+            .contains("COMPILE-CONTRACT> osgi.annotation-${osgiVersion}.jar")
+            .contains("COMPILE-CONTRACT> annotations-${jetbrainsAnnotationsVersion}.jar")
             .contains("COMPILE-CONTRACT> slf4j-api-${cordaSlf4jVersion}.jar")
             .contains("COMPILE-CONTRACT> commons-io-${commonsIoVersion}.jar")
             .contains("COMPILE-CONTRACT> library.jar")
@@ -90,6 +96,8 @@ class WithDependentCordappTest {
             .noneMatch { it == "slf4j-api-${cordaSlf4jVersion}.jar" }
             .noneMatch { it == "slf4j-api-${librarySlf4jVersion}.jar" }
             .noneMatch { it == "biz.aQute.bnd.annotation-${bndVersion}.jar" }
+            .noneMatch { it == "osgi.annotation-${osgiVersion}.jar" }
+            .noneMatch { it == "annotations-${jetbrainsAnnotationsVersion}.jar" }
             .noneMatch { it == "library.jar" }
             .noneMatch { it == "cordapp.jar" }
             .hasSizeGreaterThanOrEqualTo(1)
@@ -116,6 +124,8 @@ class WithDependentCordappTest {
         assertThat(contractCpk).isRegularFile
         assertThat(listLibrariesForCpk(contractCpk))
             .noneMatch { it == "biz.aQute.bnd.annotation-${bndVersion}.jar" }
+            .noneMatch { it == "osgi.annotation-${osgiVersion}.jar" }
+            .noneMatch { it == "annotations-${jetbrainsAnnotationsVersion}.jar" }
             .noneMatch { it == "slf4j-api-${librarySlf4jVersion}.jar" }
             .noneMatch { it == "slf4j-api-${cordaSlf4jVersion}.jar" }
             .anyMatch { it == "guava-${libraryGuavaVersion}.jar" }

--- a/cordapp-cpk2/src/test/resources/cordapp-embedded-overrides/src/main/java/com/example/embeddedoverrides/ExampleContract.java
+++ b/cordapp-cpk2/src/test/resources/cordapp-embedded-overrides/src/main/java/com/example/embeddedoverrides/ExampleContract.java
@@ -2,6 +2,7 @@ package com.example.embeddedoverrides;
 
 import net.corda.v5.ledger.contracts.Contract;
 import net.corda.v5.ledger.transactions.LedgerTransaction;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 
@@ -9,7 +10,7 @@ public class ExampleContract implements Contract {
     private final Logger logger = LoggerFactory.getLogger(ExampleContract.class);
 
     @Override
-    public void verify(LedgerTransaction ltx) {
+    public void verify(@NotNull LedgerTransaction ltx) {
         logger.info("Verify transaction: {}", ltx);
     }
 }

--- a/cordapp-cpk2/src/test/resources/cordapp-import-package/src/main/java/com/example/importpackage/ExampleContract.java
+++ b/cordapp-cpk2/src/test/resources/cordapp-import-package/src/main/java/com/example/importpackage/ExampleContract.java
@@ -2,6 +2,7 @@ package com.example.importpackage;
 
 import net.corda.v5.ledger.contracts.Contract;
 import net.corda.v5.ledger.transactions.LedgerTransaction;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 
@@ -9,7 +10,7 @@ public class ExampleContract implements Contract {
     private final Logger logger = LoggerFactory.getLogger(ExampleContract.class);
 
     @Override
-    public void verify(LedgerTransaction ltx) {
+    public void verify(@NotNull LedgerTransaction ltx) {
         logger.info("Verify transaction: {}", ltx);
     }
 }

--- a/cordapp-cpk2/src/test/resources/cordapp-override-version/src/main/java/com/example/overrideversion/ExampleContract.java
+++ b/cordapp-cpk2/src/test/resources/cordapp-override-version/src/main/java/com/example/overrideversion/ExampleContract.java
@@ -2,6 +2,7 @@ package com.example.overrideversion;
 
 import net.corda.v5.ledger.contracts.Contract;
 import net.corda.v5.ledger.transactions.LedgerTransaction;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 
@@ -9,7 +10,7 @@ public class ExampleContract implements Contract {
     private final Logger logger = LoggerFactory.getLogger(ExampleContract.class);
 
     @Override
-    public void verify(LedgerTransaction ltx) {
+    public void verify(@NotNull LedgerTransaction ltx) {
         logger.info("Verify transaction: {}", ltx);
     }
 }

--- a/cordapp-cpk2/src/test/resources/cordapp-scan-overrides/src/main/java/com/example/scanoverrides/ExampleContract.java
+++ b/cordapp-cpk2/src/test/resources/cordapp-scan-overrides/src/main/java/com/example/scanoverrides/ExampleContract.java
@@ -2,6 +2,7 @@ package com.example.scanoverrides;
 
 import net.corda.v5.ledger.contracts.Contract;
 import net.corda.v5.ledger.transactions.LedgerTransaction;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 
@@ -9,7 +10,7 @@ public class ExampleContract implements Contract {
     private final Logger logger = LoggerFactory.getLogger(ExampleContract.class);
 
     @Override
-    public void verify(LedgerTransaction ltx) {
+    public void verify(@NotNull LedgerTransaction ltx) {
         logger.info("Verify transaction: {}", ltx);
     }
 }

--- a/cordapp-cpk2/src/test/resources/cordapp-with-guava/src/main/java/com/example/contract/GuavaContract.java
+++ b/cordapp-cpk2/src/test/resources/cordapp-with-guava/src/main/java/com/example/contract/GuavaContract.java
@@ -3,12 +3,13 @@ package com.example.contract;
 import com.google.common.collect.ImmutableList;
 import net.corda.v5.ledger.contracts.Contract;
 import net.corda.v5.ledger.transactions.LedgerTransaction;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
 public class GuavaContract implements Contract {
     @Override
-    public void verify(LedgerTransaction ltx) {
+    public void verify(@NotNull LedgerTransaction ltx) {
         List<String> data = ImmutableList.of("one", "two", "three");
         for (String item : data) {
             System.out.println(item);

--- a/cordapp-cpk2/src/test/resources/cordapp-with-logging/src/main/java/com/example/contract/LoggingContract.java
+++ b/cordapp-cpk2/src/test/resources/cordapp-with-logging/src/main/java/com/example/contract/LoggingContract.java
@@ -2,13 +2,14 @@ package com.example.contract;
 
 import net.corda.v5.ledger.contracts.Contract;
 import net.corda.v5.ledger.transactions.LedgerTransaction;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 
 public class LoggingContract implements Contract {
     private static final Logger LOG = LoggerFactory.getLogger(LoggingContract.class);
     @Override
-    public void verify(LedgerTransaction ltx) {
+    public void verify(@NotNull LedgerTransaction ltx) {
         LOG.info("Transaction: {}", ltx);
     }
 }

--- a/cordapp-cpk2/src/test/resources/cpb-disable-jar/src/main/java/com/example/cpb/nojar/ExampleContract.java
+++ b/cordapp-cpk2/src/test/resources/cpb-disable-jar/src/main/java/com/example/cpb/nojar/ExampleContract.java
@@ -2,10 +2,11 @@ package com.example.cpb.nojar;
 
 import net.corda.v5.ledger.contracts.Contract;
 import net.corda.v5.ledger.transactions.LedgerTransaction;
+import org.jetbrains.annotations.NotNull;
 
 public class ExampleContract implements Contract {
     @Override
-    public void verify(LedgerTransaction ltx) {
+    public void verify(@NotNull LedgerTransaction ltx) {
     }
 }
 

--- a/cordapp-cpk2/src/test/resources/cpk-disable-jar/src/main/java/com/example/nojar/ExampleContract.java
+++ b/cordapp-cpk2/src/test/resources/cpk-disable-jar/src/main/java/com/example/nojar/ExampleContract.java
@@ -2,10 +2,11 @@ package com.example.nojar;
 
 import net.corda.v5.ledger.contracts.Contract;
 import net.corda.v5.ledger.transactions.LedgerTransaction;
+import org.jetbrains.annotations.NotNull;
 
 public class ExampleContract implements Contract {
     @Override
-    public void verify(LedgerTransaction ltx) {
+    public void verify(@NotNull LedgerTransaction ltx) {
     }
 }
 

--- a/cordapp-cpk2/src/test/resources/cpk-export-reserved-package/src/main/java/net/corda/contract/ExampleContract.java
+++ b/cordapp-cpk2/src/test/resources/cpk-export-reserved-package/src/main/java/net/corda/contract/ExampleContract.java
@@ -3,6 +3,7 @@ package net.corda.contract;
 import net.corda.v5.ledger.contracts.Contract;
 import net.corda.v5.ledger.transactions.LedgerTransaction;
 import org.apache.commons.io.IOUtils;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -13,7 +14,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class ExampleContract implements Contract {
     @Override
-    public void verify(LedgerTransaction ltx) {
+    public void verify(@NotNull LedgerTransaction ltx) {
         try (InputStream input = new ByteArrayInputStream("Hello Corda!".getBytes(UTF_8))) {
             IOUtils.copy(input, System.out);
         } catch (IOException e) {

--- a/cordapp-cpk2/src/test/resources/cpk-export-reserved-package/src/main/java/net/corda/test/ExampleContract.java
+++ b/cordapp-cpk2/src/test/resources/cpk-export-reserved-package/src/main/java/net/corda/test/ExampleContract.java
@@ -3,6 +3,7 @@ package net.corda.test;
 import net.corda.v5.ledger.contracts.Contract;
 import net.corda.v5.ledger.transactions.LedgerTransaction;
 import org.apache.commons.io.IOUtils;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -13,7 +14,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class ExampleContract implements Contract {
     @Override
-    public void verify(LedgerTransaction ltx) {
+    public void verify(@NotNull LedgerTransaction ltx) {
         try (InputStream input = new ByteArrayInputStream("Hello Corda!".getBytes(UTF_8))) {
             IOUtils.copy(input, System.out);
         } catch (IOException e) {

--- a/cordapp-cpk2/src/test/resources/gradle.properties
+++ b/cordapp-cpk2/src/test/resources/gradle.properties
@@ -13,6 +13,7 @@ corda_slf4j_version=$corda_slf4j_version
 persistence_api_version=$persistence_api_version
 osgi_service_component_version=$osgi_service_component_version
 hibernate_version=$hibernate_version
+jetbrains_annotations_version=$jetbrains_annotations_version
 kotlin_version=$kotlin_version
 osgi_version=$osgi_version
 bnd_version=$bnd_version

--- a/cordapp-cpk2/src/test/resources/simple-cordapp/src/main/java/com/example/contract/ExampleContract.java
+++ b/cordapp-cpk2/src/test/resources/simple-cordapp/src/main/java/com/example/contract/ExampleContract.java
@@ -3,6 +3,7 @@ package com.example.contract;
 import net.corda.v5.ledger.contracts.Contract;
 import net.corda.v5.ledger.transactions.LedgerTransaction;
 import org.apache.commons.io.IOUtils;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -13,7 +14,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class ExampleContract implements Contract {
     @Override
-    public void verify(LedgerTransaction ltx) {
+    public void verify(@NotNull LedgerTransaction ltx) {
         try (InputStream input = new ByteArrayInputStream("Hello Corda!".getBytes(UTF_8))) {
             IOUtils.copy(input, System.out);
         } catch (IOException e) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,7 @@ hamcrest_version=2.2
 asm_version=9.4
 slf4j_version=1.7.36
 javax_annotations_version=1.3.2
+jetbrains_annotations_version=13.0
 osgi_version=8.1.0
 bnd_version=6.4.0
 jacksonVersion=2.14.1


### PR DESCRIPTION
Allow CPK developers access to the JetBrain annotations at compile time, exactly as if they were using `kotlin-stdlib` instead of `kotlin-osgi-bundle`.