### PR TITLE
CORE-11643: Bnd check for classes in wrong folder is now only a warning.

### DIFF
--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpk2/CordappPlugin.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpk2/CordappPlugin.java
@@ -44,6 +44,7 @@ import org.gradle.util.GradleVersion;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static aQute.bnd.osgi.Constants.FIXUPMESSAGES;
 import static aQute.bnd.osgi.Constants.NOEXTRAHEADERS;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
@@ -52,6 +53,7 @@ import static java.util.Collections.unmodifiableList;
 import static net.corda.plugins.cpk2.Attributor.isPlatformModule;
 import static net.corda.plugins.cpk2.CordappProperties.nested;
 import static net.corda.plugins.cpk2.CordappUtils.ALL_CORDAPPS_CONFIGURATION_NAME;
+import static net.corda.plugins.cpk2.CordappUtils.CLASSES_IN_WRONG_DIRECTORY_FIXUP;
 import static net.corda.plugins.cpk2.CordappUtils.CORDAPP_CONFIGURATION_NAME;
 import static net.corda.plugins.cpk2.CordappUtils.CORDAPP_CONFIG_PLUGIN_ID;
 import static net.corda.plugins.cpk2.CordappUtils.CORDAPP_CONTRACT_NAME;
@@ -121,6 +123,7 @@ public final class CordappPlugin implements Plugin<Project> {
     private static final int TARGET_PLATFORM = 0;
 
     private static final String CORDAPP_VERSION_INSTRUCTION = CPK_CORDAPP_VERSION + "=${" + BUNDLE_VERSION + '}';
+    private static final String CLASSES_IN_WRONG_DIRECTORY_WARNING_INSTRUCTION = FIXUPMESSAGES + '=' + CLASSES_IN_WRONG_DIRECTORY_FIXUP;
 
     private static final List<String> CORDAPP_BUILD_CONFIGURATIONS = unmodifiableList(asList(
         /*
@@ -400,6 +403,9 @@ public final class CordappPlugin implements Plugin<Project> {
 
             // Instruct Bnd not to add any extra manifest headers concerning JDK or Bnd versions.
             bndBundle.bnd(EXCLUDE_EXTRA_HEADERS);
+
+            // Instruct Bnd that finding META-INF/versions/ classes is not an error.
+            bndBundle.bnd(CLASSES_IN_WRONG_DIRECTORY_WARNING_INSTRUCTION);
 
             // Disable the bndfile property, which could clobber our bnd instructions.
             bndBundle.getBndfile().fileValue(null).disallowChanges();

--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpk2/CordappUtils.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpk2/CordappUtils.java
@@ -41,6 +41,10 @@ import java.util.jar.Manifest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static aQute.bnd.osgi.Constants.FIXUPMESSAGES_IS_DIRECTIVE;
+import static aQute.bnd.osgi.Constants.FIXUPMESSAGES_IS_ERROR;
+import static aQute.bnd.osgi.Constants.FIXUPMESSAGES_IS_WARNING;
+import static aQute.bnd.osgi.Constants.FIXUPMESSAGES_RESTRICT_DIRECTIVE;
 import static java.util.Collections.max;
 import static java.util.Collections.unmodifiableMap;
 import static org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME;
@@ -91,6 +95,11 @@ public final class CordappUtils {
     static final String CORDAPP_WORKFLOW_NAME = "Cordapp-Workflow-Name";
     static final String CORDAPP_WORKFLOW_VERSION = "Cordapp-Workflow-Version";
     public static final String CORDA_CPK_TYPE = "Corda-CPK-Type";
+
+    static final String CLASSES_IN_WRONG_DIRECTORY_FIXUP
+        = "\"Classes found in the wrong directory\";"
+            + FIXUPMESSAGES_RESTRICT_DIRECTIVE + '=' + FIXUPMESSAGES_IS_ERROR + ';'
+            + FIXUPMESSAGES_IS_DIRECTIVE + '=' + FIXUPMESSAGES_IS_WARNING;
 
     /*
      * Location of official R3 documentation for building CPKs and CPBs.

--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpk2/VerifyBundle.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpk2/VerifyBundle.java
@@ -44,11 +44,13 @@ import java.util.regex.Pattern;
 import javax.inject.Inject;
 
 import static aQute.bnd.osgi.Constants.EXPORT_PACKAGE;
+import static aQute.bnd.osgi.Constants.FIXUPMESSAGES;
 import static aQute.bnd.osgi.Constants.OPTIONAL;
 import static aQute.bnd.osgi.Constants.RESOLUTION_DIRECTIVE;
 import static aQute.bnd.osgi.Constants.STRICT;
 import static aQute.bnd.osgi.Constants.VERSION_ATTRIBUTE;
 import static java.util.Collections.emptyMap;
+import static net.corda.plugins.cpk2.CordappUtils.CLASSES_IN_WRONG_DIRECTORY_FIXUP;
 import static net.corda.plugins.cpk2.CordappUtils.CORDAPP_TASK_GROUP;
 import static net.corda.plugins.cpk2.CordappUtils.flatMapTo;
 import static net.corda.plugins.cpk2.CordappUtils.joinToString;
@@ -128,6 +130,7 @@ public class VerifyBundle extends DefaultTask {
 
     private void verify(@NotNull Jar jar) {
         try (Verifier verifier = new Verifier(jar)) {
+            verifier.setProperty(FIXUPMESSAGES, CLASSES_IN_WRONG_DIRECTORY_FIXUP);
             verifier.setProperty(STRICT, strict.get().toString());
             verifier.verify();
             verifyImportPackage(verifier);

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/CordappPrivateDependencyTest.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/CordappPrivateDependencyTest.kt
@@ -50,6 +50,7 @@ class CordappPrivateDependencyTest {
         val cordapp = artifacts.single { it.toString().endsWith(".jar") }
         assertThat(cordapp).isRegularFile
 
+        val kotlinVersion = testProject.properties["kotlin_version"]
         val providedDeps = StringReader(testProject.output)
             .readLines()
             .filter { it.startsWith(dependencyPrefix) }
@@ -57,10 +58,12 @@ class CordappPrivateDependencyTest {
         assertThat(providedDeps)
             .contains("CORDAPP cordaPrivateProvided: commons-collections:$commonsCollectionsVersion")
             .contains("CORDAPP cordaAllProvided: commons-collections:$commonsCollectionsVersion")
+            .contains("CORDAPP cordaAllProvided: kotlin-osgi-bundle:$kotlinVersion")
             .contains("CORDAPP cordaAllProvided: corda-api:$cordaApiVersion")
             .contains("HOST cordaPrivateProvided: commons-codec:$commonsCodecVersion")
             .contains("HOST cordaAllProvided: commons-codec:$commonsCodecVersion")
+            .contains("HOST cordaAllProvided: kotlin-osgi-bundle:$kotlinVersion")
             .contains("HOST cordaAllProvided: corda-api:$cordaApiVersion")
-            .hasSize(6)
+            .hasSize(8)
     }
 }

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/CordappWithPlatformTest.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/CordappWithPlatformTest.kt
@@ -42,7 +42,7 @@ class CordappWithPlatformTest {
             .withTestName("publish-platform")
             .withTaskName("publishAllPublicationsToTestRepository")
             .withTaskOutcome(UP_TO_DATE)
-            .build(
+            .execute(
                 "-Pcorda_api_version=$cordaApiVersion",
                 "-Prepository_dir=$repositoryDir"
             )

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/GradleProject.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/GradleProject.kt
@@ -263,10 +263,16 @@ class GradleProject(private val projectDir: Path, private val reporter: TestRepo
         println(output)
     }
 
+    fun execute(vararg args: String): GradleProject {
+        configureGradle(GradleRunner::build, args)
+        assertEquals(taskOutcome, resultFor(taskName).outcome)
+        return this
+    }
+
     fun build(vararg args: String): GradleProject {
         configureGradle(GradleRunner::build, args)
-        assertThat(buildDir).isDirectory
         assertEquals(taskOutcome, resultFor(taskName).outcome)
+        assertThat(buildDir).isDirectory
         return this
     }
 

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/MultiVersionCordappTest.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/MultiVersionCordappTest.kt
@@ -1,0 +1,40 @@
+package net.corda.plugins.cpk2
+
+import java.nio.file.Path
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.junit.jupiter.api.TestReporter
+import org.junit.jupiter.api.io.TempDir
+
+@TestInstance(PER_CLASS)
+class MultiVersionCordappTest {
+    private companion object {
+        private const val cordappVersion = "1.0.1-SNAPSHOT"
+    }
+
+    private lateinit var testProject: GradleProject
+
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("multi-version-cordapp")
+            .withSubResource("src/main/java/com/example/multi/ExampleContract.java")
+            .withSubResource("src/main/java11/com/example/multi/ExampleContract.java")
+            .build(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcommons_io_version=$commonsIoVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pcordapp_version=$cordappVersion"
+            )
+    }
+
+    @Test
+    fun testFixupWarningWhenCreatingJar() {
+        assertThat(testProject.outputLines).anyMatch { line ->
+            line.endsWith(": Classes found in the wrong directory: {META-INF/versions/11/com/example/multi/ExampleContract.class=com.example.multi.ExampleContract}")
+        }
+    }
+}

--- a/cordapp-cpk2/src/test/resources/configure-corda-metadata/cordapp/build.gradle
+++ b/cordapp-cpk2/src/test/resources/configure-corda-metadata/cordapp/build.gradle
@@ -25,7 +25,7 @@ tasks.named('jar', Jar) {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
     cordaProvided project(':corda-api')
     cordaProvided("org.hibernate:hibernate-osgi:$hibernate_version") {
         exclude group: 'org.osgi'

--- a/cordapp-cpk2/src/test/resources/configure-corda-metadata/cordapp/src/main/kotlin/com/example/metadata/custom/ExampleContract.kt
+++ b/cordapp-cpk2/src/test/resources/configure-corda-metadata/cordapp/src/main/kotlin/com/example/metadata/custom/ExampleContract.kt
@@ -31,5 +31,8 @@ class ExampleContract : Contract {
 }
 
 class ExampleState(issuer: AbstractParty) : ContractState {
-    override val participants: List<AbstractParty> = unmodifiableList(listOf(issuer))
+    private val participants = unmodifiableList(listOf(issuer))
+    override fun getParticipants(): List<AbstractParty> {
+        return participants
+    }
 }

--- a/cordapp-cpk2/src/test/resources/corda-api/build.gradle
+++ b/cordapp-cpk2/src/test/resources/corda-api/build.gradle
@@ -1,11 +1,9 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm'
     id 'biz.aQute.bnd.builder'
     id 'java-library'
     id 'maven-publish'
 }
 apply from: '../javaTarget.gradle'
-apply from: '../kotlin.gradle'
 
 group = 'net.corda'
 version = corda_api_version
@@ -19,7 +17,7 @@ repositories {
 
 dependencies {
     compileOnly "org.osgi:osgi.annotation:$osgi_version"
-    api "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    compileOnly "org.jetbrains:annotations:$jetbrains_annotations_version"
     api "javax.persistence:javax.persistence-api:$persistence_api_version"
     api "org.slf4j:slf4j-api:$corda_slf4j_version"
     runtimeOnly "com.google.guava:guava:$corda_guava_version"
@@ -41,7 +39,7 @@ Bundle-Name: Fake Corda APIs
 publishing {
     publications {
         cordaApi(MavenPublication) {
-            from components.kotlin
+            from components.java
 
             pom {
                 name = 'Corda API'

--- a/cordapp-cpk2/src/test/resources/corda-api/src/main/java/net/corda/v5/application/flows/Flow.java
+++ b/cordapp-cpk2/src/test/resources/corda-api/src/main/java/net/corda/v5/application/flows/Flow.java
@@ -1,0 +1,6 @@
+package net.corda.v5.application.flows;
+
+@FunctionalInterface
+public interface Flow<T> {
+    T call() throws FlowException;
+}

--- a/cordapp-cpk2/src/test/resources/corda-api/src/main/java/net/corda/v5/application/flows/FlowException.java
+++ b/cordapp-cpk2/src/test/resources/corda-api/src/main/java/net/corda/v5/application/flows/FlowException.java
@@ -1,0 +1,9 @@
+package net.corda.v5.application.flows;
+
+import org.jetbrains.annotations.Nullable;
+
+public class FlowException extends Exception {
+    public FlowException(@Nullable String message, @Nullable Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/cordapp-cpk2/src/test/resources/corda-api/src/main/java/net/corda/v5/application/identity/AbstractParty.java
+++ b/cordapp-cpk2/src/test/resources/corda-api/src/main/java/net/corda/v5/application/identity/AbstractParty.java
@@ -1,0 +1,4 @@
+package net.corda.v5.application.identity;
+
+public abstract class AbstractParty {
+}

--- a/cordapp-cpk2/src/test/resources/corda-api/src/main/java/net/corda/v5/ledger/contracts/Contract.java
+++ b/cordapp-cpk2/src/test/resources/corda-api/src/main/java/net/corda/v5/ledger/contracts/Contract.java
@@ -1,0 +1,9 @@
+package net.corda.v5.ledger.contracts;
+
+import net.corda.v5.ledger.transactions.LedgerTransaction;
+import org.jetbrains.annotations.NotNull;
+
+@FunctionalInterface
+public interface Contract {
+    void verify(@NotNull LedgerTransaction ltx);
+}

--- a/cordapp-cpk2/src/test/resources/corda-api/src/main/java/net/corda/v5/ledger/contracts/ContractState.java
+++ b/cordapp-cpk2/src/test/resources/corda-api/src/main/java/net/corda/v5/ledger/contracts/ContractState.java
@@ -1,0 +1,10 @@
+package net.corda.v5.ledger.contracts;
+
+import java.util.List;
+import net.corda.v5.application.identity.AbstractParty;
+import org.jetbrains.annotations.NotNull;
+
+public interface ContractState {
+    @NotNull
+    List<AbstractParty> getParticipants();
+}

--- a/cordapp-cpk2/src/test/resources/corda-api/src/main/java/net/corda/v5/ledger/transactions/LedgerTransaction.java
+++ b/cordapp-cpk2/src/test/resources/corda-api/src/main/java/net/corda/v5/ledger/transactions/LedgerTransaction.java
@@ -1,0 +1,4 @@
+package net.corda.v5.ledger.transactions;
+
+public interface LedgerTransaction {
+}

--- a/cordapp-cpk2/src/test/resources/corda-api/src/main/java/net/corda/v5/persistence/MappedSchema.java
+++ b/cordapp-cpk2/src/test/resources/corda-api/src/main/java/net/corda/v5/persistence/MappedSchema.java
@@ -1,0 +1,29 @@
+package net.corda.v5.persistence;
+
+import org.jetbrains.annotations.NotNull;
+
+public class MappedSchema {
+    private final Class<?> schemaFamily;
+    private final int version;
+    private final Iterable<Class<?>> mappedTypes;
+
+    public MappedSchema(@NotNull Class<?> schemaFamily, int version, @NotNull Iterable<Class<?>> mappedTypes) {
+        this.schemaFamily = schemaFamily;
+        this.version = version;
+        this.mappedTypes = mappedTypes;
+    }
+
+    @NotNull
+    public final String getName() {
+        return schemaFamily.getName();
+    }
+
+    public final int getVersion() {
+        return version;
+    }
+
+    @NotNull
+    public final Iterable<Class<?>> getMappedTypes() {
+        return mappedTypes;
+    }
+}

--- a/cordapp-cpk2/src/test/resources/corda-api/src/main/java/net/corda/v5/serialization/SerializeAsToken.java
+++ b/cordapp-cpk2/src/test/resources/corda-api/src/main/java/net/corda/v5/serialization/SerializeAsToken.java
@@ -1,0 +1,4 @@
+package net.corda.v5.serialization;
+
+public interface SerializeAsToken {
+}

--- a/cordapp-cpk2/src/test/resources/corda-api/src/main/java/net/corda/v5/serialization/SingletonSerializeAsToken.java
+++ b/cordapp-cpk2/src/test/resources/corda-api/src/main/java/net/corda/v5/serialization/SingletonSerializeAsToken.java
@@ -1,0 +1,4 @@
+package net.corda.v5.serialization;
+
+public interface SingletonSerializeAsToken extends SerializeAsToken {
+}

--- a/cordapp-cpk2/src/test/resources/corda-api/src/main/kotlin/net/corda/v5/application/flows/Flow.kt
+++ b/cordapp-cpk2/src/test/resources/corda-api/src/main/kotlin/net/corda/v5/application/flows/Flow.kt
@@ -1,7 +1,0 @@
-@file:Suppress("PackageDirectoryMismatch")
-package net.corda.v5.application.flows
-
-fun interface Flow<out T> {
-    @Throws(FlowException::class)
-    fun call(): T
-}

--- a/cordapp-cpk2/src/test/resources/corda-api/src/main/kotlin/net/corda/v5/application/flows/FlowException.kt
+++ b/cordapp-cpk2/src/test/resources/corda-api/src/main/kotlin/net/corda/v5/application/flows/FlowException.kt
@@ -1,4 +1,0 @@
-@file:Suppress("PackageDirectoryMismatch")
-package net.corda.v5.application.flows
-
-open class FlowException(message: String?, cause: Throwable?) : Exception(message, cause)

--- a/cordapp-cpk2/src/test/resources/corda-api/src/main/kotlin/net/corda/v5/application/identity/AbstractParty.kt
+++ b/cordapp-cpk2/src/test/resources/corda-api/src/main/kotlin/net/corda/v5/application/identity/AbstractParty.kt
@@ -1,4 +1,0 @@
-@file:Suppress("PackageDirectoryMismatch")
-package net.corda.v5.application.identity
-
-abstract class AbstractParty

--- a/cordapp-cpk2/src/test/resources/corda-api/src/main/kotlin/net/corda/v5/ledger/contracts/Contract.kt
+++ b/cordapp-cpk2/src/test/resources/corda-api/src/main/kotlin/net/corda/v5/ledger/contracts/Contract.kt
@@ -1,8 +1,0 @@
-@file:Suppress("PackageDirectoryMismatch")
-package net.corda.v5.ledger.contracts
-
-import net.corda.v5.ledger.transactions.LedgerTransaction
-
-fun interface Contract {
-    fun verify(ltx: LedgerTransaction)
-}

--- a/cordapp-cpk2/src/test/resources/corda-api/src/main/kotlin/net/corda/v5/ledger/contracts/ContractState.kt
+++ b/cordapp-cpk2/src/test/resources/corda-api/src/main/kotlin/net/corda/v5/ledger/contracts/ContractState.kt
@@ -1,8 +1,0 @@
-@file:Suppress("PackageDirectoryMismatch")
-package net.corda.v5.ledger.contracts
-
-import net.corda.v5.application.identity.AbstractParty
-
-interface ContractState {
-    val participants: List<AbstractParty>
-}

--- a/cordapp-cpk2/src/test/resources/corda-api/src/main/kotlin/net/corda/v5/ledger/transactions/LedgerTransaction.kt
+++ b/cordapp-cpk2/src/test/resources/corda-api/src/main/kotlin/net/corda/v5/ledger/transactions/LedgerTransaction.kt
@@ -1,4 +1,0 @@
-@file:Suppress("PackageDirectoryMismatch")
-package net.corda.v5.ledger.transactions
-
-interface LedgerTransaction

--- a/cordapp-cpk2/src/test/resources/corda-api/src/main/kotlin/net/corda/v5/persistence/MappedSchema.kt
+++ b/cordapp-cpk2/src/test/resources/corda-api/src/main/kotlin/net/corda/v5/persistence/MappedSchema.kt
@@ -1,6 +1,0 @@
-@file:Suppress("PackageDirectoryMismatch")
-package net.corda.v5.persistence
-
-open class MappedSchema(schemaFamily: Class<*>, val version: Int, val mappedTypes: Iterable<Class<*>>) {
-    val name: String = schemaFamily.name
-}

--- a/cordapp-cpk2/src/test/resources/corda-api/src/main/kotlin/net/corda/v5/serialization/SerializeAsToken.kt
+++ b/cordapp-cpk2/src/test/resources/corda-api/src/main/kotlin/net/corda/v5/serialization/SerializeAsToken.kt
@@ -1,4 +1,0 @@
-@file:Suppress("PackageDirectoryMismatch")
-package net.corda.v5.serialization
-
-interface SerializeAsToken

--- a/cordapp-cpk2/src/test/resources/corda-api/src/main/kotlin/net/corda/v5/serialization/SingletonSerializeAsToken.kt
+++ b/cordapp-cpk2/src/test/resources/corda-api/src/main/kotlin/net/corda/v5/serialization/SingletonSerializeAsToken.kt
@@ -1,4 +1,0 @@
-@file:Suppress("PackageDirectoryMismatch", "Unused")
-package net.corda.v5.serialization
-
-interface SingletonSerializeAsToken : SerializeAsToken

--- a/cordapp-cpk2/src/test/resources/cordapp-api-library/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cordapp-api-library/build.gradle
@@ -31,7 +31,7 @@ tasks.named('jar', Jar) {
 
 dependencies {
     cordaProvided project(':corda-api')
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
     cordapp project(':cordapp')
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
     implementation "com.google.guava:guava:$workflow_guava_version"
 }

--- a/cordapp-cpk2/src/test/resources/cordapp-classes-dep/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cordapp-classes-dep/build.gradle
@@ -23,7 +23,7 @@ cordapp {
 
 dependencies {
     compileOnly "org.osgi:org.osgi.service.component.annotations:$osgi_service_component_version"
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
     cordaProvided project(':corda-api')
     implementation project(':library')
 }

--- a/cordapp-cpk2/src/test/resources/cordapp-embedded-transitives/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cordapp-embedded-transitives/build.gradle
@@ -26,7 +26,7 @@ cordapp {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
     implementation "commons-io:commons-io:$commons_io_version"
     cordaProvided "org.slf4j:slf4j-api:$slf4j_version"
     cordaEmbedded project(':embeddable-library')

--- a/cordapp-cpk2/src/test/resources/cordapp-embedded-transitives/cordapp/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cordapp-embedded-transitives/cordapp/build.gradle
@@ -22,7 +22,7 @@ cordapp {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
     cordaEmbedded project(':embeddable-library')
     cordaProvided project(':corda-api')
     cordaProvided "org.slf4j:slf4j-api:$slf4j_version"

--- a/cordapp-cpk2/src/test/resources/cordapp-private-deps/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cordapp-private-deps/build.gradle
@@ -26,7 +26,7 @@ cordapp {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
     cordaPrivateProvided "commons-codec:commons-codec:$commons_codec_version"
     cordapp project(':cordapp')
 }

--- a/cordapp-cpk2/src/test/resources/cordapp-private-deps/cordapp/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cordapp-private-deps/cordapp/build.gradle
@@ -22,7 +22,7 @@ cordapp {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
     cordaPrivateProvided "commons-collections:commons-collections:$commons_collections_version"
     cordaProvided project(':corda-api')
 }

--- a/cordapp-cpk2/src/test/resources/cordapp-with-platform/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cordapp-with-platform/build.gradle
@@ -30,7 +30,7 @@ cordapp {
 dependencies {
     cordaProvided platform("net.corda:corda-platform:$corda_api_version")
     cordaProvided 'net.corda:corda-api'
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
 }
 
 tasks.named('jar', Jar) {

--- a/cordapp-cpk2/src/test/resources/cordapp-with-schema/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cordapp-with-schema/build.gradle
@@ -24,7 +24,7 @@ cordapp {
 
 dependencies {
     cordaProvided project(':corda-api')
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
     implementation "org.slf4j:slf4j-api:$slf4j_version"
 }
 

--- a/cordapp-cpk2/src/test/resources/cordapp-with-schema/src/main/kotlin/com/example/schema/SchemaContract.kt
+++ b/cordapp-cpk2/src/test/resources/cordapp-with-schema/src/main/kotlin/com/example/schema/SchemaContract.kt
@@ -17,11 +17,7 @@ data class Sample(val names: Set<String>)
 
 object SampleBase
 
-object SampleSchema : MappedSchema(
-    schemaFamily = SampleBase::class.java,
-    version = 1,
-    mappedTypes = listOf(PersistentSampleState::class.java)
-) {
+object SampleSchema : MappedSchema(SampleBase::class.java, 1, listOf(PersistentSampleState::class.java)) {
     @Entity
     @Table(name = "sample_states")
     class PersistentSampleState(

--- a/cordapp-cpk2/src/test/resources/cpb-with-platform/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cpb-with-platform/build.gradle
@@ -34,7 +34,7 @@ configurations {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
     cordaProvided 'net.corda:corda-api'
 
     cordapp platform("net.corda:corda-platform:$corda_api_version")

--- a/cordapp-cpk2/src/test/resources/deep-transitive-cordapps/cpk-final/build.gradle
+++ b/cordapp-cpk2/src/test/resources/deep-transitive-cordapps/cpk-final/build.gradle
@@ -22,6 +22,6 @@ cordapp {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
     cordapp project(':cpk-one')
 }

--- a/cordapp-cpk2/src/test/resources/deep-transitive-cordapps/cpk-one/build.gradle
+++ b/cordapp-cpk2/src/test/resources/deep-transitive-cordapps/cpk-one/build.gradle
@@ -33,6 +33,6 @@ tasks.named('compileKotlin') {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
     cordapp project(':cpk-two')
 }

--- a/cordapp-cpk2/src/test/resources/deep-transitive-cordapps/cpk-two/build.gradle
+++ b/cordapp-cpk2/src/test/resources/deep-transitive-cordapps/cpk-two/build.gradle
@@ -22,6 +22,6 @@ cordapp {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
     cordaProvided project(':corda-api')
 }

--- a/cordapp-cpk2/src/test/resources/multi-version-cordapp/build.gradle
+++ b/cordapp-cpk2/src/test/resources/multi-version-cordapp/build.gradle
@@ -1,0 +1,55 @@
+plugins {
+    id 'net.corda.plugins.cordapp-cpk2'
+}
+
+apply from: 'repositories.gradle'
+apply from: 'javaTarget.gradle'
+
+group = 'com.example'
+version = cordapp_version
+
+cordapp {
+    targetPlatformVersion = platform_version.toInteger()
+    minimumPlatformVersion = platform_version.toInteger()
+
+    contract {
+        name = 'Multi-Version Java'
+        versionId = cordapp_contract_version.toInteger()
+        licence = 'Test-Licence'
+        vendor = 'R3'
+    }
+}
+
+sourceSets {
+    java11 {
+        java {
+            srcDirs = [ 'src/main/java11' ]
+        }
+        compileClasspath += main.compileClasspath
+    }
+}
+
+dependencies {
+    cordaProvided project(':corda-api')
+    implementation "commons-io:commons-io:$commons_io_version"
+
+    java11Implementation files(sourceSets.main.output) {
+        builtBy tasks.named('compileJava', JavaCompile)
+    }
+}
+
+tasks.named('compileJava11Java', JavaCompile) {
+    options.release = 11
+}
+
+tasks.named('jar', Jar) {
+    archiveBaseName = 'multi-version-cordapp'
+
+    from(sourceSets.java11.output) { CopySpec spec ->
+        spec.into 'META-INF/versions/11'
+    }
+
+    manifest {
+        attributes('Multi-Release': true)
+    }
+}

--- a/cordapp-cpk2/src/test/resources/multi-version-cordapp/settings.gradle
+++ b/cordapp-cpk2/src/test/resources/multi-version-cordapp/settings.gradle
@@ -1,0 +1,11 @@
+// Common settings for all Gradle test projects.
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = 'multi-version-cordapp'
+
+include 'corda-api'
+project(':corda-api').projectDir = file('../resources/test/corda-api')

--- a/cordapp-cpk2/src/test/resources/multi-version-cordapp/src/main/java/com/example/multi/ExampleContract.java
+++ b/cordapp-cpk2/src/test/resources/multi-version-cordapp/src/main/java/com/example/multi/ExampleContract.java
@@ -1,0 +1,15 @@
+package com.example.multi;
+
+import net.corda.v5.ledger.contracts.Contract;
+import net.corda.v5.ledger.transactions.LedgerTransaction;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+
+public class ExampleContract implements Contract {
+    private final Logger LOGGER = LoggerFactory.getLogger(ExampleContract.class);
+
+    @Override
+    public void verify(LedgerTransaction ltx) {
+        LOGGER.info("Base Java: {}", ltx);
+    }
+}

--- a/cordapp-cpk2/src/test/resources/multi-version-cordapp/src/main/java11/com/example/multi/ExampleContract.java
+++ b/cordapp-cpk2/src/test/resources/multi-version-cordapp/src/main/java11/com/example/multi/ExampleContract.java
@@ -1,0 +1,15 @@
+package com.example.multi;
+
+import net.corda.v5.ledger.contracts.Contract;
+import net.corda.v5.ledger.transactions.LedgerTransaction;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+
+public class ExampleContract implements Contract {
+    private final Logger LOGGER = LoggerFactory.getLogger(ExampleContract.class);
+
+    @Override
+    public void verify(LedgerTransaction ltx) {
+        LOGGER.info("Java 11: {}", ltx);
+    }
+}

--- a/cordapp-cpk2/src/test/resources/publish-platform/settings.gradle
+++ b/cordapp-cpk2/src/test/resources/publish-platform/settings.gradle
@@ -1,9 +1,3 @@
-pluginManagement {
-    plugins {
-        id 'org.jetbrains.kotlin.jvm' version kotlin_version
-    }
-}
-
 rootProject.name = 'publish-platform'
 
 include 'corda-api'

--- a/cordapp-cpk2/src/test/resources/simple-kotlin-cordapp/build.gradle
+++ b/cordapp-cpk2/src/test/resources/simple-kotlin-cordapp/build.gradle
@@ -24,7 +24,7 @@ cordapp {
 
 dependencies {
     cordaProvided project(':corda-api')
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
     implementation "commons-io:commons-io:$commons_io_version"
     implementation "com.google.guava:guava:$guava_version"
     cordaEmbedded 'com.google.errorprone:error_prone_annotations'

--- a/cordapp-cpk2/src/test/resources/simple-kotlin-cordapp/src/main/kotlin/com/example/contract/states/ExampleState.kt
+++ b/cordapp-cpk2/src/test/resources/simple-kotlin-cordapp/src/main/kotlin/com/example/contract/states/ExampleState.kt
@@ -1,3 +1,4 @@
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package com.example.contract.states
 
 import com.google.common.collect.ImmutableList
@@ -5,5 +6,7 @@ import net.corda.v5.application.identity.AbstractParty
 import net.corda.v5.ledger.contracts.ContractState
 
 class ExampleState(val issuer: AbstractParty) : ContractState {
-    override val participants: List<AbstractParty> = ImmutableList.of(issuer)
+    override fun getParticipants(): List<AbstractParty> {
+        return ImmutableList.of(issuer)
+    }
 }

--- a/cordapp-cpk2/src/test/resources/transitive-cordapps/build.gradle
+++ b/cordapp-cpk2/src/test/resources/transitive-cordapps/build.gradle
@@ -77,7 +77,7 @@ cordapp {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
     implementation "commons-io:commons-io:$commons_io_version"
     cordapp project(':cpk-three')
 }

--- a/cordapp-cpk2/src/test/resources/transitive-remote-cordapps/build.gradle
+++ b/cordapp-cpk2/src/test/resources/transitive-remote-cordapps/build.gradle
@@ -29,7 +29,7 @@ cordapp {
 
 dependencies {
     cordaProvided platform("net.corda:corda-platform:$corda_api_version")
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
     implementation "commons-io:commons-io:$commons_io_version"
     cordapp "com.example:cpk-three:$cpk3_version"
 }

--- a/cordapp-cpk2/src/test/resources/verify-cordapp-dependency/build.gradle
+++ b/cordapp-cpk2/src/test/resources/verify-cordapp-dependency/build.gradle
@@ -28,7 +28,7 @@ cordapp {
 dependencies {
     cordapp project(':cordapp')
     cordaProvided project(':corda-api')
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
     implementation "commons-collections:commons-collections:$commons_collections_version"
 }
 

--- a/cordapp-cpk2/src/test/resources/verify-cordapp-dependency/cordapp/build.gradle
+++ b/cordapp-cpk2/src/test/resources/verify-cordapp-dependency/cordapp/build.gradle
@@ -23,7 +23,7 @@ cordapp {
 
 dependencies {
     cordaProvided project(':corda-api')
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
     implementation "commons-io:commons-io:$commons_io_version"
 }
 

--- a/cordapp-cpk2/src/test/resources/with-corda-metadata/contracts/build.gradle
+++ b/cordapp-cpk2/src/test/resources/with-corda-metadata/contracts/build.gradle
@@ -26,7 +26,7 @@ jar {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
     cordaProvided project(':corda-api')
     cordaProvided("org.hibernate:hibernate-osgi:$hibernate_version") {
         exclude group: 'org.osgi'

--- a/cordapp-cpk2/src/test/resources/with-corda-metadata/contracts/src/main/kotlin/com/example/metadata/contracts/ExampleContract.kt
+++ b/cordapp-cpk2/src/test/resources/with-corda-metadata/contracts/src/main/kotlin/com/example/metadata/contracts/ExampleContract.kt
@@ -1,4 +1,4 @@
-@file:Suppress("unused")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package com.example.metadata.contracts
 
 import net.corda.v5.application.identity.AbstractParty
@@ -31,5 +31,7 @@ class ExampleContract : Contract {
 }
 
 class ExampleState(val issuer: AbstractParty) : ContractState {
-    override val participants: List<AbstractParty> = unmodifiableList(listOf(issuer))
+    override fun getParticipants(): List<AbstractParty> {
+        return unmodifiableList(listOf(issuer))
+    }
 }

--- a/cordapp-cpk2/src/test/resources/with-corda-metadata/contracts/src/main/kotlin/com/example/metadata/schemas/ExampleSchema.kt
+++ b/cordapp-cpk2/src/test/resources/with-corda-metadata/contracts/src/main/kotlin/com/example/metadata/schemas/ExampleSchema.kt
@@ -1,4 +1,4 @@
-@file:Suppress("unused")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package com.example.metadata.schemas
 
 import net.corda.v5.persistence.MappedSchema
@@ -9,11 +9,7 @@ import javax.persistence.Table
 
 object ExampleSchema
 
-object ExampleSchemaV1 : MappedSchema(
-    schemaFamily = ExampleSchema::class.java,
-    version = 1,
-    mappedTypes = listOf(ExampleEntity::class.java)
-) {
+object ExampleSchemaV1 : MappedSchema(ExampleSchema::class.java, 1, listOf(ExampleEntity::class.java)) {
     @Entity
     @Table(name = "example_entities")
     class ExampleEntity(

--- a/cordapp-cpk2/src/test/resources/with-corda-metadata/workflows/build.gradle
+++ b/cordapp-cpk2/src/test/resources/with-corda-metadata/workflows/build.gradle
@@ -26,7 +26,7 @@ jar {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
     cordaProvided project(':corda-api')
     cordapp project(':contracts')
 }

--- a/cordapp-cpk2/src/test/resources/with-corda-metadata/workflows/src/main/kotlin/com/example/metadata/workflows/ExampleFlow.kt
+++ b/cordapp-cpk2/src/test/resources/with-corda-metadata/workflows/src/main/kotlin/com/example/metadata/workflows/ExampleFlow.kt
@@ -1,4 +1,4 @@
-@file:Suppress("unused")
+@file:Suppress("unused", "PackageDirectoryMismatch")
 package com.example.metadata.workflows
 
 import com.example.metadata.contracts.ExampleState


### PR DESCRIPTION
Instruct Bnd that finding classes in folders other than their package folder is a warning rather than an error. This allows CorDapps to contain multi-release jars, which have classes in `META-INF/versions` folders.

Also translate the "dummy" Corda API from Kotlin to Java to make the tests more realistic, which in turn means that the `kotlin-osgi-bundle` _must_ now be a `cordaProvided` dependency.