### PR TITLE
NOTICK: Fix generated name for CPK marker POM.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ### Version 7.0.3
 
+* `cordapp-cpk2`: Set "name" correctly in CPK marker POM.
+
 ### Version 7.0.2
 
 * `cordapp-cpk2`: Upgrade to Bnd 6.4.0.

--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpk2/CordappDependencyCollector.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpk2/CordappDependencyCollector.java
@@ -150,7 +150,7 @@ final class CordappDependencyCollector {
                         }
                     }
                     final Dependency cordapp = dependencyHandler.create(toCPK(depMap));
-                    // Try to resolve the CorDapp's "companion" dependency.
+                    // Try to resolve the CorDapp's "marker" dependency.
                     // This may not exist, although it's better if it does.
                     collectFrom(cordapp);
                 }
@@ -175,7 +175,7 @@ final class CordappDependencyCollector {
         if (resolved.hasError()) {
             logger.warn("CorDapp has unresolved dependencies:{}",
                 joinToString(resolved.getLenientConfiguration().getUnresolvedModuleDependencies(), SEPARATOR, SEPARATOR));
-            logger.warn("Cannot resolve CPK companion artifact '{}' - SKIPPED", toMaven(cordapp));
+            logger.warn("Cannot resolve CPK marker artifact '{}' - SKIPPED", toMaven(cordapp));
         } else {
             // This should never now throw ResolveException.
             collectFrom(resolved.getFirstLevelModuleDependencies(dep ->
@@ -202,12 +202,12 @@ final class CordappDependencyCollector {
     }
 
     @NotNull
-    static String toCompanionGroupId(@Nullable String group, @NotNull String artifactId) {
+    static String toMarkerGroupId(@Nullable String group, @NotNull String artifactId) {
         return toCpkPrefix(group) + artifactId;
     }
 
     @NotNull
-    static String toCompanionArtifactId(@NotNull String artifactId) {
+    static String toMarkerArtifactId(@NotNull String artifactId) {
         return artifactId + CPK_SUFFIX;
     }
 
@@ -265,8 +265,8 @@ final class CordappDependencyCollector {
     @NotNull
     private static Map<String, String> toCPK(@NotNull Map<String, String> map) {
         final String artifactName = map.get(DEPENDENCY_NAME);
-        map.put(DEPENDENCY_GROUP, toCompanionGroupId(map.get(DEPENDENCY_GROUP), artifactName));
-        map.put(DEPENDENCY_NAME, toCompanionArtifactId(artifactName));
+        map.put(DEPENDENCY_GROUP, toMarkerGroupId(map.get(DEPENDENCY_GROUP), artifactName));
+        map.put(DEPENDENCY_NAME, toMarkerArtifactId(artifactName));
         return map;
     }
 

--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpk2/CordappPlugin.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpk2/CordappPlugin.java
@@ -294,7 +294,7 @@ public final class CordappPlugin implements Plugin<Project> {
 
             // Unlike cordaProvided dependencies, cordaPrivateProvided ones will not be
             // added to the compilation classpath of any CPKs that will depend on this CPK.
-            // In other words, they will not be included in this CPK's companion POM.
+            // In other words, they will not be included in this CPK's marker POM.
             final Configuration cordaPrivate = createCompileConfiguration(configurations, CORDA_PRIVATE_CONFIGURATION_NAME)
                 .setDescription("Corda-provided dependencies which are only available to this CorDapp.");
 

--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpk2/PomXmlWriter.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpk2/PomXmlWriter.java
@@ -12,8 +12,8 @@ import org.jetbrains.annotations.Nullable;
 import org.w3c.dom.Element;
 import java.util.function.Function;
 
-import static net.corda.plugins.cpk2.CordappDependencyCollector.toCompanionArtifactId;
-import static net.corda.plugins.cpk2.CordappDependencyCollector.toCompanionGroupId;
+import static net.corda.plugins.cpk2.CordappDependencyCollector.toMarkerArtifactId;
+import static net.corda.plugins.cpk2.CordappDependencyCollector.toMarkerGroupId;
 import static net.corda.plugins.cpk2.CordappUtils.CORDAPP_CONFIGURATION_NAME;
 import static net.corda.plugins.cpk2.CordappUtils.CORDA_PROVIDED_CONFIGURATION_NAME;
 import static net.corda.plugins.cpk2.CordappUtils.appendElement;
@@ -98,13 +98,13 @@ final class CordappCoordinate extends MavenCoordinate {
     @Override
     @NotNull
     String getGroupId() {
-        return toCompanionGroupId(id.getGroup(), artifactName);
+        return toMarkerGroupId(id.getGroup(), artifactName);
     }
 
     @Override
     @NotNull
     String getArtifactId() {
-        return toCompanionArtifactId(artifactName);
+        return toMarkerArtifactId(artifactName);
     }
 }
 


### PR DESCRIPTION
The `MavenPom.getName()` is a Gradle property, so map the parent name instead of assigning it.

Rename this POM as a "marker" rather than a "companion".