### PR TITLE
ENT0000 - Setup for next dev version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.incremental=true
 org.gradle.jvmargs=-XX:+UseG1GC -Xmx1g
 org.gradle.caching=false
 
-gradle_plugins_version=5.0.21-SNAPSHOT
+gradle_plugins_version=5.0.22-SNAPSHOT
 typesafe_config_version=1.4.2
 classgraph_version=4.8.115
 kotlin_version=1.3.41


### PR DESCRIPTION
Bumped the plugins version number ready for the next round of development, following the release/publication of 5.0.21.
