### PR TITLE
CORE-17494: Add check to CPB creation to ensure that 2 CPKs don't share a name

### DIFF
--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbPlugin.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbPlugin.java
@@ -72,6 +72,8 @@ public final class CpbPlugin implements Plugin<Project> {
             cpbTask.getArchiveAppendix().convention(cpkTask.flatMap(Jar::getArchiveAppendix));
             cpbTask.getArchiveVersion().convention(cpkTask.flatMap(Jar::getArchiveVersion));
 
+            cpbTask.doFirst(task -> cpbTask.checkForDuplicates());
+
             cpbTask.doLast(task -> {
                 if (cordappExtension.getSigning().getEnabled().get()) {
                     sign(task, cordappExtension.getSigning().getOptions(), cpbTask.getArchiveFile().get().getAsFile());

--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbPlugin.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbPlugin.java
@@ -72,7 +72,7 @@ public final class CpbPlugin implements Plugin<Project> {
             cpbTask.getArchiveAppendix().convention(cpkTask.flatMap(Jar::getArchiveAppendix));
             cpbTask.getArchiveVersion().convention(cpkTask.flatMap(Jar::getArchiveVersion));
 
-            cpbTask.doFirst(task -> cpbTask.checkForDuplicates());
+            cpbTask.doFirst(task -> cpbTask.checkForDuplicateCpkCordappNames());
 
             cpbTask.doLast(task -> {
                 if (cordappExtension.getSigning().getEnabled().get()) {

--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbTask.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbTask.java
@@ -66,11 +66,11 @@ public class CpbTask extends Jar {
     @NotNull
     public AbstractCopyTask from(@NotNull Object... args) {
         return super.from(args, copySpec ->
-            copySpec.exclude(this::isCPK)
+            copySpec.exclude(this::isValidCPK)
         );
     }
 
-    private boolean isCPK(@NotNull FileTreeElement element) {
+    private boolean isValidCPK(@NotNull FileTreeElement element) {
         if (!element.getName().endsWith(CPK_FILE_SUFFIX)) {
             return false;
         }

--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbTask.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbTask.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.jar.JarInputStream;
 

--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbTask.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbTask.java
@@ -74,9 +74,9 @@ public class CpbTask extends Jar {
             return false;
         }
 
-        Path cpkPath = element.getFile().toPath();
+        final Path cpkPath = element.getFile().toPath();
         try (JarInputStream cpkStream = new JarInputStream(new BufferedInputStream(Files.newInputStream(cpkPath)))) {
-            String cpkType = cpkStream.getManifest().getMainAttributes().getValue(CORDA_CPK_TYPE);
+            final String cpkType = cpkStream.getManifest().getMainAttributes().getValue(CORDA_CPK_TYPE);
             return cpkType != null && EXCLUDED_CPK_TYPES.contains(cpkType.toLowerCase());
         } catch (IOException e) {
             throw new InvalidUserDataException(e.getMessage(), e);
@@ -85,7 +85,6 @@ public class CpbTask extends Jar {
 
     public void checkForDuplicates() {
         Set<String> cpkNames = new HashSet<>();
-        System.out.println("checking duplicates");
         FileCollection files = getInputs().getFiles();
         for (File file : files) {
             Path path = file.toPath();

--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbTask.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbTask.java
@@ -84,7 +84,7 @@ public class CpbTask extends Jar {
     }
 
     public void checkForDuplicateCpkCordappNames() {
-        Set<String> cpkNames = new HashSet<>();
+        Set<String> cpkCordappNames = new HashSet<>();
         FileCollection files = getInputs().getFiles();
         for (File file : files) {
             Path path = file.toPath();

--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbTask.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbTask.java
@@ -83,7 +83,7 @@ public class CpbTask extends Jar {
         }
     }
 
-    public void checkForDuplicates() {
+    public void checkForDuplicateCpkCordappNames() {
         Set<String> cpkNames = new HashSet<>();
         FileCollection files = getInputs().getFiles();
         for (File file : files) {

--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbTask.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbTask.java
@@ -92,10 +92,10 @@ public class CpbTask extends Jar {
                 try (JarInputStream cpkStream = new JarInputStream(new BufferedInputStream(Files.newInputStream(path)))) {
                     String cpkCordappName = cpkStream.getManifest().getMainAttributes().getValue(CPK_CORDAPP_NAME);
                     if (cpkCordappName != null) {
-                        if (cpkNames.contains(cpkCordappName)) {
-                            throw new InvalidUserDataException("Two CPKs may not share a cordappCpkName. Error in " + cpkCordappName);
+                        if (cpkCordappNames.contains(cpkCordappName)) {
+                            throw new InvalidUserDataException("Two CPKs may not share a cpkCordappName. Error in " + cpkCordappName);
                         } else {
-                            cpkNames.add(cpkCordappName);
+                            cpkCordappNames.add(cpkCordappName);
                         }
                     }
                 } catch (IOException e) {

--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbTask.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbTask.java
@@ -82,7 +82,7 @@ public class CpbTask extends Jar {
             if (cpkCordappName != null) {
                 if (cpkNames.containsKey(cpkCordappName)) {
                     if (!cpkNames.get(cpkCordappName).equals(manifest)) {
-                        throw new InvalidUserDataException("Two CPKs may not share a cordappName. Error in " + cpkCordappName);
+                        throw new InvalidUserDataException("Two CPKs may not share a cordappCpkName. Error in " + cpkCordappName);
                     }
                 } else {
                     cpkNames.put(cpkCordappName, manifest);

--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbTask.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbTask.java
@@ -33,7 +33,7 @@ public class CpbTask extends Jar {
     public static final String CPB_VERSION_ATTRIBUTE = "Corda-CPB-Version";
     public static final String CPB_FORMAT_VERSION = "Corda-CPB-Format";
     public static final String CPB_CURRENT_FORMAT_VERSION = "2.0";
-    private static HashMap<String, Integer> cpkNames = new HashMap<>();
+    private final HashMap<String, Integer> cpkNames = new HashMap<>();
 
     public CpbTask() {
         setGroup(CORDAPP_TASK_GROUP);
@@ -58,8 +58,6 @@ public class CpbTask extends Jar {
             m.getAttributes().put(CPB_NAME_ATTRIBUTE, getArchiveBaseName());
             m.getAttributes().put(CPB_VERSION_ATTRIBUTE, getArchiveVersion());
         });
-
-        cpkNames = new HashMap<>();
     }
 
     @Override

--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpk2/CordappUtils.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpk2/CordappUtils.java
@@ -79,7 +79,7 @@ public final class CordappUtils {
 
     // These tags are for the CPK file.
     static final String CPK_PLATFORM_VERSION = "Corda-CPK-Built-Platform-Version";
-    static final String CPK_CORDAPP_NAME = "Corda-CPK-Cordapp-Name";
+    public static final String CPK_CORDAPP_NAME = "Corda-CPK-Cordapp-Name";
     static final String CPK_CORDAPP_VERSION = "Corda-CPK-Cordapp-Version";
     static final String CPK_CORDAPP_LICENCE = "Corda-CPK-Cordapp-Licence";
     static final String CPK_CORDAPP_VENDOR = "Corda-CPK-Cordapp-Vendor";

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpb2/CpbSharedName.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpb2/CpbSharedName.kt
@@ -1,0 +1,61 @@
+package net.corda.plugins.cpb2
+
+import net.corda.plugins.cpk2.GradleProject
+import net.corda.plugins.cpk2.cordaApiVersion
+import net.corda.plugins.cpk2.expectedCordappContractVersion
+import org.gradle.testkit.runner.UnexpectedBuildFailure
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.junit.jupiter.api.TestReporter
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.*
+
+@TestInstance(PER_CLASS)
+class CpbSharedName {
+    private companion object {
+        private const val platformCordappVersion = "2.3.4"
+        private const val cordappVersion = "1.2.1"
+    }
+
+    private lateinit var externalProject: GradleProject
+
+    @Test
+    fun `Assert 2 CPKs don't share a cordappName`(
+        @TempDir externalCordappProjectDir: Path,
+        @TempDir testDir: Path,
+        reporter: TestReporter
+    ) {
+        val mavenRepoDir = Files.createDirectory(testDir.resolve("maven"))
+        val cpbProjectDir = Files.createDirectory(testDir.resolve("cpb"))
+        externalProject = GradleProject(externalCordappProjectDir, reporter)
+            .withTestName("external-cordapp")
+            .withSubResource("corda-platform-cordapp/build.gradle")
+            .withSubResource("external-cordapp-transitive-dependency/build.gradle")
+            .withTaskName("publishAllPublicationsToTestRepository")
+            .build("-Pmaven_repository_dir=$mavenRepoDir",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pplatform_cordapp_version=$platformCordappVersion",
+                "-Pcordapp_version=$cordappVersion",
+                "-Pcordapp_contract_version=$expectedCordappContractVersion")
+        val e = assertThrows<UnexpectedBuildFailure> {
+            GradleProject(cpbProjectDir, reporter)
+                .withTestName("cpb-shared-name")
+                .withSubResource("project-dependency/build.gradle")
+                .build(
+                    "-Pmaven_repository_dir=$mavenRepoDir",
+                    "-Pplatform_cordapp_version=$platformCordappVersion",
+                    "-Pcordapp_version=$cordappVersion",
+                    "-Pcordapp_contract_version=$expectedCordappContractVersion"
+                )
+        }
+
+        val expectedMessage = "Two CPKs may not share a cordappName."
+        assert(e.message!!.contains(expectedMessage)) {
+            "Error message does not match expected value. Error message should contain \"$expectedMessage\""
+        }
+    }
+}

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpb2/CpbSharedName.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpb2/CpbSharedName.kt
@@ -43,7 +43,7 @@ class CpbSharedName {
                 )
         }
 
-        val expectedMessage = "Two CPKs may not share a cordappName."
+        val expectedMessage = "Two CPKs may not share a cordappCpkName."
         assert(e.message!!.contains(expectedMessage)) {
             "Error message does not match expected value. Error message should contain \"$expectedMessage\""
         }

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpb2/CpbSharedName.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpb2/CpbSharedName.kt
@@ -43,7 +43,7 @@ class CpbSharedName {
                 )
         }
 
-        val expectedMessage = "Two CPKs may not share a cordappCpkName."
+        val expectedMessage = "Two CPKs may not share a cpkCordappName."
         assert(e.message!!.contains(expectedMessage)) {
             "Error message does not match expected value. Error message should contain \"$expectedMessage\""
         }

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpb2/CpbSharedName.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpb2/CpbSharedName.kt
@@ -45,6 +45,7 @@ class CpbSharedName {
             GradleProject(cpbProjectDir, reporter)
                 .withTestName("cpb-shared-name")
                 .withSubResource("project-dependency/build.gradle")
+                .withSubResource("second-project-dependency/build.gradle")
                 .build(
                     "-Pmaven_repository_dir=$mavenRepoDir",
                     "-Pplatform_cordapp_version=$platformCordappVersion",

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpb2/CpbSharedName.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpb2/CpbSharedName.kt
@@ -25,22 +25,11 @@ class CpbSharedName {
 
     @Test
     fun `Assert 2 CPKs don't share a cordappName`(
-        @TempDir externalCordappProjectDir: Path,
         @TempDir testDir: Path,
         reporter: TestReporter
     ) {
         val mavenRepoDir = Files.createDirectory(testDir.resolve("maven"))
         val cpbProjectDir = Files.createDirectory(testDir.resolve("cpb"))
-        externalProject = GradleProject(externalCordappProjectDir, reporter)
-            .withTestName("external-cordapp")
-            .withSubResource("corda-platform-cordapp/build.gradle")
-            .withSubResource("external-cordapp-transitive-dependency/build.gradle")
-            .withTaskName("publishAllPublicationsToTestRepository")
-            .build("-Pmaven_repository_dir=$mavenRepoDir",
-                "-Pcorda_api_version=$cordaApiVersion",
-                "-Pplatform_cordapp_version=$platformCordappVersion",
-                "-Pcordapp_version=$cordappVersion",
-                "-Pcordapp_contract_version=$expectedCordappContractVersion")
         val e = assertThrows<UnexpectedBuildFailure> {
             GradleProject(cpbProjectDir, reporter)
                 .withTestName("cpb-shared-name")

--- a/cordapp-cpk2/src/test/resources/cpb-shared-name/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cpb-shared-name/build.gradle
@@ -1,0 +1,65 @@
+plugins {
+    id 'net.corda.plugins.cordapp-cpb2'
+    id 'org.jetbrains.kotlin.jvm'
+}
+
+apply from: 'javaTarget.gradle'
+apply from: 'kotlin.gradle'
+
+allprojects {
+    group = 'com.example'
+    version = cordapp_version
+
+    repositories {
+        maven {
+            name = 'test-repository'
+            url = maven_repository_dir
+        }
+    }
+    apply from: "$rootDir/repositories.gradle"
+}
+
+cordapp {
+    targetPlatformVersion = platform_version.toInteger()
+
+    contract {
+        name = 'CorDapp CPB test'
+        versionId = cordapp_contract_version.toInteger()
+        licence = 'Test-Licence'
+        vendor = 'R3'
+    }
+}
+
+configurations {
+    cpks {
+        canBeConsumed = false
+    }
+}
+
+dependencies {
+    cordapp group: group, name: "external-cordapp", version: cordapp_version
+    cordapp project('project-dependency')
+
+    cpks project(path: 'project-dependency', configuration: 'cordaCPK')
+    cpks group: "net.corda", name: "corda-platform-cordapp", version: platform_cordapp_version
+    cpks group: "com.example", name: "external-cordapp", version: cordapp_version
+    cpks group: "com.example", name: "external-cordapp-transitive-dependency", version: cordapp_version
+}
+
+
+def cpkDir = layout.buildDirectory.dir('cpks')
+def copyCPKs = tasks.register('copyCPKs', Copy) {
+    from configurations.cpks
+    into cpkDir
+}
+
+artifacts {
+    archives(cpkDir) {
+        builtBy copyCPKs
+    }
+}
+
+cpb {
+    archiveBaseName = "customName"
+    archiveVersion = "customVersion"
+}

--- a/cordapp-cpk2/src/test/resources/cpb-shared-name/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cpb-shared-name/build.gradle
@@ -37,13 +37,11 @@ configurations {
 }
 
 dependencies {
-    cordapp group: group, name: "external-cordapp", version: cordapp_version
     cordapp project('project-dependency')
+    cordapp project('second-project-dependency')
 
     cpks project(path: 'project-dependency', configuration: 'cordaCPK')
-    cpks group: "net.corda", name: "corda-platform-cordapp", version: platform_cordapp_version
-    cpks group: "com.example", name: "external-cordapp", version: cordapp_version
-    cpks group: "com.example", name: "external-cordapp-transitive-dependency", version: cordapp_version
+    cpks project(path: 'second-project-dependency', configuration: 'cordaCPK')
 }
 
 

--- a/cordapp-cpk2/src/test/resources/cpb-shared-name/project-dependency/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cpb-shared-name/project-dependency/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+    id 'net.corda.plugins.cordapp-cpk2'
+    id 'org.jetbrains.kotlin.jvm'
+}
+
+apply from: '../javaTarget.gradle'
+apply from: '../kotlin.gradle'
+
+cordapp {
+    targetPlatformVersion = platform_version.toInteger()
+
+    contract {
+        name = 'Project CorDapp'
+        versionId = cordapp_contract_version.toInteger()
+        licence = 'Test-Licence'
+        vendor = 'R3'
+        cordappName = 'com.example.cordapp-cpb'
+    }
+}
+
+tasks.named('jar', Jar) {
+    archiveBaseName = 'project-cordapp'
+}

--- a/cordapp-cpk2/src/test/resources/cpb-shared-name/project-dependency/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cpb-shared-name/project-dependency/build.gradle
@@ -14,7 +14,7 @@ cordapp {
         versionId = cordapp_contract_version.toInteger()
         licence = 'Test-Licence'
         vendor = 'R3'
-        cordappCpkName = 'com.example.cordapp-cpb.duplicate'
+        cpkCordappName = 'com.example.cordapp-cpb.duplicate'
     }
 }
 

--- a/cordapp-cpk2/src/test/resources/cpb-shared-name/project-dependency/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cpb-shared-name/project-dependency/build.gradle
@@ -14,7 +14,7 @@ cordapp {
         versionId = cordapp_contract_version.toInteger()
         licence = 'Test-Licence'
         vendor = 'R3'
-        cordappName = 'com.example.cordapp-cpb'
+        cordappCpkName = 'com.example.cordapp-cpb'
     }
 }
 

--- a/cordapp-cpk2/src/test/resources/cpb-shared-name/project-dependency/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cpb-shared-name/project-dependency/build.gradle
@@ -19,5 +19,5 @@ cordapp {
 }
 
 tasks.named('jar', Jar) {
-    archiveBaseName = 'second-project-cordapp'
+    archiveBaseName = 'project-cordapp'
 }

--- a/cordapp-cpk2/src/test/resources/cpb-shared-name/second-project-dependency/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cpb-shared-name/second-project-dependency/build.gradle
@@ -19,5 +19,5 @@ cordapp {
 }
 
 tasks.named('jar', Jar) {
-    archiveBaseName = 'project-cordapp'
+    archiveBaseName = 'second-project-cordapp'
 }

--- a/cordapp-cpk2/src/test/resources/cpb-shared-name/second-project-dependency/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cpb-shared-name/second-project-dependency/build.gradle
@@ -14,7 +14,7 @@ cordapp {
         versionId = cordapp_contract_version.toInteger()
         licence = 'Test-Licence'
         vendor = 'R3'
-        cordappCpkName = 'com.example.cordapp-cpb.duplicate'
+        cpkCordappName = 'com.example.cordapp-cpb.duplicate'
     }
 }
 

--- a/cordapp-cpk2/src/test/resources/cpb-shared-name/second-project-dependency/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cpb-shared-name/second-project-dependency/build.gradle
@@ -19,5 +19,5 @@ cordapp {
 }
 
 tasks.named('jar', Jar) {
-    archiveBaseName = 'second-project-cordapp'
+    archiveBaseName = 'project-cordapp'
 }

--- a/cordapp-cpk2/src/test/resources/cpb-shared-name/settings.gradle
+++ b/cordapp-cpk2/src/test/resources/cpb-shared-name/settings.gradle
@@ -1,0 +1,10 @@
+pluginManagement {
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version kotlin_version
+    }
+}
+
+rootProject.name = 'cordapp-cpb'
+
+include 'project-dependency'
+include 'project-dependency-2'

--- a/cordapp-cpk2/src/test/resources/cpb-shared-name/settings.gradle
+++ b/cordapp-cpk2/src/test/resources/cpb-shared-name/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
     }
 }
 
-rootProject.name = 'cordapp-cpb'
+rootProject.name = 'cpb-shared-name'
 
 include 'project-dependency'
-include 'project-dependency-2'
+include 'second-project-dependency'


### PR DESCRIPTION
As part of https://github.com/corda/corda-gradle-plugins/pull/595, we are adding the ability for users to set an identifiable name for their own CPKs. However, we do not want 2 CPKs in the same CPB to have the same name, so we need to add a check in the CPB plugin to ensure that names are not reused within it.