### PR TITLE
CORE-20557: Fix issue in CPB and CPK plugins preventing dependencies of transitive dependencies from being included

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@
 
 ### Version 7.0.5
 
+* `cordapp-cpk2`: Include transitive dependencies in list of dependencies
+* `cordapp-cpb2`: Include transitive dependencies in CPB archive
+
 ### Version 7.0.4
 
 * `cordapp-cpk2`: Upgrade to Bndlib 6.4.1.

--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbPlugin.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbPlugin.java
@@ -73,6 +73,7 @@ public final class CpbPlugin implements Plugin<Project> {
             cpbTask.getArchiveVersion().convention(cpkTask.flatMap(Jar::getArchiveVersion));
 
             cpbTask.doFirst(task -> cpbTask.checkForDuplicateCpkCordappNames());
+            cpbTask.doFirst(task -> cpbTask.extractTransitiveDeps());
 
             cpbTask.doLast(task -> {
                 if (cordappExtension.getSigning().getEnabled().get()) {

--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbTask.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbTask.java
@@ -13,10 +13,16 @@ import org.jetbrains.annotations.NotNull;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 import java.util.jar.JarInputStream;
 
 import static java.util.Collections.singleton;
@@ -29,12 +35,15 @@ import static net.corda.plugins.cpk2.CordappUtils.CPK_FILE_EXTENSION;
 public class CpbTask extends Jar {
     private static final String CPB_ARTIFACT_CLASSIFIER = "package";
     public static final String CPB_FILE_EXTENSION = "cpb";
+    private static final String CPB_FILE_SUFFIX = "." + CPB_FILE_EXTENSION;
     private static final String CPK_FILE_SUFFIX = '.' + CPK_FILE_EXTENSION;
     private static final Set<String> EXCLUDED_CPK_TYPES = singleton("corda-api");
     public static final String CPB_NAME_ATTRIBUTE = "Corda-CPB-Name";
     public static final String CPB_VERSION_ATTRIBUTE = "Corda-CPB-Version";
     public static final String CPB_FORMAT_VERSION = "Corda-CPB-Format";
     public static final String CPB_CURRENT_FORMAT_VERSION = "2.0";
+    private static File jarDir;
+    Set<String> cordappFileNames = new HashSet<>();
 
     public CpbTask() {
         setGroup(CORDAPP_TASK_GROUP);
@@ -59,11 +68,21 @@ public class CpbTask extends Jar {
             m.getAttributes().put(CPB_NAME_ATTRIBUTE, getArchiveBaseName());
             m.getAttributes().put(CPB_VERSION_ATTRIBUTE, getArchiveVersion());
         });
+
+        try {
+            jarDir = Files.createTempDirectory("").toFile();
+            jarDir.deleteOnExit();
+        } catch (IOException e) {
+            getLogger().warn("Could not create jar directory: {}", e.getMessage());
+            jarDir = null;
+        }
     }
 
     @Override
     @NotNull
     public AbstractCopyTask from(@NotNull Object... args) {
+        args = Arrays.copyOf(args, args.length + 1);
+        args[args.length - 1] = jarDir;
         return super.from(args, copySpec ->
             copySpec.exclude(this::isCPK)
         );
@@ -102,6 +121,59 @@ public class CpbTask extends Jar {
                     throw new InvalidUserDataException(e.getMessage(), e);
                 }
             }
+        }
+    }
+
+    public void extractTransitiveDeps() {
+        if (jarDir != null) {
+            FileCollection jars = getInputs().getFiles();
+            Set<String> jarNames = new HashSet<>();
+            for (File file : jars) {
+                jarNames.add(file.getName());
+            }
+            Set<File> cpbs = new HashSet<>();
+            for (File file : jars) {
+                File parent = file.getParentFile();
+                for (File sibling : parent.listFiles()) {
+                    if (sibling.isFile() && sibling.getName().endsWith(CPB_FILE_SUFFIX)) {
+                        cpbs.add(sibling);
+                    }
+                }
+            }
+            for (File cpb : cpbs) {
+                extractJarsFromCPB(cpb, jarNames);
+            }
+        }
+    }
+
+    private void extractJarsFromCPB(File cpb, Set<String> jarNames) {
+        try (JarFile jarFile = new JarFile(cpb)) {
+            Enumeration<JarEntry> jarEntries = jarFile.entries();
+            while (jarEntries.hasMoreElements()) {
+                JarEntry jarEntry = jarEntries.nextElement();
+                if (!cordappFileNames.contains(jarEntry.getName())) {
+                    cordappFileNames.add(jarEntry.getName());
+                    String jarName = jarEntry.getName();
+                    if (jarName.endsWith(".jar") && !jarNames.contains(jarName)) {
+                        extractJarEntry(jarFile, jarEntry);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            getLogger().warn("Could not extract cpb: {}", e.getMessage());
+        }
+    }
+
+    private void extractJarEntry(JarFile jarFile, JarEntry jarEntry) {
+        try {
+            Path path = Paths.get(jarDir.getAbsolutePath(), jarEntry.getName());
+            if (!Files.exists(path)) {
+                InputStream inputStream = jarFile.getInputStream(jarEntry);
+                Files.copy(inputStream, path);
+                path.toFile().deleteOnExit();
+            }
+        } catch (IOException e) {
+            getLogger().error("Could not copy jar: {}", e.getMessage());
         }
     }
 }

--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbTask.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpb2/CpbTask.java
@@ -128,11 +128,9 @@ public class CpbTask extends Jar {
         if (jarDir != null) {
             FileCollection jars = getInputs().getFiles();
             Set<String> jarNames = new HashSet<>();
-            for (File file : jars) {
-                jarNames.add(file.getName());
-            }
             Set<File> cpbs = new HashSet<>();
             for (File file : jars) {
+                jarNames.add(file.getName());
                 File parent = file.getParentFile();
                 for (File sibling : parent.listFiles()) {
                     if (sibling.isFile() && sibling.getName().endsWith(CPB_FILE_SUFFIX)) {

--- a/cordapp-cpk2/src/main/java/net/corda/plugins/cpk2/DependencyCalculator.java
+++ b/cordapp-cpk2/src/main/java/net/corda/plugins/cpk2/DependencyCalculator.java
@@ -297,6 +297,7 @@ public class DependencyCalculator extends DefaultTask {
         return transitives;
     }
 
+    @NotNull
     private static File extractJarEntry(JarFile jarFile, JarEntry jarEntry, Path pathToDir) throws IOException {
         File file;
         Path path = Paths.get(pathToDir.toString(), jarEntry.getName());

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpb2/CpbTransitiveDependency.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpb2/CpbTransitiveDependency.kt
@@ -1,0 +1,70 @@
+package net.corda.plugins.cpb2
+
+import net.corda.plugins.cpk2.GradleProject
+import net.corda.plugins.cpk2.annotationsVersion
+import net.corda.plugins.cpk2.cordaApiVersion
+import net.corda.plugins.cpk2.expectedCordappContractVersion
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.junit.jupiter.api.TestReporter
+import org.junit.jupiter.api.io.CleanupMode
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import java.util.jar.JarEntry
+import java.util.jar.JarFile
+
+@TestInstance(PER_CLASS)
+class CpbTransitiveDependency {
+    private companion object {
+        private const val cpk1Version = "1.0-SNAPSHOT"
+        private const val cpkFinalVersion = "3.0-SNAPSHOT"
+        private const val cordaNotaryPluginVersion = "5.2.0.0"
+    }
+
+    private lateinit var testProject: GradleProject
+
+    @BeforeAll
+    fun setup(@TempDir testProjectDir: Path, reporter: TestReporter) {
+        testProject = GradleProject(testProjectDir, reporter)
+            .withTestName("cpb-transitive-dependencies")
+            .withSubResource("cpk-one/build.gradle")
+            .withSubResource("cpk-one/src/main/kotlin/com/example/one/ContractOne.kt")
+            .withSubResource("cpk-final/build.gradle")
+            .withSubResource("cpk-final/src/main/kotlin/com/example/final/ContractFinal.kt")
+            .build(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pannotations_version=$annotationsVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pcorda_notary_plugin_version=$cordaNotaryPluginVersion",
+                "-Pcpk1_version=$cpk1Version",
+                "-PcpkFinal_version=$cpkFinalVersion"
+            )
+    }
+
+    @Test
+    fun deepTransitivesTest() {
+        val artifacts = testProject.artifacts
+        assertThat(artifacts).hasSize(1)
+
+        val cpb = artifacts.single { it.toString().endsWith(".cpb") }
+        assertThat(cpb).isRegularFile
+
+        val cpks = JarFile(cpb.toFile()).use { jar ->
+            jar.entries().asSequence()
+                .map(JarEntry::getName)
+                .filter { it.endsWith(".jar") }
+                .toList()
+        }
+        println(cpks)
+        assertThat(cpks)
+            .anyMatch { it == "notary-plugin-non-validating-client-$cordaNotaryPluginVersion.jar" }
+            .anyMatch { it == "notary-plugin-non-validating-api-$cordaNotaryPluginVersion.jar" }
+            .anyMatch { it == "notary-plugin-common-$cordaNotaryPluginVersion.jar" }
+            .anyMatch { it == "cpk-final-$cpkFinalVersion.jar" }
+            .anyMatch { it == "cpk-one-$cpk1Version.jar" }
+            .hasSize(5)
+    }
+}

--- a/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/CpkTransitiveDependencies.kt
+++ b/cordapp-cpk2/src/test/kotlin/net/corda/plugins/cpk2/CpkTransitiveDependencies.kt
@@ -1,0 +1,77 @@
+package net.corda.plugins.cpk2
+
+import net.corda.plugins.cpk2.CordappUtils.CPK_DEPENDENCIES
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.junit.jupiter.api.TestReporter
+import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.osgi.framework.Constants.BUNDLE_LICENSE
+import org.osgi.framework.Constants.BUNDLE_NAME
+import org.osgi.framework.Constants.BUNDLE_SYMBOLICNAME
+import org.osgi.framework.Constants.BUNDLE_VENDOR
+import org.osgi.framework.Constants.BUNDLE_VERSION
+import org.osgi.framework.Constants.EXPORT_PACKAGE
+import org.osgi.framework.Constants.IMPORT_PACKAGE
+import org.osgi.framework.Constants.REQUIRE_CAPABILITY
+import java.nio.file.Path
+
+/**
+ * Verify that transitive cordapp and cordaProvided dependencies
+ * are inherited by downstream CPK projects.
+ */
+@TestInstance(PER_CLASS)
+class CpkTransitiveDependencies {
+    private companion object {
+        private const val cordappVersion = "1.0.1-SNAPSHOT"
+        private const val cpk1Version = "1.0-SNAPSHOT"
+        private const val cpk2Version = "2.0-SNAPSHOT"
+        private const val cpk1Type = "foo"
+        private const val cpk2Type = "api"
+        private const val cordaNotaryPluginVersion = "5.2.0.0"
+    }
+
+    private fun buildProject(
+        taskName: String,
+        testProjectDir: Path,
+        reporter: TestReporter
+    ): GradleProject {
+        val repositoryDir = testProjectDir.resolve("maven")
+        return GradleProject(testProjectDir, reporter)
+            .withTestName("cpk-transitive-dependencies")
+            .withSubResource("cpk-one/build.gradle")
+            .withSubResource("cpk-two/build.gradle")
+            .withTaskName(taskName)
+            .build(
+                "-Pcordapp_contract_version=$expectedCordappContractVersion",
+                "-Pcommons_io_version=$commonsIoVersion",
+                "-Pcorda_api_version=$cordaApiVersion",
+                "-Pcordapp_version=$cordappVersion",
+                "-Pcorda_notary_plugin_version=$cordaNotaryPluginVersion",
+                "-Pcpk1_version=$cpk1Version",
+                "-Pcpk2_version=$cpk2Version",
+                "-Prepository_dir=$repositoryDir",
+                "-Pcpk1_type=$cpk1Type",
+                "-Pcpk2_type=$cpk2Type"
+            )
+    }
+
+    @Test
+    fun transitivesTest(
+        @TempDir testProjectDir: Path,
+        reporter: TestReporter
+    ) {
+        val testProject = buildProject("assemble", testProjectDir, reporter)
+        assertThat(testProject.cpkDependencies)
+            .anyMatch { it.name == "com.example.cpk-one" && it.version == toOSGi(cpk1Version) && it.type == cpk1Type }
+            .anyMatch { it.name == "com.example.cpk-two" && it.version == toOSGi(cpk2Version) && it.type == cpk2Type }
+            .anyMatch { it.name == "com.r3.corda.notary.plugin.nonvalidating.notary-plugin-non-validating-client" && it.version == cordaNotaryPluginVersion }
+            .anyMatch { it.name == "com.r3.corda.notary.plugin.nonvalidating.notary-plugin-non-validating-api" && it.version == cordaNotaryPluginVersion }
+            .anyMatch { it.name == "com.r3.corda.notary.plugin.common.notary-plugin-common" && it.version == cordaNotaryPluginVersion }
+            .hasSize(5)
+    }
+}

--- a/cordapp-cpk2/src/test/resources/cpb-transitive-dependencies/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cpb-transitive-dependencies/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'base'
+}
+
+configurations {
+    cpbs {
+        canBeConsumed = false
+    }
+}
+
+dependencies {
+    cpbs project(path: ':cpk-final', configuration: 'cordaCPB')
+}
+
+def copyCPB = tasks.register('copyCPB', Copy) {
+    from configurations.cpbs
+    into layout.buildDirectory.dir('libs')
+}
+
+tasks.named('assemble') {
+    dependsOn copyCPB
+}

--- a/cordapp-cpk2/src/test/resources/cpb-transitive-dependencies/cpk-final/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cpb-transitive-dependencies/cpk-final/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'net.corda.plugins.cordapp-cpb2'
+    id 'org.jetbrains.kotlin.jvm'
+}
+
+apply from: '../repositories.gradle'
+apply from: '../javaTarget.gradle'
+apply from: '../kotlin.gradle'
+
+group = 'com.example'
+version = cpkFinal_version
+
+cordapp {
+    targetPlatformVersion = platform_version.toInteger()
+
+    contract {
+        name = 'CPK-Final'
+        versionId = cordapp_contract_version.toInteger()
+        licence = 'Test-Licence'
+        vendor = 'R3'
+    }
+}
+
+dependencies {
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordapp project(':cpk-one')
+}

--- a/cordapp-cpk2/src/test/resources/cpb-transitive-dependencies/cpk-one/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cpb-transitive-dependencies/cpk-one/build.gradle
@@ -1,0 +1,40 @@
+plugins {
+    id 'net.corda.plugins.cordapp-cpk2'
+    id 'org.jetbrains.kotlin.jvm'
+}
+
+apply from: '../repositories.gradle'
+apply from: '../javaTarget.gradle'
+apply from: '../kotlin.gradle'
+
+group = 'com.example'
+version = cpk1_version
+
+cordapp {
+    targetPlatformVersion = platform_version.toInteger()
+
+    contract {
+        name = 'CPK-1'
+        versionId = cordapp_contract_version.toInteger()
+        licence = 'Test-Licence'
+        vendor = 'R3'
+    }
+}
+
+tasks.named('compileKotlin') {
+    doFirst {
+        configurations.cordappPackaging.forEach {
+            println "PACKAGE>> ${it.name}"
+        }
+        configurations.cordappExternal.forEach {
+            println "EXTERNAL>> ${it.name}"
+        }
+    }
+}
+
+dependencies {
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordaProvided project(':corda-api')
+
+    cordapp "com.r3.corda.notary.plugin.nonvalidating:notary-plugin-non-validating-client:$corda_notary_plugin_version"
+}

--- a/cordapp-cpk2/src/test/resources/cpb-transitive-dependencies/settings.gradle
+++ b/cordapp-cpk2/src/test/resources/cpb-transitive-dependencies/settings.gradle
@@ -1,0 +1,20 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+    }
+
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version kotlin_version
+    }
+}
+
+rootProject.name = 'cpb-transitive-dependencies'
+
+include 'cpk-one'
+include 'cpk-final'
+
+include 'corda-api'
+project(':corda-api').projectDir = file('../resources/test/corda-api')
+
+include 'corda-platform'
+project(':corda-platform').projectDir = file('../resources/test/corda-platform')

--- a/cordapp-cpk2/src/test/resources/cpk-transitive-dependencies/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cpk-transitive-dependencies/build.gradle
@@ -1,0 +1,82 @@
+plugins {
+    id 'net.corda.plugins.cordapp-cpk2'
+    id 'org.jetbrains.kotlin.jvm'
+}
+
+apply from: 'repositories.gradle'
+apply from: 'javaTarget.gradle'
+apply from: 'kotlin.gradle'
+
+allprojects {
+    apply plugin: 'maven-publish'
+
+    tasks.withType(GenerateModuleMetadata).configureEach {
+        // Ensure our Maven Repository is "bare bones",
+        // i.e. has no sneaky extra Gradle metadata.
+        enabled = false
+    }
+
+    publishing {
+        publishing {
+            repositories {
+                maven {
+                    name = 'Test'
+                    url = repository_dir
+                }
+            }
+
+            pluginManager.withPlugin('net.corda.plugins.cordapp-cpk2') {
+                publications {
+                    maven(MavenPublication) {
+                        from components.cordapp
+
+                        pom {
+                            name = 'Transitive CorDapps'
+                            url = 'https://com.example.cordapp'
+                            scm {
+                                url = 'https://com.example.cordapp'
+                            }
+                            organization {
+                                name = 'Example-Name'
+                                url = 'https://example.com'
+                            }
+                            licenses {
+                                license {
+                                    name = 'Apache-2.0'
+                                    url = 'https://www.apache.org/licenses/LICENSE-2.0'
+                                    distribution = 'repo'
+                                }
+                            }
+                            developers {
+                                developer {
+                                    id = 'Example-Id'
+                                    name = 'Example-Name'
+                                    email = 'dev@example.com'
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+group = 'com.example'
+version = cordapp_version
+
+cordapp {
+    targetPlatformVersion = platform_version.toInteger()
+
+    contract {
+        name = 'Transitive CorDapps'
+        versionId = cordapp_contract_version.toInteger()
+        licence = 'Test-Licence'
+        vendor = 'R3'
+    }
+}
+
+dependencies {
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlin_version"
+    cordapp project(':cpk-two')
+}

--- a/cordapp-cpk2/src/test/resources/cpk-transitive-dependencies/cpk-one/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cpk-transitive-dependencies/cpk-one/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+    id 'net.corda.plugins.cordapp-cpk2'
+}
+
+apply from: '../repositories.gradle'
+apply from: '../javaTarget.gradle'
+
+group = 'com.example'
+version = cpk1_version
+
+cordapp {
+    targetPlatformVersion = platform_version.toInteger()
+
+    contract {
+        name = 'CPK-1'
+        versionId = cordapp_contract_version.toInteger()
+        licence = 'Test-Licence'
+        vendor = 'R3'
+    }
+}
+
+dependencies {
+    cordaProvided project(':corda-api')
+    cordapp "com.r3.corda.notary.plugin.nonvalidating:notary-plugin-non-validating-client:$corda_notary_plugin_version"
+}
+
+tasks.named('jar', Jar) {
+    archiveBaseName = 'cpk-one'
+    manifest {
+        attributes('Corda-CPK-Type': cpk1_type)
+    }
+}

--- a/cordapp-cpk2/src/test/resources/cpk-transitive-dependencies/cpk-two/build.gradle
+++ b/cordapp-cpk2/src/test/resources/cpk-transitive-dependencies/cpk-two/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+    id 'net.corda.plugins.cordapp-cpk2'
+}
+
+apply from: '../repositories.gradle'
+apply from: '../javaTarget.gradle'
+
+group = 'com.example'
+version = cpk2_version
+
+cordapp {
+    targetPlatformVersion = platform_version.toInteger()
+
+    contract {
+        name = 'CPK-2'
+        versionId = cordapp_contract_version.toInteger()
+        licence = 'Test-Licence'
+        vendor = 'R3'
+    }
+}
+
+dependencies {
+    cordapp project(':cpk-one')
+}
+
+tasks.named('jar', Jar) {
+    archiveBaseName = 'cpk-two'
+    manifest {
+        attributes('Corda-CPK-Type': cpk2_type)
+    }
+}

--- a/cordapp-cpk2/src/test/resources/cpk-transitive-dependencies/settings.gradle
+++ b/cordapp-cpk2/src/test/resources/cpk-transitive-dependencies/settings.gradle
@@ -1,0 +1,21 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+    }
+
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version kotlin_version
+    }
+}
+
+rootProject.name = 'transitive-cordapps'
+
+include 'cpk-one'
+include 'cpk-two'
+include 'cpk-three'
+
+include 'corda-api'
+project(':corda-api').projectDir = file('../resources/test/corda-api')
+
+include 'corda-platform'
+project(':corda-platform').projectDir = file('../resources/test/corda-platform')


### PR DESCRIPTION
The packaging plugins had an issue which prevented certain transitive dependencies from being included in the outputs, which meant that packages had to declare transitive dependencies themself. This PR changes that by creating a temporary directory where jar files are extracted from the CPB file of declared dependencies and including those files as dependencies.