### PR TITLE
ENT-12854 - Escrow build support

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 pluginManagement {
     repositories {
+        mavenLocal()
         gradlePluginPortal()
     }
 


### PR DESCRIPTION
Added local maven to the list of plugin repositories.
This is to support builds by developers outside of R3, using the escrow archive of Corda Enterprise.