### PR TITLE
CORE-14504: Upgrade to Bndlib 6.4.1.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ### Version 7.0.4
 
+* `cordapp-cpk2`: Upgrade to Bndlib 6.4.1.
+
 ### Version 7.0.3
 
 * `cordapp-cpk2`: Set "name" correctly in CPK marker POM.

--- a/cordapp-cpk2/build.gradle
+++ b/cordapp-cpk2/build.gradle
@@ -71,7 +71,22 @@ dependencies {
         }
         implementation('biz.aQute.bnd:biz.aQute.bndlib') {
             version {
-                require bnd_version
+                require bndlib_version
+            }
+        }
+        implementation('biz.aQute.bnd:biz.aQute.bnd.embedded-repo') {
+            version {
+                require bndlib_version
+            }
+        }
+        implementation('biz.aQute.bnd:biz.aQute.repository') {
+            version {
+                require bndlib_version
+            }
+        }
+        implementation('biz.aQute.bnd:biz.aQute.resolve') {
+            version {
+                require bndlib_version
             }
         }
     }
@@ -80,7 +95,7 @@ dependencies {
 
     // Add the Bnd plugins to our classpath too, so that we can use them.
     implementation "biz.aQute.bnd:biz.aQute.bnd.gradle:$bnd_version"
-    implementation "biz.aQute.bnd:biz.aQute.bndlib:$bnd_version"
+    implementation "biz.aQute.bnd:biz.aQute.bndlib:$bndlib_version"
 
     testImplementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_jupiter_version"
@@ -101,7 +116,7 @@ processResources {
         expand([
             'jetbrains_annotations_version': jetbrains_annotations_version,
             'osgi_version': osgi_version,
-            'bnd_version': bnd_version
+            'bndlib_version': bndlib_version
         ])
     }
 }
@@ -117,6 +132,7 @@ processTestResources {
             'osgi_version': osgi_version,
             'jetbrains_annotations_version': jetbrains_annotations_version,
             'kotlin_version': test_kotlin_version,
+            'bndlib_version': bndlib_version,
             'bnd_version': bnd_version
         ])
     }

--- a/cordapp-cpk2/src/main/resources/net/corda/plugins/cpk2/cordapp-cpk2.properties
+++ b/cordapp-cpk2/src/main/resources/net/corda/plugins/cpk2/cordapp-cpk2.properties
@@ -1,3 +1,3 @@
 jetbrainsAnnotationsVersion=$jetbrains_annotations_version
 osgiVersion=$osgi_version
