### PR TITLE
ES-858: Update Corda Gradle plugins post artifactory change

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -9,6 +9,6 @@ cordaPipeline(
     slimBuild: true,
     snykAdditionalCommands: "--configuration-matching='^runtimeClasspath\$' -d",
     snykOrgId: 'r3-gradle-plugins-snyk-org-id',
-    snykToken: 'r3-gradle-plugins',
+    snykToken: 'r3-gradle-plugins-secret',
     stableUnstableRepoPattern: false,
     )

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@connelm/ES-858/corda-gradle-plugins-changes') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaPipeline(
     dedicatedJobForSnykDelta: false,

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,122 +1,14 @@
-#!groovy
-/**
- * Jenkins pipeline to build Corda Gradle Plugins
- */
+@Library('corda-shared-build-pipeline-steps@connelm/ES-858/corda-gradle-plugins-changes') _
 
-/**
- * Kill already started job.
- * Assume new commit takes precedence and results from previousunfinished builds are not required.
- * This feature doesn't play well with disableConcurrentBuilds() option
- */
-@Library('corda-shared-build-pipeline-steps')
-import static com.r3.build.BuildControl.killAllExistingBuildsForJob
-killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
-
-/**
- * Sense environment
- */
-boolean isReleaseBranch = (env.BRANCH_NAME =~ /^release\/.*/)
-boolean isRelease = (env.TAG_NAME =~ /^release\/.*/)
-
-boolean isBeta = (env.TAG_NAME =~ /^beta\/.*/)
-
-boolean doPublish = isReleaseBranch || isRelease || isBeta
-
-pipeline {
-    agent {
-        label 'standard'
-    }
-    parameters {
-        booleanParam name: 'DO_PUBLISH',
-                     defaultValue: doPublish,
-                     description: 'Publish artifacts to Artifactory?'
-    }
-    options {
-        ansiColor('xterm')
-        timestamps()
-        timeout(3*60) // 3 hours
-        buildDiscarder(logRotator(daysToKeepStr: '14', artifactDaysToKeepStr: '14'))
-    }
-    environment {
-        // Replace / with :: as links from Jenkins to Artifactory are broken if we use slashes
-        // in the name
-        ARTIFACTORY_BUILD_NAME = "Corda Gradle Plugins / Publish To Artifactory"
-            .replaceAll("/", " :: ")
-        ARTIFACTORY_REPO = "${isRelease || isBeta ? "corda-releases" : "corda-dev"}"
-        ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
-        CORDA_ARTIFACTORY_USERNAME = "${env.ARTIFACTORY_CREDENTIALS_USR}"
-        CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
-        SNYK_TOKEN = "r3-gradle-plugins"
-        SNYK_COMMANDS = "--all-sub-projects --configuration-matching='^runtimeClasspath\$' --prune-repeated-subdependencies --target-reference='${env.BRANCH_NAME}' --project-tags=Branch='${env.BRANCH_NAME.replaceAll("[^0-9|a-z|A-Z]+","_")}'"
-    }
-    stages {
-        stage('Build') {
-            steps {
-                authenticateGradleWrapper()
-                sh './gradlew --no-daemon --info --no-build-cache clean build'
-            }
-        }
-        
-        stage('Snyk Security Scan') {
-            when {
-                not {
-                    changeRequest()
-                }
-            }
-            steps {
-                snykSecurityScan("${env.SNYK_TOKEN}", "${env.SNYK_COMMANDS}", true, true)
-            }
-        }
-        stage('Publish to Artifactory') {
-            when {
-                expression { params.DO_PUBLISH }
-                beforeAgent true
-            }
-            steps {
-                rtServer (
-                    id: 'R3-Artifactory',
-                    url: 'https://software.r3.com/artifactory',
-                    credentialsId: 'artifactory-credentials'
-                )
-                rtGradleDeployer (
-                    id: 'deployer',
-                    serverId: 'R3-Artifactory',
-                    repo: env.ARTIFACTORY_REPO,
-                )
-                rtGradleRun (
-                    usesPlugin: true,
-                    useWrapper: true,
-                    switches: "--no-daemon --info -s",
-                    tasks: 'artifactoryPublish',
-                    deployerId: 'deployer',
-                    buildName: env.ARTIFACTORY_BUILD_NAME
-                )
-                rtPublishBuildInfo (
-                    serverId: 'R3-Artifactory',
-                    buildName: env.ARTIFACTORY_BUILD_NAME
-                )
-            }
-        }
-    }
-    post {
-        always {
-            script {
-                if(!env.CHANGE_ID) {
-                    snykSecurityScan.generateHtmlElements()
-                }
-            }
-            junit testResults: '**/build/test-results/**/*.xml', keepLongStdio: true, allowEmptyResults: true
-        }
-        cleanup {
-            deleteDir()
-        }
-    }
-}
-
-def isReleaseBranch() {
-    return (env.BRANCH_NAME =~ /^release\/.*$/)
-}
-
-def isMainBranch() {
-    return (env.BRANCH_NAME =~ /^master$/)
-}
+cordaPipeline(
+    dedicatedJobForSnykDelta: false,
+    gitHubComments: false,
+    javaVersion: '8',
+    publishToMavenS3Repository: true,
+    publishRepoPrefix: 'corda',
+    slimBuild: true,
+    snykAdditionalCommands: "--configuration-matching='^runtimeClasspath\$' -d",
+    snykOrgId: 'r3-gradle-plugins-snyk-org-id',
+    snykToken: 'r3-gradle-plugins',
+    stableUnstableRepoPattern: false,
+    )

