### PR TITLE
ENT-12500: Allow adding custom JVM arguments to the jarsigner task

### DIFF
--- a/cordapp/src/main/kotlin/net/corda/plugins/SignJar.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/SignJar.kt
@@ -63,7 +63,25 @@ open class SignJar @Inject constructor(objects: ObjectFactory) : DefaultTask() {
                     ant.invokeMethod("signjar", options)
                 } else {
                     // direct jarsigner execution path
-                    val executable = signing.options.executable.orNull?.asFile?.absolutePath ?: "jarsigner"
+                    val executableFile = signing.options.executable.orNull?.asFile
+                    val executable = executableFile?.absolutePath ?: run {
+                        val javaHome = System.getProperty("java.home")
+                        // java.home might point to JRE inside JDK (e.g., .../jdk/jre)
+                        // Try to find jarsigner in bin directory, or parent JDK's bin
+                        val jarsignerPath = File(File(javaHome, "bin"), "jarsigner")
+                        if (jarsignerPath.exists()) {
+                            jarsignerPath.absolutePath
+                        } else {
+                            // Try parent directory (for JRE inside JDK layout)
+                            val parentJarsigner = File(File(javaHome).parentFile, "bin/jarsigner")
+                            if (parentJarsigner.exists()) {
+                                parentJarsigner.absolutePath
+                            } else {
+                                // Fallback to just "jarsigner"
+                                "jarsigner"
+                            }
+                        }
+                    }
                     val args = mutableListOf<String>()
                     jvmArgs.forEach{ arg ->
                         args.add("-J$arg")

--- a/cordapp/src/main/kotlin/net/corda/plugins/SignJar.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/SignJar.kt
@@ -63,25 +63,7 @@ open class SignJar @Inject constructor(objects: ObjectFactory) : DefaultTask() {
                     ant.invokeMethod("signjar", options)
                 } else {
                     // direct jarsigner execution path
-                    val executableFile = signing.options.executable.orNull?.asFile
-                    val executable = executableFile?.absolutePath ?: run {
-                        val javaHome = System.getProperty("java.home")
-                        // java.home might point to JRE inside JDK (e.g., .../jdk/jre)
-                        // Try to find jarsigner in bin directory, or parent JDK's bin
-                        val jarsignerPath = File(File(javaHome, "bin"), "jarsigner")
-                        if (jarsignerPath.exists()) {
-                            jarsignerPath.absolutePath
-                        } else {
-                            // Try parent directory (for JRE inside JDK layout)
-                            val parentJarsigner = File(File(javaHome).parentFile, "bin/jarsigner")
-                            if (parentJarsigner.exists()) {
-                                parentJarsigner.absolutePath
-                            } else {
-                                // Fallback to just "jarsigner"
-                                "jarsigner"
-                            }
-                        }
-                    }
+                    val executable = signing.options.executable.orNull?.asFile?.absolutePath ?: "jarsigner"
                     val args = mutableListOf<String>()
                     jvmArgs.forEach{ arg ->
                         args.add("-J$arg")

--- a/cordapp/src/main/kotlin/net/corda/plugins/SignJar.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/SignJar.kt
@@ -40,6 +40,8 @@ open class SignJar @Inject constructor(objects: ObjectFactory) : DefaultTask() {
 
         fun Task.sign(signing: Signing, file: File, outputFile: File? = null) {
             val options = signing.options.signJarOptions.get()
+            val jvmArgs = signing.options.jarsignerJvmArgs.orNull ?: emptyList()
+
             val useDefaultKeyStore = !signing.options.keyStore.isPresent
             if (useDefaultKeyStore) {
                 logger.info("CorDapp JAR signing with the default Corda development key, suitable for Corda running in development mode only.")
@@ -57,7 +59,51 @@ open class SignJar @Inject constructor(objects: ObjectFactory) : DefaultTask() {
 
             logger.info("Jar signing with following options: {}", options.toSanitized())
             try {
-                ant.invokeMethod("signjar", options)
+                if (jvmArgs.isEmpty()) {
+                    ant.invokeMethod("signjar", options)
+                } else {
+                    // direct jarsigner execution path
+                    val executable = signing.options.executable.orNull?.asFile?.absolutePath ?: "jarsigner"
+                    val args = mutableListOf<String>()
+                    jvmArgs.forEach{ arg ->
+                        args.add("-J$arg")
+                    }
+                    // convert options map to jarsigner args
+                    options.forEach { (key, value) ->
+                        when (key) {
+                            Key.JAR -> {
+                                //handled later
+                            }
+                            Key.ALIAS -> {
+                                // handled later
+                            }
+                            Key.VERBOSE,
+                            Key.STRICT,
+                            Key.INTERNALSF,
+                            Key.SECTIONSONLY,
+                            Key.LAZY,
+                            Key.PRESERVELASTMODIFIED,
+                            Key.FORCE -> {
+                                if (value.toBoolean()) {
+                                    args.add("-$key")
+                                    args.add(value)
+                                }
+                            }
+                            else -> {
+                                args.add("-$key")
+                                args.add(value)
+                            }
+                        }
+                    }
+                    // Required args
+                    args.add(options[Key.JAR]!!)
+                    args.add(options[Key.ALIAS]!!)
+
+                    project.exec { execSpec ->
+                        execSpec.executable = executable
+                        execSpec.args = args
+                    }
+                }
             } catch (e: Exception) {
                 // Not adding error message as it's always meaningless, logs with --INFO level contain more insights
                 throw InvalidUserDataException("Exception while signing ${path.fileName}, " +

--- a/cordapp/src/main/kotlin/net/corda/plugins/SignJar.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/SignJar.kt
@@ -57,7 +57,8 @@ open class SignJar @Inject constructor(objects: ObjectFactory) : DefaultTask() {
                 options[Key.SIGNEDJAR] = outputFile.toPath().toString()
             }
 
-            logger.info("Jar signing with following options: {}", options.toSanitized())
+            val jvmArgsMessage = if (jvmArgs.isNotEmpty()) " and JVM args: ${jvmArgs.joinToString()}." else "."
+            logger.info("Jar signing with following options: ${options.toSanitized().entries.joinToString { "${it.key}=${it.value}" }}$jvmArgsMessage")
             try {
                 if (jvmArgs.isEmpty()) {
                     ant.invokeMethod("signjar", options)

--- a/cordapp/src/main/kotlin/net/corda/plugins/SignJar.kt
+++ b/cordapp/src/main/kotlin/net/corda/plugins/SignJar.kt
@@ -86,7 +86,6 @@ open class SignJar @Inject constructor(objects: ObjectFactory) : DefaultTask() {
                             Key.FORCE -> {
                                 if (value.toBoolean()) {
                                     args.add("-$key")
-                                    args.add(value)
                                 }
                             }
                             else -> {

--- a/cordapp/src/main/template/SigningOptions.kt
+++ b/cordapp/src/main/template/SigningOptions.kt
@@ -49,7 +49,6 @@ fun TaskInputs.nested(nestName: String, options: SigningOptions) {
     property("${nestName}.digestAlgorithm", options.digestAlgorithm).optional(true)
     property("${nestName}.tsaDigestAlgorithm", options.tsaDigestAlgorithm).optional(true)
     property("${nestName}.providerClass", options.providerClass).optional(true)
-    property("${nestName}.providerArg", options.providerArg).optional(true)
     property("${nestName}.jarsignerJvmArgs", options.jarsignerJvmArgs).optional(true)
 }
 
@@ -97,7 +96,6 @@ open class SigningOptions @Inject constructor(objects: ObjectFactory, providers:
             const val DIGESTALG = "digestalg"
             const val TSADIGESTALG = "tsadigestalg"
             const val PROVIDER_CLASS = "providerClass"
-            const val PROVIDER_ARG = "providerArg"
         }
     }
 
@@ -219,10 +217,6 @@ open class SigningOptions @Inject constructor(objects: ObjectFactory, providers:
 
     @get:Optional
     @get:Input
-    val providerArg: Property<String> = objects.property(String::class.java)
-
-    @get:Optional
-    @get:Input
     val jarsignerJvmArgs: ListProperty<String> = objects.listProperty(String::class.java).convention(emptyList())
 
     private val _signJarOptions = objects.mapProperty(String::class.java, String::class.java).apply {
@@ -265,7 +259,6 @@ open class SigningOptions @Inject constructor(objects: ObjectFactory, providers:
         signatureAlgorithm.set(options.signatureAlgorithm)
         digestAlgorithm.set(options.digestAlgorithm)
         providerClass.set(options.providerClass)
-        providerArg.set(options.providerArg)
         jarsignerJvmArgs.set(options.jarsignerJvmArgs)
         return this
     }
@@ -299,7 +292,6 @@ open class SigningOptions @Inject constructor(objects: ObjectFactory, providers:
         result.setOptional(Key.DIGESTALG, digestAlgorithm)
         result.setOptional(Key.TSADIGESTALG, tsaDigestAlgorithm)
         result.setOptional(Key.PROVIDER_CLASS, providerClass)
-        result.setOptional(Key.PROVIDER_ARG, providerArg)
         result
     }
 }

--- a/cordapp/src/main/template/SigningOptions.kt
+++ b/cordapp/src/main/template/SigningOptions.kt
@@ -47,6 +47,9 @@ fun TaskInputs.nested(nestName: String, options: SigningOptions) {
     property("${nestName}.signatureAlgorithm", options.signatureAlgorithm).optional(true)
     property("${nestName}.digestAlgorithm", options.digestAlgorithm).optional(true)
     property("${nestName}.tsaDigestAlgorithm", options.tsaDigestAlgorithm).optional(true)
+    property("${nestName}.providerClass", options.providerClass).optional(true)
+    property("${nestName}.providerArg", options.providerArg).optional(true)
+    property("${nestName}.jarsignerJvmArgs", options.jarsignerJvmArgs).optional(true)
 }
 
 /** Options for ANT task "signjar". */
@@ -92,6 +95,8 @@ open class SigningOptions @Inject constructor(objects: ObjectFactory, providers:
             const val SIGALG = "sigalg"
             const val DIGESTALG = "digestalg"
             const val TSADIGESTALG = "tsadigestalg"
+            const val PROVIDER_CLASS = "providerClass"
+            const val PROVIDER_ARG = "providerArg"
         }
     }
 
@@ -207,6 +212,18 @@ open class SigningOptions @Inject constructor(objects: ObjectFactory, providers:
     @get:Input
     val tsaDigestAlgorithm: Property<String> = objects.property(String::class.java)
 
+    @get:Optional
+    @get:Input
+    val providerClass: Property<String> = objects.property(String::class.java)
+
+    @get:Optional
+    @get:Input
+    val providerArg: Property<String> = objects.property(String::class.java)
+
+    @get:Optional
+    @get:Input
+    val jarsignerJvmArgs = objects.listProperty(String::class.java).convention(emptyList())
+
     private val _signJarOptions = objects.mapProperty(String::class.java, String::class.java).apply {
         put(Key.ALIAS, alias)
         put(Key.STOREPASS, storePassword)
@@ -246,6 +263,9 @@ open class SigningOptions @Inject constructor(objects: ObjectFactory, providers:
         force.set(options.force)
         signatureAlgorithm.set(options.signatureAlgorithm)
         digestAlgorithm.set(options.digestAlgorithm)
+        providerClass.set(options.providerClass)
+        providerArg.set(options.providerArg)
+        jarsignerJvmArgs.set(options.jarsignerJvmArgs)
         return this
     }
 
@@ -277,6 +297,8 @@ open class SigningOptions @Inject constructor(objects: ObjectFactory, providers:
         result.setOptional(Key.SIGALG, signatureAlgorithm)
         result.setOptional(Key.DIGESTALG, digestAlgorithm)
         result.setOptional(Key.TSADIGESTALG, tsaDigestAlgorithm)
+        result.setOptional(Key.PROVIDER_CLASS, providerClass)
+        result.setOptional(Key.PROVIDER_ARG, providerArg)
         result
     }
 }

--- a/cordapp/src/main/template/SigningOptions.kt
+++ b/cordapp/src/main/template/SigningOptions.kt
@@ -3,6 +3,7 @@ package @root_package@.signing
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
@@ -222,7 +223,7 @@ open class SigningOptions @Inject constructor(objects: ObjectFactory, providers:
 
     @get:Optional
     @get:Input
-    val jarsignerJvmArgs = objects.listProperty(String::class.java).convention(emptyList())
+    val jarsignerJvmArgs: ListProperty<String> = objects.listProperty(String::class.java).convention(emptyList())
 
     private val _signJarOptions = objects.mapProperty(String::class.java, String::class.java).apply {
         put(Key.ALIAS, alias)

--- a/cordapp/src/test/kotlin/net/corda/plugins/CordappTest.kt
+++ b/cordapp/src/test/kotlin/net/corda/plugins/CordappTest.kt
@@ -210,7 +210,7 @@ class CordappTest {
     fun `jarsigner JVM args are logged when configured`() {
         val extraArgs = listOf(
             "-Ptarget_version_arg=10",
-            "-Psigning_jvm_args=-cp,/path/to/primusX.jar"
+            "-Psigning_jvm_args=-Dcom.sun.net.ssl.checkRevocation=false,-Xmx512m"
         )
 
         val jarTaskRunner = jarTaskRunner("CorDappWithCustomSigning.gradle", extraArgs)
@@ -220,8 +220,8 @@ class CordappTest {
         assertThat(result.task(":jar")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
         assertThat(result.output)
-            .contains("-J-cp")
-            .contains("-J/path/to/primusX.jar")
+            .contains("-J-Dcom.sun.net.ssl.checkRevocation=false")
+            .contains("-J-Xmx512m")
     }
 
     @Test

--- a/cordapp/src/test/kotlin/net/corda/plugins/CordappTest.kt
+++ b/cordapp/src/test/kotlin/net/corda/plugins/CordappTest.kt
@@ -205,6 +205,41 @@ class CordappTest {
         assertThat(attributes.getValue("Sealed")).isEqualTo(expectedSealed)
     }
 
+
+    @Test
+    fun `jarsigner JVM args are logged when configured`() {
+        val extraArgs = listOf(
+            "-Ptarget_version_arg=10",
+            "-Psigning_jvm_args=-cp,/path/to/primusX.jar"
+        )
+
+        val jarTaskRunner = jarTaskRunner("CorDappWithCustomSigning.gradle", extraArgs)
+
+        val result = jarTaskRunner.build()
+
+        assertThat(result.task(":jar")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+        assertThat(result.output)
+            .contains("-J-cp")
+            .contains("-J/path/to/primusX.jar")
+    }
+
+    @Test
+    fun `legacy signing path still works without JVM args`() {
+        val jarTaskRunner = jarTaskRunner(
+            "CorDappWithoutMetadata.gradle",
+            listOf("-Ptarget_version_arg=10")
+        )
+
+        val result = jarTaskRunner.build()
+
+        assertThat(result.task(":jar")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+        assertThat(result.output)
+            .doesNotContain("-J-cp")
+            .doesNotContain("primusX.jar")
+    }
+
     @Test
     fun `a cordapp without any metadata`() {
         val jarTaskRunner = jarTaskRunner("CorDappWithoutMetadata.gradle", listOf(

--- a/cordapp/src/test/kotlin/net/corda/plugins/CordappTest.kt
+++ b/cordapp/src/test/kotlin/net/corda/plugins/CordappTest.kt
@@ -210,7 +210,7 @@ class CordappTest {
     fun `jarsigner JVM args are logged when configured`() {
         val extraArgs = listOf(
             "-Ptarget_version_arg=10",
-            "-Psigning_jvm_args=-Dcom.sun.net.ssl.checkRevocation=false,-Xmx512m"
+            "-Psigning_jvm_args=-cp,/path/to/primusX.jar"
         )
 
         val jarTaskRunner = jarTaskRunner("CorDappWithCustomSigning.gradle", extraArgs)
@@ -220,8 +220,8 @@ class CordappTest {
         assertThat(result.task(":jar")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
         assertThat(result.output)
-            .contains("-J-Dcom.sun.net.ssl.checkRevocation=false")
-            .contains("-J-Xmx512m")
+            .contains("-J-cp")
+            .contains("-J/path/to/primusX.jar")
     }
 
     @Test

--- a/cordapp/src/test/resources/net/corda/plugins/CorDappWithCustomSigning.gradle
+++ b/cordapp/src/test/resources/net/corda/plugins/CorDappWithCustomSigning.gradle
@@ -10,12 +10,10 @@ cordapp {
     targetPlatformVersion = target_version_arg.toInteger()
 
     signing {
-        enabled = true
         options {
             if (project.hasProperty("signing_jvm_args")) {
                 jarsignerJvmArgs = signing_jvm_args.split(",") as List<String>
             }
-            verbose = true
         }
     }
 

--- a/cordapp/src/test/resources/net/corda/plugins/CorDappWithCustomSigning.gradle
+++ b/cordapp/src/test/resources/net/corda/plugins/CorDappWithCustomSigning.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'net.corda.plugins.cordapp'
+}
+
+tasks.named('jar', Jar) {
+    archiveBaseName = 'test-cordapp'
+}
+
+cordapp {
+    targetPlatformVersion = target_version_arg.toInteger()
+
+    signing {
+        enabled = true
+        options {
+            if (project.hasProperty("signing_jvm_args")) {
+                jarsignerJvmArgs = signing_jvm_args.split(",") as List<String>
+            }
+        }
+    }
+
+    contract {
+        name "Test Contract"
+        versionId 1
+    }
+}

--- a/cordapp/src/test/resources/net/corda/plugins/CorDappWithCustomSigning.gradle
+++ b/cordapp/src/test/resources/net/corda/plugins/CorDappWithCustomSigning.gradle
@@ -15,6 +15,7 @@ cordapp {
             if (project.hasProperty("signing_jvm_args")) {
                 jarsignerJvmArgs = signing_jvm_args.split(",") as List<String>
             }
+            verbose = true
         }
     }
 


### PR DESCRIPTION
Changes:
1. Allow adding custom JVM arguments to the jarsigner task - by using jarsigner directly. If there are no JVM args provided, use the old workflow - through Ant.
2. Also add the `providerClass` option in the plugin to pass in the security provider.
3. Improve the log message, now with the JVM args added it looks like this:
```
Jar signing with following options: alias=cordapp-signer, storepass=****, storetype=PKCS12, keypass=****, sigfile=cordapp-signer, verbose=false, strict=false, internalsf=false, sectionsonly=false, lazy=false, preservelastmodified=false, force=false, keystore=jarSignKeystore.pkcs12, providerClass=com.securosys.primus.jce.PrimusProvider, jar=/Users/jakub.zadroga/IdeaProjects/samples-kotlin/Basic/tutorial-jarsigning/contracts/build/libs/contracts-0.1.jar and JVM args: -cp, primusX.jar.
```


Tested locally by signing the contract jar with the new parameters (`jarsignerJvmArgs` and `providerClass`) in the `tutorial-jarsigning` sample CorDapp.

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described here? https://docs.corda.net/head/testing.html
- [ ] If you added/changed public APIs, did you write/update the JavaDocs?
- [ ] If the changes are of interest to application developers, have you added them to the changelog, and potentially release notes?
- [ ] If you are contributing for the first time, please read the agreement in CONTRIBUTING.md now and add to this Pull Request that you agree to it.

Thanks for your code, it's appreciated! :)