-bndVersion=$bnd_version
+bndVersion=$bndlib_version

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/WithDependentCordappTest.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/WithDependentCordappTest.kt
@@ -54,14 +54,14 @@ class WithDependentCordappTest {
     ) {
         val testProject = buildProject(guavaVersion, libraryGuavaVersion, testProjectDir, reporter)
         val cordaSlf4jVersion = testProject.properties.getProperty("corda_slf4j_version")
-        val bndVersion = testProject.properties.getProperty("bnd_version")
+        val bndlibVersion = testProject.properties.getProperty("bndlib_version")
         val osgiVersion = testProject.properties.getProperty("osgi_version")
         val jetbrainsAnnotationsVersion = testProject.properties.getProperty("jetbrains_annotations_version")
         assertEquals(CORDA_GUAVA_VERSION, testProject.properties.getProperty("corda_guava_version"))
         assertNotEquals(cordaSlf4jVersion, librarySlf4jVersion)
 
         assertThat(testProject.outputLines)
-            .contains("COMPILE-WORKFLOW> biz.aQute.bnd.annotation-${bndVersion}.jar")
+            .contains("COMPILE-WORKFLOW> biz.aQute.bnd.annotation-${bndlibVersion}.jar")
             .contains("COMPILE-WORKFLOW> osgi.annotation-${osgiVersion}.jar")
             .contains("COMPILE-WORKFLOW> annotations-${jetbrainsAnnotationsVersion}.jar")
             .contains("COMPILE-WORKFLOW> guava-${guavaVersion}.jar")
@@ -69,7 +69,7 @@ class WithDependentCordappTest {
             .contains("EXTERNAL-WORKFLOW> corda-api-${cordaApiVersion}.jar")
             .contains("EXTERNAL-WORKFLOW> slf4j-api-${cordaSlf4jVersion}.jar")
             .contains("EXTERNAL-WORKFLOW> cordapp.jar")
-            .contains("COMPILE-CONTRACT> biz.aQute.bnd.annotation-${bndVersion}.jar")
+            .contains("COMPILE-CONTRACT> biz.aQute.bnd.annotation-${bndlibVersion}.jar")
             .contains("COMPILE-CONTRACT> osgi.annotation-${osgiVersion}.jar")
             .contains("COMPILE-CONTRACT> annotations-${jetbrainsAnnotationsVersion}.jar")
             .contains("COMPILE-CONTRACT> slf4j-api-${cordaSlf4jVersion}.jar")
@@ -95,7 +95,7 @@ class WithDependentCordappTest {
             .noneMatch { it == "commons-io-$commonsIoVersion.jar" }
             .noneMatch { it == "slf4j-api-${cordaSlf4jVersion}.jar" }
             .noneMatch { it == "slf4j-api-${librarySlf4jVersion}.jar" }
-            .noneMatch { it == "biz.aQute.bnd.annotation-${bndVersion}.jar" }
+            .noneMatch { it == "biz.aQute.bnd.annotation-${bndlibVersion}.jar" }
             .noneMatch { it == "osgi.annotation-${osgiVersion}.jar" }
             .noneMatch { it == "annotations-${jetbrainsAnnotationsVersion}.jar" }
             .noneMatch { it == "library.jar" }
@@ -123,7 +123,7 @@ class WithDependentCordappTest {
         val contractCpk = testProject.buildDir.resolve("cordapp.jar")
         assertThat(contractCpk).isRegularFile
         assertThat(listLibrariesForCpk(contractCpk))
-            .noneMatch { it == "biz.aQute.bnd.annotation-${bndVersion}.jar" }
+            .noneMatch { it == "biz.aQute.bnd.annotation-${bndlibVersion}.jar" }
             .noneMatch { it == "osgi.annotation-${osgiVersion}.jar" }
             .noneMatch { it == "annotations-${jetbrainsAnnotationsVersion}.jar" }
             .noneMatch { it == "slf4j-api-${librarySlf4jVersion}.jar" }

--- a/cordapp-cpk2/src/test/resources/gradle.properties
+++ b/cordapp-cpk2/src/test/resources/gradle.properties
@@ -16,4 +16,5 @@ hibernate_version=$hibernate_version
 jetbrains_annotations_version=$jetbrains_annotations_version
 kotlin_version=$kotlin_version
 osgi_version=$osgi_version
+bndlib_version=$bndlib_version
 bnd_version=$bnd_version

--- a/cordapp-cpk2/src/test/resources/with-dependent-cordapp/build.gradle
+++ b/cordapp-cpk2/src/test/resources/with-dependent-cordapp/build.gradle
@@ -27,7 +27,7 @@ cordapp {
     }
 }
 
-jar {
+tasks.named('jar', Jar) {
     archiveBaseName = 'with-dependent-cordapp'
     doFirst {
         configurations.compileClasspath.forEach { dep ->
@@ -52,6 +52,7 @@ dependencies {
 def copy = tasks.register('copy', Copy) {
     into project.layout.buildDirectory
     from configurations.cordappDependency
+    mustRunAfter tasks.named('verifyBundle')
 }
 
 tasks.named('assemble') {

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,8 @@ javax_annotations_version=1.3.2
 jetbrains_annotations_version=13.0
 osgi_version=8.1.0
 bnd_version=6.4.0
-jacksonVersion=2.14.2
+bndlib_version=6.4.1
+jacksonVersion=2.15.1
 
 artifactory_version=4.29.2
 gradle_publish_version=0.21.0


### PR DESCRIPTION
Bndlib 6.4.1 has been released, although it has is no accompanying Gradle plugin. Upgrade `cordapp-cpk2` to use Bndlib 6.4.1 while still using Bnd's 6.4.0 builder plugin.