### PR TITLE
CORE-17149: Set Configuration flags correctly for Gradle 8+.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Version 7.0.4
 
 * `cordapp-cpk2`: Upgrade to Bndlib 6.4.1.
+* `cordapp-cpk2`: Resolve deprecation warnings when used with Gradle 8+.
 
 ### Version 7.0.3
 

--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbPlugin.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbPlugin.java
@@ -17,6 +17,7 @@ import org.jetbrains.annotations.NotNull;
 
 import static net.corda.plugins.cpk2.CordappUtils.ALL_CORDAPPS_CONFIGURATION_NAME;
 import static net.corda.plugins.cpk2.CordappUtils.copyJarEnabledTo;
+import static net.corda.plugins.cpk2.CordappUtils.setCannotBeDeclared;
 import static net.corda.plugins.cpk2.SignJar.sign;
 import static net.corda.plugins.cpk2.SigningProperties.nested;
 import static org.gradle.api.artifacts.Dependency.ARCHIVES_CONFIGURATION;
@@ -46,10 +47,12 @@ public final class CpbPlugin implements Plugin<Project> {
             .setVisible(false)
             .extendsFrom(cpbConfiguration);
         cpbPackaging.setCanBeConsumed(false);
+        setCannotBeDeclared(cpbPackaging);
 
-        project.getConfigurations().create(CORDA_CPB_CONFIGURATION_NAME)
-            .attributes(attributor::forCpb)
-            .setCanBeResolved(false);
+        final Configuration cordaCPB = project.getConfigurations().create(CORDA_CPB_CONFIGURATION_NAME)
+            .attributes(attributor::forCpb);
+        cordaCPB.setCanBeResolved(false);
+        setCannotBeDeclared(cordaCPB);
 
         final TaskProvider<Jar> cpkTask = project.getTasks().named(JAR_TASK_NAME, Jar.class);
         final Provider<RegularFile> cpkPath = cpkTask.flatMap(Jar::getArchiveFile);

--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpk2/CordappDependencyCollector.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpk2/CordappDependencyCollector.java
@@ -103,10 +103,11 @@ final class CordappDependencyCollector {
             dependencies[++idx] = platform;
         }
 
-        return configurations.detachedConfiguration(dependencies)
+        final Configuration detached = configurations.detachedConfiguration(dependencies)
             .attributes(attributor::forCompileClasspath)
-            .setVisible(false)
-            .getResolvedConfiguration();
+            .setVisible(false);
+        detached.setCanBeConsumed(false);
+        return detached.getResolvedConfiguration();
     }
 
     @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")

--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpk2/CordappUtils.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpk2/CordappUtils.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.io.UncheckedIOException;
+import java.lang.invoke.MethodHandles;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -45,6 +46,7 @@ import static aQute.bnd.osgi.Constants.FIXUPMESSAGES_IS_DIRECTIVE;
 import static aQute.bnd.osgi.Constants.FIXUPMESSAGES_IS_ERROR;
 import static aQute.bnd.osgi.Constants.FIXUPMESSAGES_IS_WARNING;
 import static aQute.bnd.osgi.Constants.FIXUPMESSAGES_RESTRICT_DIRECTIVE;
+import static java.lang.invoke.MethodType.methodType;
 import static java.util.Collections.max;
 import static java.util.Collections.unmodifiableMap;
 import static org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME;
@@ -197,6 +199,18 @@ public final class CordappUtils {
             cfg.extendsFrom(configuration)
         );
         return configuration;
+    }
+
+    // Configuration.setCanBeDeclared(boolean) was introduced in Gradle 8.2.
+    public static void setCannotBeDeclared(@NotNull Configuration configuration) {
+        try {
+            MethodHandles.publicLookup()
+                .findVirtual(configuration.getClass(), "setCanBeDeclared", methodType(void.class, boolean.class))
+                .invoke(configuration, false);
+        } catch (Error e) {
+            throw e;
+        } catch (Throwable ignored) {
+        }
     }
 
     /**


### PR DESCRIPTION
Gradle 8+ requires each `Configuration`'s `canBeConsumed`, `canBeResolved` and `canBeDeclared` flags to be set consistently.

- `canBeConsumed`, `canBeResolved` must not both be true.
- `canBeConsumed`, `canBeDeclared` must not both be true.

`setCanBeDeclared()` was introduced in Gradle 8.2, so set this flag reflectively to preserve the plugin's compatibility with Gradle 7.