### PR TITLE
ENT-12854 - Bumped version for next release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -228,7 +228,7 @@ artifactory {
     publish {
         contextUrl = artifactory_contextUrl
         repository {
-            repoKey = 'corda-dev'
+            repoKey = System.getenv('CORDA_PUBLISH_REPOSITORY_KEY') ?: 'corda-dev'
             username = project.findProperty('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME') ?: System.getProperty('corda.artifactory.username')
             password = project.findProperty('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD') ?: System.getProperty('corda.artifactory.password')
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.incremental=true
 org.gradle.jvmargs=-XX:+UseG1GC -Xmx1g
 org.gradle.caching=false
 
-gradle_plugins_version=5.0.18-SNAPSHOT
+gradle_plugins_version=5.0.20-SNAPSHOT
 typesafe_config_version=1.4.2
 classgraph_version=4.8.115
 kotlin_version=1.3.41


### PR DESCRIPTION
Bumped the plugins version for the next release.
Just done release 5.0.19; someone forgot to bump it last time.
Additionally - ensure the repo-key for publishing is correct - it was previously always publishing to "corda-dev".
Apparently this was broken a while back when we switched to using Infra's shared build pipeline - since then all releases of the plugins were released to 'corda-dev'; previously the build infra 'did the right thing' (somehow) and published to corda-releases.
