### PR TITLE
ES-858: Update Corda Gradle plugins post artifactory change

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -10,5 +10,4 @@ cordaPipeline(
     nexusAppId :'corda-gradle-plugins-7.0.0',
     snykAdditionalCommands: "--configuration-matching='^runtimeClasspath\$' -d",
     gitHubComments: false,
-    snykIntegrationId: 'r3-snyk-corda5'
     )

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -9,5 +9,6 @@ cordaPipeline(
     stableUnstableRepoPattern: false,
     nexusAppId :'corda-gradle-plugins-7.0.0',
     snykAdditionalCommands: "--configuration-matching='^runtimeClasspath\$' -d",
-    gitHubComments: false
+    gitHubComments: false,
+    snykIntegrationId: 'snyk-artifactory-c4'
     )

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.0') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaPipeline(
     dedicatedJobForSnykDelta: false,

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,13 +1,12 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@connelm/ES-858/corda-gradle-plugins-changes') _
 
 cordaPipeline(
     dedicatedJobForSnykDelta: false,
+    gitHubComments: false,
     javaVersion: '8',
     publishToMavenS3Repository: true,
     publishRepoPrefix: 'corda',
     slimBuild: true,
-    stableUnstableRepoPattern: false,
-    nexusAppId :'corda-gradle-plugins-7.0.0',
     snykAdditionalCommands: "--configuration-matching='^runtimeClasspath\$' -d",
-    gitHubComments: false,
+    stableUnstableRepoPattern: false,
     )

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -10,5 +10,5 @@ cordaPipeline(
     nexusAppId :'corda-gradle-plugins-7.0.0',
     snykAdditionalCommands: "--configuration-matching='^runtimeClasspath\$' -d",
     gitHubComments: false,
-    snykIntegrationId: 'snyk-artifactory-c4'
+    snykIntegrationId: 'r3-snyk-corda5'
     )

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@connelm/ES-858/corda-gradle-plugins-changes') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaPipeline(
     dedicatedJobForSnykDelta: false,

--- a/build.gradle
+++ b/build.gradle
@@ -260,7 +260,7 @@ configure(publishProjects) { Project subproject ->
                     }
                 }
             }
-      }
+        }
     }
 }
 

--- a/cordapp-cpk2/src/test/resources/gradle.properties
+++ b/cordapp-cpk2/src/test/resources/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-XX:+UseG1GC -Xmx512m
 org.gradle.caching=false
 org.gradle.java.installations.auto-download=false
 
-artifactory_contextUrl=https://software.r3.com/artifactory
+publicArtifactURL=https://download.corda.net/maven
 
 kotlin.stdlib.default.dependency=false
 platform_version=999

--- a/cordapp-cpk2/src/test/resources/repositories.gradle
+++ b/cordapp-cpk2/src/test/resources/repositories.gradle
@@ -1,7 +1,13 @@
 repositories {
     mavenCentral()
     maven {
-        url "$artifactory_contextUrl/corda"
+        url "$publicArtifactURL/corda-dependencies"
+        mavenContent {
+            releasesOnly()
+        }
+    }
+    maven {
+        url "$publicArtifactURL/corda-releases"
         mavenContent {
             releasesOnly()
         }

--- a/cordformation/src/test/resources/gradle.properties
+++ b/cordformation/src/test/resources/gradle.properties
@@ -7,3 +7,4 @@ jolokia_version=1.6.0
 docker_image_name=corda/corda-zulu-4.3
 
 artifactory_contextUrl=https://software.r3.com/artifactory
+publicArtifactURL=https://download.corda.net/maven

--- a/cordformation/src/test/resources/repositories.gradle
+++ b/cordformation/src/test/resources/repositories.gradle
@@ -7,10 +7,10 @@ repositories {
         }
     }
     maven {
-        url "$artifactory_contextUrl/corda-releases"
+        url "$publicArtifactURL/corda-releases"
     }
     maven {
-        url "$artifactory_contextUrl/corda-dependencies"
+        url "$publicArtifactURL/corda-dependencies"
     }
     mavenCentral()
 }

--- a/quasar-utils/src/test/resources/gradle.properties
+++ b/quasar-utils/src/test/resources/gradle.properties
@@ -2,3 +2,5 @@
 org.gradle.java.installations.auto-download=false
 org.gradle.jvmargs=-XX:+UseG1GC -Xmx512m
 org.gradle.caching=false
+
+publicArtifactURL=https://download.corda.net/maven

--- a/quasar-utils/src/test/resources/repositories.gradle
+++ b/quasar-utils/src/test/resources/repositories.gradle
@@ -1,9 +1,9 @@
 repositories {
     mavenCentral()
     maven {
-        url 'https://software.r3.com/artifactory/corda-dependencies-dev'
+        url "$publicArtifactURL/corda-dependencies-dev"
     }
     maven {
-        url 'https://software.r3.com/artifactory/corda-dependencies'
+        url "$publicArtifactURL/corda-dependencies"
     }
 }


### PR DESCRIPTION
Relates to [ES-486](https://r3-cev.atlassian.net/browse/ES-486) Remove public facing access to Artifactory

[ES-486]: https://r3-cev.atlassian.net/browse/ES-486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Standard publishing to Artifactory remains as this is the ultimate source of truth. 

Separate automation is in place such if an item is removed from artifactory it is removed from S3.

also, this PR removes some redundant references in the Jenkins file to Nexus 