--- a/.ci/nightly/JenkinsfileSnykScan
+++ b/.ci/nightly/JenkinsfileSnykScan
@@ -1,0 +1,6 @@
+@Library('corda-shared-build-pipeline-steps@5.1') _
+
+cordaSnykScanPipeline (
+    snykTokenId: 'r3-gradle-plugins',
+    snykAdditionalCommands: "--all-sub-projects --configuration-matching='^runtimeClasspath\$' -d"
+)

--- a/build.gradle
+++ b/build.gradle
@@ -234,6 +234,19 @@ configure(publishProjects) { Project subproject ->
                 }
             }
         }
+        if (subproject.hasProperty('maven.repo.s3')) {
+            repositories {
+                maven {
+                    name = 'AWS'
+                    url = subproject.findProperty('maven.repo.s3')
+                    credentials(AwsCredentials) {
+                        accessKey "${System.getenv('AWS_ACCESS_KEY_ID')}"
+                        secretKey "${System.getenv('AWS_SECRET_ACCESS_KEY')}"
+                        sessionToken "${System.getenv('AWS_SESSION_TOKEN')}"
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/cordapp-cpk/src/test/resources/gradle.properties
+++ b/cordapp-cpk/src/test/resources/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-XX:+UseG1GC -Xmx512m
 org.gradle.caching=false
 org.gradle.java.installations.auto-download=false
 
-artifactory_contextUrl=https://software.r3.com/artifactory
+publicArtifactURL=https://download.corda.net/maven
 
 kotlin.stdlib.default.dependency=false
 platform_version=999

--- a/cordapp-cpk/src/test/resources/repositories.gradle
+++ b/cordapp-cpk/src/test/resources/repositories.gradle
@@ -1,7 +1,13 @@
 repositories {
     mavenCentral()
     maven {
-        url "$publicArtifactURL/corda"
+        url "$publicArtifactURL/corda-dependencies"
+        mavenContent {
+            releasesOnly()
+        }
+    }
+    maven {
+        url "$publicArtifactURL/corda-releases"
         mavenContent {
             releasesOnly()
         }

--- a/cordapp-cpk/src/test/resources/repositories.gradle
+++ b/cordapp-cpk/src/test/resources/repositories.gradle
@@ -1,7 +1,7 @@
 repositories {
     mavenCentral()
     maven {
-        url "$artifactory_contextUrl/corda"
+        url "$publicArtifactURL/corda"
         mavenContent {
             releasesOnly()
         }

--- a/cordformation/src/test/resources/gradle.properties
+++ b/cordformation/src/test/resources/gradle.properties
@@ -7,3 +7,4 @@ jolokia_version=1.6.0
 docker_image_name=corda/corda-zulu-4.3
 
 artifactory_contextUrl=https://software.r3.com/artifactory
+publicArtifactURL=https://download.corda.net/maven

--- a/cordformation/src/test/resources/repositories.gradle
+++ b/cordformation/src/test/resources/repositories.gradle
@@ -7,10 +7,10 @@ repositories {
         }
     }
     maven {
-        url "$artifactory_contextUrl/corda-releases"
+        url "$publicArtifactURL/corda-releases"
     }
     maven {
-        url "$artifactory_contextUrl/corda-dependencies"
+        url "$publicArtifactURL/corda-dependencies"
     }
     mavenCentral()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,4 @@ artifactory_version=4.21.0
 gradle_publish_version=0.21.0
 
 artifactory_contextUrl=https://software.r3.com/artifactory
-
+publicArtifactURL=https://download.corda.net/maven

--- a/quasar-utils/src/test/resources/gradle.properties
+++ b/quasar-utils/src/test/resources/gradle.properties
@@ -2,3 +2,5 @@
 org.gradle.java.installations.auto-download=false
 org.gradle.jvmargs=-XX:+UseG1GC -Xmx512m
 org.gradle.caching=false
+
+publicArtifactURL=https://download.corda.net/maven

--- a/quasar-utils/src/test/resources/repositories.gradle
+++ b/quasar-utils/src/test/resources/repositories.gradle
@@ -1,9 +1,9 @@
 repositories {
     mavenCentral()
     maven {
-        url 'https://software.r3.com/artifactory/corda-dependencies-dev'
+        url "$publicArtifactURL/corda-dependencies-dev"
     }
     maven {
-        url 'https://software.r3.com/artifactory/corda-dependencies'
+        url "$publicArtifactURL/corda-dependencies"
     }
 }


### PR DESCRIPTION
Relates to [ES-486](https://r3-cev.atlassian.net/browse/ES-486)
Remove public facing access to Artifactory

[ES-486]: https://r3-cev.atlassian.net/browse/ES-486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Enabling shared pipeline and leveraging PR [here ](https://github.com/corda/corda-shared-build-pipeline-steps/pull/986) to publish to the Maven Prod S3 bucket

Standard publishing to Artifactory remains as this is the ultimate source of truth. 

Separate automation is in place such if an item is removed from artifactory it is removed from S3.

This PR also updates the `Jenkins` file here in line with the approach taken in the `master` branch of this repo to leverage our Jenkins shared library, core functionality and tasks triggered remain the same in the PR gate